### PR TITLE
Add d1_databases to wrangler.json

### DIFF
--- a/alchemy/src/cloudflare/wrangler.json.ts
+++ b/alchemy/src/cloudflare/wrangler.json.ts
@@ -338,6 +338,10 @@ function processBindings(spec: WranglerJsonSpec, bindings: Bindings): void {
     spec.services = services;
   }
 
+  if (d1Databases.length > 0) {
+    spec.d1_databases = d1Databases;
+  }
+
   if (queues.length > 0) {
     spec.queues = queues;
   }


### PR DESCRIPTION
I noticed that when binding a D1 Database, it was not properly exported to the wrangler.json