### PR TITLE
feat(cloudflare): default R2RestStateStore bucketName to alchemy-state

### DIFF
--- a/alchemy/src/cloudflare/bucket.ts
+++ b/alchemy/src/cloudflare/bucket.ts
@@ -264,10 +264,15 @@ export function createR2Client(config?: R2ClientConfig): Promise<R2Client> {
 }
 
 interface CloudflareBucketResponse {
+  /**
+   * The bucket information returned from the Cloudflare REST API
+   * @see https://developers.cloudflare.com/api/node/resources/r2/subresources/buckets/models/bucket/#(schema)
+   */
   result: {
-    name: string;
-    location?: string;
     creation_date: string;
+    location?: "apac" | "eeur" | "enam" | "weur" | "wnam" | "oc";
+    name: string;
+    storage_class?: "Standard" | "InfrequentAccess";
   };
   success: boolean;
   errors: Array<{ code: number; message: string }>;

--- a/alchemy/src/cloudflare/r2-rest-state-store.ts
+++ b/alchemy/src/cloudflare/r2-rest-state-store.ts
@@ -23,7 +23,7 @@ export interface CloudflareR2StateStoreOptions extends CloudflareApiOptions {
    * The R2 bucket name to use
    * Required - the bucket must already exist
    */
-  bucketName: string;
+  bucketName?: string;
 }
 
 /**
@@ -44,7 +44,7 @@ export class R2RestStateStore implements StateStore {
    */
   constructor(
     public readonly scope: Scope,
-    private readonly options: CloudflareR2StateStoreOptions
+    private readonly options: CloudflareR2StateStoreOptions = {}
   ) {
     // Use the scope's chain to build the prefix, similar to how FileSystemStateStore builds its directory
     const scopePath = scope.chain.join("/");
@@ -52,10 +52,7 @@ export class R2RestStateStore implements StateStore {
       ? `${options.prefix}${scopePath}/`
       : `alchemy/${scopePath}/`;
 
-    if (!options.bucketName) {
-      throw new Error("bucketName is required for CloudflareR2StateStore");
-    }
-    this.bucketName = options.bucketName;
+    this.bucketName = options.bucketName ?? "alchemy-state";
 
     // We'll initialize the API in init() to allow for async creation
     this.api = null as any;

--- a/alchemy/test/cloudflare/bucket.test.ts
+++ b/alchemy/test/cloudflare/bucket.test.ts
@@ -3,6 +3,7 @@ import { alchemy } from "../../src/alchemy";
 import { createCloudflareApi } from "../../src/cloudflare/api";
 import {
   createR2Client,
+  getBucket,
   listBuckets,
   listObjects,
   R2Bucket,
@@ -35,6 +36,10 @@ describe("R2 Bucket Resource", async () => {
         locationHint: "wnam", // West North America
       });
       expect(bucket.name).toEqual(testId);
+
+      // Check if bucket exists by getting it explicitly
+      const gotBucket = await getBucket(api, testId);
+      expect(gotBucket.result.name).toEqual(testId);
 
       // Check if bucket exists by listing buckets
       const buckets = await listBuckets(api);


### PR DESCRIPTION
Fixes #100 


I don't have `R2_*` tokens setup yet, but looking good...


```console
bun test v1.0.29 (a146856d)

alchemy/test/cloudflare/bucket.test.ts:
Create:  "eric/eric-bucket.test.ts/create, update, and delete bucket/eric-test-bucket"
Created: "eric/eric-bucket.test.ts/create, update, and delete bucket/eric-test-bucket"
Update:  "eric/eric-bucket.test.ts/create, update, and delete bucket/eric-test-bucket"
Updated: "eric/eric-bucket.test.ts/create, update, and delete bucket/eric-test-bucket"
Delete:  "eric/eric-bucket.test.ts/create, update, and delete bucket/eric-test-bucket"
Deleted: "eric/eric-bucket.test.ts/create, update, and delete bucket/eric-test-bucket"
✓ R2 Bucket Resource > create, update, and delete bucket [5160.41ms]
Create:  "eric/eric-bucket.test.ts/bucket with jurisdiction/eric-test-bucket-eu"
Created: "eric/eric-bucket.test.ts/bucket with jurisdiction/eric-test-bucket-eu"
Delete:  "eric/eric-bucket.test.ts/bucket with jurisdiction/eric-test-bucket-eu"
Deleted: "eric/eric-bucket.test.ts/bucket with jurisdiction/eric-test-bucket-eu"
✓ R2 Bucket Resource > bucket with jurisdiction [5119.45ms]
Create:  "eric/eric-bucket.test.ts/bucket with file is properly emptied and deleted/eric-test-bucket-with-files"
Created: "eric/eric-bucket.test.ts/bucket with file is properly emptied and deleted/eric-test-bucket-with-files"
Delete:  "eric/eric-bucket.test.ts/bucket with file is properly emptied and deleted/eric-test-bucket-with-files"
Emptying R2 bucket: eric-test-bucket-with-files
245 |   if (!accountId) {
246 |     throw new Error("CLOUDFLARE_ACCOUNT_ID environment variable is required");
247 |   }
248 | 
249 |   if (!accessKeyId || !secretAccessKey) {
250 |     throw new Error(
                ^
error: R2_ACCESS_KEY_ID and R2_SECRET_ACCESS_KEY environment variables are required
      at createR2Client (/Users/eric/Projects/ericclemmons/alchemy/alchemy/src/cloudflare/bucket.ts:250:11)
      at /Users/eric/Projects/ericclemmons/alchemy/alchemy/src/cloudflare/bucket.ts:174:34

Scope failed eric/eric-bucket.test.ts/bucket with file is properly emptied and deleted/eric-test-bucket-with-files
Scope is in error, skipping finalize
245 |   if (!accountId) {
246 |     throw new Error("CLOUDFLARE_ACCOUNT_ID environment variable is required");
247 |   }
248 | 
249 |   if (!accessKeyId || !secretAccessKey) {
250 |     throw new Error(
                ^
error: R2_ACCESS_KEY_ID and R2_SECRET_ACCESS_KEY environment variables are required
      at createR2Client (/Users/eric/Projects/ericclemmons/alchemy/alchemy/src/cloudflare/bucket.ts:250:11)
      at /Users/eric/Projects/ericclemmons/alchemy/alchemy/src/cloudflare/bucket.ts:174:34

245 |   if (!accountId) {
246 |     throw new Error("CLOUDFLARE_ACCOUNT_ID environment variable is required");
247 |   }
248 | 
249 |   if (!accessKeyId || !secretAccessKey) {
250 |     throw new Error(
                ^
error: R2_ACCESS_KEY_ID and R2_SECRET_ACCESS_KEY environment variables are required
      at createR2Client (/Users/eric/Projects/ericclemmons/alchemy/alchemy/src/cloudflare/bucket.ts:250:11)
      at /Users/eric/Projects/ericclemmons/alchemy/alchemy/src/cloudflare/bucket.ts:174:34

245 |   if (!accountId) {
246 |     throw new Error("CLOUDFLARE_ACCOUNT_ID environment variable is required");
247 |   }
248 | 
249 |   if (!accessKeyId || !secretAccessKey) {
250 |     throw new Error(
                ^
error: R2_ACCESS_KEY_ID and R2_SECRET_ACCESS_KEY environment variables are required
      at createR2Client (/Users/eric/Projects/ericclemmons/alchemy/alchemy/src/cloudflare/bucket.ts:250:11)
      at /Users/eric/Projects/ericclemmons/alchemy/alchemy/src/cloudflare/bucket.ts:174:34

Scope failed eric/eric-bucket.test.ts/bucket with file is properly emptied and deleted
Scope is in error, skipping finalize
245 |   if (!accountId) {
246 |     throw new Error("CLOUDFLARE_ACCOUNT_ID environment variable is required");
247 |   }
248 | 
249 |   if (!accessKeyId || !secretAccessKey) {
250 |     throw new Error(
                ^
error: R2_ACCESS_KEY_ID and R2_SECRET_ACCESS_KEY environment variables are required
      at createR2Client (/Users/eric/Projects/ericclemmons/alchemy/alchemy/src/cloudflare/bucket.ts:250:11)
      at /Users/eric/Projects/ericclemmons/alchemy/alchemy/src/cloudflare/bucket.ts:174:34
✗ R2 Bucket Resource > bucket with file is properly emptied and deleted [1852.51ms]

alchemy/test/cloudflare/r2-rest-state-store.test.ts:
✓ R2RestStateStore > optimistically creates alchemy-state bucket [2378.96ms]

 3 pass
 1 fail
 9 expect() calls
Ran 4 tests across 2 files. [15.11s]
```