### PR TITLE
removed hard-coded references

### DIFF
--- a/alchemy/src/esbuild/bundle.ts
+++ b/alchemy/src/esbuild/bundle.ts
@@ -138,7 +138,23 @@ export const Bundle = Resource(
     // Check that bundle created output an file for the given entrypoint
     // Use bundle metada data to retrieve its content
     const bundleOutputPath = Object.entries(result.metafile.outputs).find(
-      ([file, output]) => output.entryPoint === props.entryPoint
+      ([file, output]) => {
+        if (output.entryPoint === undefined) {
+          return false;
+        }
+        // resolve to absolute and then relative to ensure consistent result (e.g. ./src/handler.ts instead of src/handler.ts)
+        const relativeOutput = path.relative(
+          process.cwd(),
+          path.resolve(output.entryPoint)
+        );
+        return (
+          relativeOutput ===
+          path.relative(
+            process.cwd(),
+            path.resolve(process.cwd(), props.entryPoint)
+          )
+        );
+      }
     )?.[0];
 
     if (!bundleOutputPath) {


### PR DESCRIPTION
This pr to fix the bundle to allow for output to mjs and support of main outdir/outfile esbuild params. 
- Remove creating a magic "dist" if none is provided, throw if neither a outdir or outfile is passed, if both are passed, esbuild will correctly bark at you. 

Tested with the following options: 

```
const bundle = await Bundle("example-bundle", {
  entryPoint: "./src/index.mts",
  outdir: "./dist",
  format: "esm",
  platform: "node",
  target: "node20",
  external: ["@aws-sdk/*"],
  options: {
    outExtension: { ".js": ".mjs" },
  },
});
```

```
const bundle = await Bundle("example-bundle", {
  entryPoint: "./src/index.mts",
  outfile: "./dist/index.mjs",
  format: "esm",
  platform: "node",
  target: "node20",
  external: ["@aws-sdk/*"]
});
```

