### PR TITLE
fix: export type Scope

### DIFF
--- a/alchemy/src/index.ts
+++ b/alchemy/src/index.ts
@@ -1,5 +1,6 @@
 export type * from "./context";
 export * from "./resource";
+export type * from "./scope";
 export * from "./secret";
 export * from "./state";
 export * from "./util/ignore";


### PR DESCRIPTION
I tried using the cursorrules to generate a Resource and in order to create a test, it wants to use Scope, but that's not exported yet.

I assume we only want to export the type, since scope is constructed internally.

Sample generated in my codebase:
```ts
import "alchemy/test/bun";
import { describe, expect } from "bun:test";
import alchemy, { type Scope } from "alchemy";
import { TypeDBServer } from "../../src/typedb/server";
import { Socket } from "net";

describe("TypeDBServer Resource", () => {
  const testId = `test-typedb-server`;

  alchemy.test(import.meta)("create, verify connection, and destroy server", async (scope: Scope) => {
    let server: TypeDBServer | undefined;
    
    try {
      // Create a test server
      server = await TypeDBServer(testId, {
        binaryPath: process.env.TYPEDB_BINARY_PATH || "./typedb-server/bin/typedb",
        host: "localhost"
      });

      expect(server.pid).toBeTruthy();
      expect(server.actualPort).toBeGreaterThan(0);
      expect(server.actualHost).toBe("localhost");

      // Verify we can connect to the server
      const canConnect = await new Promise<boolean>((resolve) => {
        const socket = new Socket();
        socket.connect(server!.actualPort, server!.actualHost, () => {
          socket.end();
          resolve(true);
        });
        socket.on("error", () => resolve(false));
      });

      expect(canConnect).toBe(true);

    } catch(err) {
      console.error("Test failed:", err);
      throw err;
    } finally {
      // Clean up
      await alchemy.destroy(scope);

      // Verify server process is killed
      if (server?.pid) {
        try {
          process.kill(server.pid, 0); // Check if process exists
          throw new Error("Server process still running after destroy");
        } catch (err) {
          // Process not found error is expected
          expect((err as NodeJS.ErrnoException).code).toBe("ESRCH");
        }
      }
    }
  });
}); 
```