### PR TITLE
fix: opt-in to empty R2 bucket and document CF credentials in Guide

### DIFF
--- a/alchemy-web/docs/guides/cloudflare-vitejs.md
+++ b/alchemy-web/docs/guides/cloudflare-vitejs.md
@@ -16,6 +16,18 @@ cd my-cloudflare-app
 bun install
 ```
 
+## Set up Cloudflare Credentials
+
+Create a `.env` file in the root of the new project and place your Cloudflare Account's Email and API Key:
+
+```
+CLOUDFLARE_API_KEY=<your-api-key>
+CLOUDFLARE_EMAIL=<account-email>
+```
+
+> [!TIP]
+> Use the "Global API Key" from https://dash.cloudflare.com/profile/api-tokens
+
 ## Create `alchemy.run.ts`
 
 Create a standard `alchemy.run.ts` file in your project root:

--- a/alchemy/src/apply.ts
+++ b/alchemy/src/apply.ts
@@ -70,15 +70,6 @@ export async function apply<Out extends Resource>(
         }
         return state.output as Awaited<Out>;
       }
-
-      const diff = await import("diff");
-      const yaml = await import("yaml");
-      const old = yaml.stringify(oldProps);
-      const news = yaml.stringify(newProps);
-      const patch = diff.createPatch(resource.ID, old, news);
-      // console.log(patch);
-      // if (resource.ID === "what-is-alchemy") {
-      // }
     }
 
     const phase = state.status === "creating" ? "create" : "update";

--- a/alchemy/src/cloudflare/bucket.ts
+++ b/alchemy/src/cloudflare/bucket.ts
@@ -110,6 +110,14 @@ export interface R2Bucket
  *   jurisdiction: "fedramp"
  * });
  *
+ * @example
+ * // Create a bucket that will be automatically emptied when deleted
+ * // This will delete all objects in the bucket before deleting the bucket itself
+ * const temporaryBucket = await R2Bucket("temp-storage", {
+ *   name: "temp-storage",
+ *   empty: true  // All objects will be deleted when this resource is destroyed
+ * });
+ *
  * @see https://developers.cloudflare.com/r2/buckets/
  */
 export const R2Bucket = Resource(

--- a/alchemy/test/cloudflare/bucket.test.ts
+++ b/alchemy/test/cloudflare/bucket.test.ts
@@ -96,6 +96,7 @@ describe("R2 Bucket Resource", async () => {
       const bucketName = `${testId}-with-files`;
       bucket = await R2Bucket(bucketName, {
         name: bucketName,
+        empty: true,
       });
       expect(bucket.name).toEqual(bucketName);
 


### PR DESCRIPTION
There was a bug where the `R2Bucket` resources would instantiate a R2 client during create, update and delete phases even though it was only needed to empty the R2 bucket during delete phase.

This caused a problem where a bucket couldn't even be created without first creating and storing R2_ACCESS_KEY and R2_SECRET_KEY in your .env

Also, it's dangerous behavior to delete objects by default, so I've changed the behavior to be opt-in instead of opt-out.