### PR TITLE
fix: in-memory bundle and update aws/Function to accept bundle instead of zipPath

### DIFF
--- a/alchemy/src/aws/function.ts
+++ b/alchemy/src/aws/function.ts
@@ -723,7 +723,6 @@ async function zipCode(props: FunctionProps): Promise<Buffer> {
   // Create a zip buffer in memory
   const zip = new (await import("jszip")).default();
   zip.file(fileName, fileContent);
-  console.log(fileName);
   return zip.generateAsync({
     type: "nodebuffer",
     compression: "DEFLATE",

--- a/alchemy/src/aws/function.ts
+++ b/alchemy/src/aws/function.ts
@@ -15,9 +15,8 @@ import {
   UpdateFunctionConfigurationCommand,
   UpdateFunctionUrlConfigCommand,
 } from "@aws-sdk/client-lambda";
-import fs from "node:fs";
-import path from "node:path";
 import type { Context } from "../context";
+import type { Bundle } from "../esbuild/bundle";
 import { Resource } from "../resource";
 import { ignore } from "../util/ignore";
 
@@ -31,9 +30,9 @@ export interface FunctionProps {
   functionName: string;
 
   /**
-   * Path to the zip file containing the function code
+   * Bundle for the function
    */
-  zipPath: string;
+  bundle: Bundle;
 
   /**
    * ARN of the IAM role that Lambda assumes when executing the function
@@ -44,7 +43,7 @@ export interface FunctionProps {
    * Function handler in the format 'file.function'
    * For Node.js this is typically 'index.handler' or similar
    */
-  handler?: string;
+  handler: string;
 
   /**
    * Lambda runtime environment for the function
@@ -301,7 +300,7 @@ export const Function = Resource(
     const client = new LambdaClient({});
     const region = await resolveRegion(client);
 
-    const code = await zipCode(props.zipPath);
+    const code = await zipCode(props);
 
     if (this.phase === "delete") {
       // Delete function URL if it exists
@@ -714,13 +713,17 @@ async function waitForFunctionStabilization(
 }
 
 // Helper to zip the code
-async function zipCode(filePath: string): Promise<Buffer> {
-  const fileContent = await fs.promises.readFile(filePath);
-  const fileName = path.basename(filePath);
+async function zipCode(props: FunctionProps): Promise<Buffer> {
+  const fileContent = props.bundle.content;
+
+  const fileName =
+    props.handler.split(".").reverse().slice(0, -1).reverse().join(".") +
+    (props.bundle.format === "cjs" ? ".cjs" : ".mjs");
 
   // Create a zip buffer in memory
   const zip = new (await import("jszip")).default();
   zip.file(fileName, fileContent);
+  console.log(fileName);
   return zip.generateAsync({
     type: "nodebuffer",
     compression: "DEFLATE",

--- a/alchemy/src/cloudflare/worker.ts
+++ b/alchemy/src/cloudflare/worker.ts
@@ -747,7 +747,13 @@ async function bundleWorkerScript<B extends Bindings>(props: WorkerProps) {
   });
 
   try {
-    return await fs.readFile(bundle.path, "utf-8");
+    if (bundle.content) {
+      return bundle.content;
+    } else if (bundle.path) {
+      return await fs.readFile(bundle.path, "utf-8");
+    } else {
+      throw new Error("Failed to create bundle");
+    }
   } catch (error) {
     console.error("Error reading bundle:", error);
     throw new Error("Error reading bundle");

--- a/alchemy/src/esbuild/bundle.ts
+++ b/alchemy/src/esbuild/bundle.ts
@@ -1,6 +1,6 @@
-import * as esbuild from "esbuild";
+import esbuild from "esbuild";
 import crypto from "node:crypto";
-import fs from "node:fs";
+import fs from "node:fs/promises";
 import path from "node:path";
 import type { Context } from "../context";
 import { Resource } from "../resource";
@@ -78,18 +78,25 @@ export interface BundleProps {
 /**
  * Output returned after bundle creation/update
  */
-export interface Bundle extends Resource<"esbuild::Bundle"> {
+export interface Bundle<P extends BundleProps = BundleProps>
+  extends Resource<"esbuild::Bundle">,
+    BundleProps {
   /**
    * Path to the bundled file
    * Absolute or relative path to the generated bundle
    */
-  path: string;
+  path: P extends { outdir: string } | { outfile: string } ? string : undefined;
 
   /**
    * SHA-256 hash of the bundle contents
    * Used for cache busting and content verification
    */
   hash: string;
+
+  /**
+   * The content of the bundle (the .js or .mjs file)
+   */
+  content: string;
 }
 
 /**
@@ -113,32 +120,31 @@ export const Bundle = Resource(
   {
     alwaysUpdate: true,
   },
-  async function (
-    this: Context<Bundle>,
+  async function <Props extends BundleProps>(
+    this: Context<Bundle<any>>,
     id: string,
-    props: BundleProps
-  ): Promise<Bundle> {
-    // Determine output path
-    const outDirPath =
-      props.outfile != null ? path.dirname(props.outfile) : props.outdir;
-
-    if (outDirPath == null) {
-      throw new Error(
-        `You need to specify either outfile or outdir in your bundle configuration ${JSON.stringify(props)}`
-      );
-    }
-
-    // Ensure output directory exists
-    await fs.promises.mkdir(path.dirname(outDirPath), { recursive: true });
+    props: Props
+  ): Promise<Bundle<Props>> {
     if (this.phase === "delete") {
-      await fs.promises.rm(outDirPath, { recursive: true });
+      console.log("delete", this.output.path);
+      if (this.output.path) {
+        try {
+          await fs.rm(this.output.path, { force: true });
+        } catch (error) {
+          if (error instanceof Error && error.message.includes("ENOENT")) {
+            // File doesn't exist, so we can ignore the error
+          } else {
+            throw error;
+          }
+        }
+      }
+      return this.destroy();
     }
 
     const result = await bundle(props);
-    // Check that bundle created output an file for the given entrypoint
-    // Use bundle metada data to retrieve its content
-    const bundleOutputPath = Object.entries(result.metafile.outputs).find(
-      ([file, output]) => {
+
+    const bundlePath = Object.entries(result.metafile.outputs).find(
+      ([_, output]) => {
         if (output.entryPoint === undefined) {
           return false;
         }
@@ -157,34 +163,37 @@ export const Bundle = Resource(
       }
     )?.[0];
 
-    if (!bundleOutputPath) {
-      throw new Error(`Unable to find a compiled file`);
+    const outputFile = result.outputFiles?.[0];
+    if (outputFile === undefined && bundlePath === undefined) {
+      throw new Error("Failed to create bundle");
+    } else if (outputFile) {
+      return this({
+        ...props,
+        path: bundlePath,
+        hash: outputFile.hash,
+        content: outputFile.text,
+      });
+    } else {
+      console.log("read", bundlePath);
+      const content = await fs.readFile(bundlePath!, "utf-8");
+      return this({
+        ...props,
+        path: bundlePath,
+        hash: crypto.createHash("sha256").update(content).digest("hex"),
+        content,
+      });
     }
-
-    // Calculate hash of the output
-    const bundleOutputContent = await fs.promises.readFile(bundleOutputPath);
-    const hash = crypto
-      .createHash("sha256")
-      .update(bundleOutputContent)
-      .digest("hex");
-
-    // Store metadata in context
-    await this.set("metafile", result.metafile);
-    await this.set("hash", hash);
-
-    // Return output info
-    return this({
-      path: bundleOutputPath,
-      hash,
-    });
   }
 );
 
 export async function bundle(props: BundleProps) {
   return await esbuild.build({
     ...props.options,
+    // write: !(props.outdir === undefined && props.outfile === undefined),
+    write: false,
+    // write: false,
     entryPoints: [props.entryPoint],
-    outdir: props.outdir,
+    outdir: (props.outdir ?? props.outfile) ? undefined : ".out",
     outfile: props.outfile,
     bundle: true,
     format: props.format,
@@ -198,6 +207,5 @@ export async function bundle(props: BundleProps) {
     ],
     platform: props.platform,
     metafile: true,
-    write: true,
   });
 }

--- a/alchemy/src/esbuild/bundle.ts
+++ b/alchemy/src/esbuild/bundle.ts
@@ -174,7 +174,6 @@ export const Bundle = Resource(
         content: outputFile.text,
       });
     } else {
-      console.log("read", bundlePath);
       const content = await fs.readFile(bundlePath!, "utf-8");
       return this({
         ...props,
@@ -189,11 +188,12 @@ export const Bundle = Resource(
 export async function bundle(props: BundleProps) {
   return await esbuild.build({
     ...props.options,
-    // write: !(props.outdir === undefined && props.outfile === undefined),
-    write: false,
+    write: !(props.outdir === undefined && props.outfile === undefined),
+    // write:
+    //   props.outdir === undefined && props.outfile === undefined ? false : true,
     // write: false,
     entryPoints: [props.entryPoint],
-    outdir: (props.outdir ?? props.outfile) ? undefined : ".out",
+    outdir: props.outdir ? props.outdir : props.outfile ? undefined : ".out",
     outfile: props.outfile,
     bundle: true,
     format: props.format,

--- a/alchemy/test/aws/function.test.ts
+++ b/alchemy/test/aws/function.test.ts
@@ -143,7 +143,6 @@ describe("AWS Resources", () => {
           invokeResponse.Payload
         );
         const response = JSON.parse(responsePayload);
-        console.log(response);
         expect(response.statusCode).toBe(200);
 
         const body = JSON.parse(response.body);

--- a/alchemy/test/aws/function.test.ts
+++ b/alchemy/test/aws/function.test.ts
@@ -72,13 +72,12 @@ describe("AWS Resources", () => {
       // First create the execution role
       // Define resources that need to be cleaned up
       let role: Role | undefined = undefined;
-      let bundle: Bundle | undefined = undefined;
       let func: Function | null = null;
       const functionName = `${BRANCH_PREFIX}-alchemy-test-function`;
       const roleName = `${BRANCH_PREFIX}-alchemy-test-lambda-role`;
 
       try {
-        bundle = await Bundle(`${BRANCH_PREFIX}-test-lambda-bundle`, {
+        let bundle = await Bundle(`${BRANCH_PREFIX}-test-lambda-bundle`, {
           entryPoint: path.join(__dirname, "..", "handler.ts"),
           outdir: ".out",
           format: "cjs",
@@ -104,7 +103,7 @@ describe("AWS Resources", () => {
         // Create the Lambda function
         func = await Function(functionName, {
           functionName,
-          zipPath: bundle.path,
+          bundle,
           roleArn: role.arn,
           handler: "handler.handler",
           runtime: "nodejs20.x",
@@ -144,6 +143,7 @@ describe("AWS Resources", () => {
           invokeResponse.Payload
         );
         const response = JSON.parse(responsePayload);
+        console.log(response);
         expect(response.statusCode).toBe(200);
 
         const body = JSON.parse(response.body);
@@ -151,7 +151,6 @@ describe("AWS Resources", () => {
         expect(body.event).toEqual(testEvent);
       } finally {
         await destroy(scope);
-
         // Verify function was properly deleted after cleanup
         if (func) {
           await expect(
@@ -169,13 +168,12 @@ describe("AWS Resources", () => {
       // Create execution role
       // Define resources that need to be cleaned up
       let role: Role | undefined = undefined;
-      let bundle: Bundle | undefined = undefined;
       let func: Function | null = null;
       const functionName = `${BRANCH_PREFIX}-alchemy-test-function-url`;
       const roleName = `${BRANCH_PREFIX}-alchemy-test-lambda-url-role`;
 
       try {
-        bundle = await Bundle(`${BRANCH_PREFIX}-test-lambda-url-bundle`, {
+        let bundle = await Bundle(`${BRANCH_PREFIX}-test-lambda-url-bundle`, {
           entryPoint: path.join(__dirname, "..", "handler.ts"),
           outdir: ".out",
           format: "cjs",
@@ -201,7 +199,7 @@ describe("AWS Resources", () => {
         // Create the Lambda function with URL config
         func = await Function(functionName, {
           functionName,
-          zipPath: bundle.path,
+          bundle,
           roleArn: role.arn,
           handler: "handler.handler",
           runtime: "nodejs20.x",
@@ -250,7 +248,7 @@ describe("AWS Resources", () => {
         // Update the function to remove the URL
         func = await Function(functionName, {
           functionName,
-          zipPath: bundle.path,
+          bundle,
           roleArn: role.arn,
           handler: "handler.handler",
           runtime: "nodejs20.x",
@@ -281,13 +279,12 @@ describe("AWS Resources", () => {
     test("create function with URL then remove URL in update phase", async (scope) => {
       // Define resources that need to be cleaned up
       let role: Role | undefined = undefined;
-      let bundle: Bundle | undefined = undefined;
       let func: Function | null = null;
       const functionName = `${BRANCH_PREFIX}-alchemy-test-func-url-remove`;
       const roleName = `${BRANCH_PREFIX}-alchemy-test-lambda-url-rem-role`;
 
       try {
-        bundle = await Bundle(
+        let bundle = await Bundle(
           `${BRANCH_PREFIX}-test-lambda-url-remove-bundle`,
           {
             entryPoint: path.join(__dirname, "..", "handler.ts"),
@@ -316,7 +313,7 @@ describe("AWS Resources", () => {
         // Create the Lambda function with URL config
         func = await Function(functionName, {
           functionName,
-          zipPath: bundle.path,
+          bundle,
           roleArn: role.arn,
           handler: "handler.handler",
           runtime: "nodejs20.x",
@@ -366,7 +363,7 @@ describe("AWS Resources", () => {
         // Now update the function to remove the URL
         func = await Function(functionName, {
           functionName,
-          zipPath: bundle.path,
+          bundle,
           roleArn: role.arn,
           handler: "handler.handler",
           runtime: "nodejs20.x",
@@ -406,19 +403,21 @@ describe("AWS Resources", () => {
     test("create function without URL then add URL in update phase", async (scope) => {
       // Define resources that need to be cleaned up
       let role: Role | undefined = undefined;
-      let bundle: Bundle | undefined = undefined;
       let func: Function | null = null;
       const functionName = `${BRANCH_PREFIX}-alchemy-test-func-add-url`;
       const roleName = `${BRANCH_PREFIX}-alchemy-test-lambda-add-url-role`;
 
       try {
-        bundle = await Bundle(`${BRANCH_PREFIX}-test-lambda-add-url-bundle`, {
-          entryPoint: path.join(__dirname, "..", "handler.ts"),
-          outdir: ".out",
-          format: "cjs",
-          platform: "node",
-          target: "node18",
-        });
+        let bundle = await Bundle(
+          `${BRANCH_PREFIX}-test-lambda-add-url-bundle`,
+          {
+            entryPoint: path.join(__dirname, "..", "handler.ts"),
+            outdir: ".out",
+            format: "cjs",
+            platform: "node",
+            target: "node18",
+          }
+        );
 
         role = await Role(roleName, {
           roleName,
@@ -438,7 +437,7 @@ describe("AWS Resources", () => {
         // Create the Lambda function without URL config
         func = await Function(functionName, {
           functionName,
-          zipPath: bundle.path,
+          bundle,
           roleArn: role.arn,
           handler: "handler.handler",
           runtime: "nodejs20.x",
@@ -465,7 +464,7 @@ describe("AWS Resources", () => {
         // Now update the function to add the URL
         func = await Function(functionName, {
           functionName,
-          zipPath: bundle.path,
+          bundle,
           roleArn: role.arn,
           handler: "handler.handler",
           runtime: "nodejs20.x",

--- a/alchemy/test/esbuild.test.ts
+++ b/alchemy/test/esbuild.test.ts
@@ -2,10 +2,10 @@ import { afterAll, expect } from "bun:test";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { alchemy } from "../src/alchemy";
-import { destroy } from "../src/destroy";
 import { Bundle } from "../src/esbuild/bundle";
 import { BRANCH_PREFIX } from "./util";
 
+import { destroy } from "../src/destroy";
 import "../src/test/bun";
 
 const test = alchemy.test(import.meta, {

--- a/examples/aws-app/alchemy.run.ts
+++ b/examples/aws-app/alchemy.run.ts
@@ -62,7 +62,7 @@ const bundle = await Bundle("api-bundle", {
 
 const api = await Function("api", {
   functionName: "alchemy-items-api",
-  zipPath: bundle.path,
+  bundle,
   roleArn: role.arn,
   handler: "index.handler",
   environment: {


### PR DESCRIPTION
There was a regression where the `Bundle` resource required a `outfile` or `outdir`. This change makes it so the `Bundle` can operate entirely in memory and now returns the bundle content which is then used in `Function` and `Worker`.

I also updated `Function` to accept `bundle: Bundle` instead of `zipPath: string` since `zipPath` was not doing what it was meant to do (actually upload a path to a zip file, instead it zipped up a `.js` file)

BREAKING CHANGE:
```ts
const bundle = await Bundle(.);
await Function("my-func", {
  // zipPath is not longer supported, pass bundle instead
  bundle
});
```