### PR TITLE
chore(docs): add vitepress-plugin-group-icons for ::: code-block

### DIFF
--- a/alchemy-web/.vitepress/config.mts
+++ b/alchemy-web/.vitepress/config.mts
@@ -3,6 +3,10 @@ import fs from "fs";
 import footnotePlugin from "markdown-it-footnote";
 import path from "path";
 import { defineConfig } from "vitepress";
+import {
+  groupIconMdPlugin,
+  groupIconVitePlugin,
+} from "vitepress-plugin-group-icons";
 import { processFrontmatterFiles } from "../../alchemy/src/web/vitepress";
 
 const description = "Alchemy: Typescript-native Infrastructure-as-Code";
@@ -30,7 +34,10 @@ export default defineConfig({
     // @ts-ignore
     codeTransformers: [transformerTwoslash()],
     theme: { light: "light-plus", dark: "dark-plus" },
-    config: (md) => md.use(footnotePlugin),
+    config: (md) => md.use(footnotePlugin).use(groupIconMdPlugin),
+  },
+  vite: {
+    plugins: [groupIconVitePlugin() as any],
   },
   // https://vitepress.dev/reference/default-theme-config
   themeConfig: {

--- a/alchemy-web/.vitepress/theme/index.ts
+++ b/alchemy-web/.vitepress/theme/index.ts
@@ -1,5 +1,6 @@
 import TwoslashFloatingVue from "@shikijs/vitepress-twoslash/client";
 import "@shikijs/vitepress-twoslash/style.css";
+import "virtual:group-icons.css";
 import type { Theme as ThemeConfig } from "vitepress";
 import Theme from "vitepress/theme-without-fonts";
 import "./style.css";

--- a/alchemy-web/docs/getting-started.md
+++ b/alchemy-web/docs/getting-started.md
@@ -7,9 +7,25 @@
 
 Start by installing the Alchemy library using Bun (or your preferred package manager):
 
-```bash
+::: code-group
+
+```sh [bun]
 bun add alchemy
 ```
+
+```sh [npm]
+npm add alchemy
+```
+
+```sh [pnpm]
+pnpm add alchemy
+```
+
+```sh [yarn]
+yarn add alchemy
+```
+
+:::
 
 ## Create Your First Alchemy App
 

--- a/alchemy-web/package.json
+++ b/alchemy-web/package.json
@@ -6,7 +6,7 @@
     "docs:build": "vitepress build",
     "docs:preview": "vitepress preview"
   },
-  "dependencies": {},
+  "dependencies": { "vitepress-plugin-group-icons": "^1.5.2" },
   "devDependencies": {
     "@shikijs/vitepress-twoslash": "^3.3.0",
     "markdown-it-footnote": "^4.0.0",


### PR DESCRIPTION
I'm a `pnpm` user primarily, and this also started showing places that `bun`'s built-in `.ts` support has slight differences from others.

This is the start for updating other parts of the docs to have per-package-manager code blocks...

### Before

![image](https://github.com/user-attachments/assets/7b8208a9-8f9e-4e69-a1bd-8a6700472107)

### After

![image](https://github.com/user-attachments/assets/b55531b4-509b-4203-aee6-c0b065ef2004)

![image](https://github.com/user-attachments/assets/eb2df42d-bb4a-43b9-b8bd-e638787962a7)
