### PR TITLE
WranglerJson returns `spec` for re-use

### DIFF
--- a/alchemy/src/cloudflare/wrangler.json.ts
+++ b/alchemy/src/cloudflare/wrangler.json.ts
@@ -52,6 +52,11 @@ export interface WranglerJson
    * Path to the wrangler.json file
    */
   path: string;
+
+  /**
+   * `wrangler.json` spec
+   */
+  spec: WranglerJsonSpec;
 }
 
 /**
@@ -104,6 +109,7 @@ export const WranglerJson = Resource(
     return this({
       ...props,
       path: filePath,
+      spec,
       createdAt: Date.now(),
       updatedAt: Date.now(),
     });

--- a/alchemy/test/cloudflare/wrangler-json.test.ts
+++ b/alchemy/test/cloudflare/wrangler-json.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { alchemy } from "../../src/alchemy";
+import { createCloudflareApi } from "../../src/cloudflare/api";
+import { Worker } from "../../src/cloudflare/worker";
+import {
+  WranglerJson,
+  WranglerJsonSpec,
+} from "../../src/cloudflare/wrangler.json";
+import { destroy } from "../../src/destroy";
+import { BRANCH_PREFIX } from "../util";
+
+import "../../src/test/bun";
+
+const test = alchemy.test(import.meta, {
+  prefix: BRANCH_PREFIX,
+});
+
+// Create a Cloudflare API client for verification
+const api = await createCloudflareApi();
+
+// Sample ESM worker script
+const esmWorkerScript = `
+  export default {
+    async fetch(request, env, ctx) {
+      return new Response('Hello ESM world!', { status: 200 });
+    }
+  };
+`;
+
+describe("WranglerJson Resource", () => {
+  describe("with worker", () => {
+    test("infers spec from worker", async (scope) => {
+      const name = `${BRANCH_PREFIX}-test-worker-esm-1`;
+      const tempDir = path.join(".out", "alchemy-entrypoint-test");
+      const entrypoint = path.join(tempDir, "worker.ts");
+
+      try {
+        // Create a temporary directory for the entrypoint file
+        await fs.rm(tempDir, { recursive: true, force: true });
+        await fs.mkdir(tempDir, { recursive: true });
+        await fs.writeFile(entrypoint, esmWorkerScript);
+
+        const worker = await Worker(name, {
+          format: "esm",
+          entrypoint,
+          compatibilityDate: "2024-01-01",
+          compatibilityFlags: ["nodejs_compat"],
+        });
+
+        const wranglerJson = await WranglerJson(
+          `${BRANCH_PREFIX}-test-wrangler-json-1`,
+          { worker }
+        );
+
+        const spec: WranglerJsonSpec = JSON.parse(
+          await fs.readFile(wranglerJson.path, "utf-8")
+        );
+
+        expect(spec.name).toEqual(name);
+        expect(spec.main).toEqual(entrypoint);
+        expect(spec.compatibility_date).toEqual(worker.compatibilityDate);
+        expect(spec.compatibility_flags).toEqual(worker.compatibilityFlags);
+      } finally {
+        await fs.rm(tempDir, { recursive: true, force: true });
+        await destroy(scope);
+      }
+    });
+
+    test("requires entrypoint", async (scope) => {
+      const name = `${BRANCH_PREFIX}-test-worker-esm-2`;
+
+      try {
+        const worker = await Worker(name, {
+          format: "esm",
+          script: esmWorkerScript,
+        });
+
+        const id = `${BRANCH_PREFIX}-test-wrangler-json-2`;
+
+        await expect(async () => await WranglerJson(id, { worker })).toThrow(
+          "Worker must have an entrypoint to generate a wrangler.json"
+        );
+      } finally {
+        await destroy(scope);
+      }
+    });
+  });
+
+  describe("without worker", () => {
+    test("throws error", async (scope) => {
+      const id = `${BRANCH_PREFIX}-test-wrangler-json-3`;
+
+      try {
+        await expect(
+          async () => await WranglerJson(id, { worker: undefined as any })
+        ).toThrow(
+          "undefined is not an object (evaluating 'props.worker.entrypoint')"
+        );
+      } finally {
+        await destroy(scope);
+      }
+    });
+  });
+});

--- a/alchemy/test/cloudflare/wrangler-json.test.ts
+++ b/alchemy/test/cloudflare/wrangler-json.test.ts
@@ -4,10 +4,7 @@ import * as path from "node:path";
 import { alchemy } from "../../src/alchemy";
 import { createCloudflareApi } from "../../src/cloudflare/api";
 import { Worker } from "../../src/cloudflare/worker";
-import {
-  WranglerJson,
-  WranglerJsonSpec,
-} from "../../src/cloudflare/wrangler.json";
+import { WranglerJson } from "../../src/cloudflare/wrangler.json";
 import { destroy } from "../../src/destroy";
 import { BRANCH_PREFIX } from "../util";
 
@@ -49,13 +46,9 @@ describe("WranglerJson Resource", () => {
           compatibilityFlags: ["nodejs_compat"],
         });
 
-        const wranglerJson = await WranglerJson(
+        const { spec } = await WranglerJson(
           `${BRANCH_PREFIX}-test-wrangler-json-1`,
           { worker }
-        );
-
-        const spec: WranglerJsonSpec = JSON.parse(
-          await fs.readFile(wranglerJson.path, "utf-8")
         );
 
         expect(spec.name).toEqual(name);


### PR DESCRIPTION
**EDIT**

Opted to move the `wrangler.jsonc` generation into user-code.  There's benefit to move `processBindings` out for re-use in user-land, but I feel like this is in _niche_ territory.

--- 

_Previous motivation below..._


Users can use Alchemy for creating Resources (e.g. `R2Bucket`, etc.) that can be used for generating a dynamic `wrangler.jsonc` using these Resources' IDs.

However, today `WranglerJson` requires a `worker`.

In my real-world application, this adds **22 seconds** to Alchemy's deploy time (otherwise < 1 second)!

This PR makes `worker` optional so users can generate a dynamic `wrangler.jsonc` and run `wrangler dev|deploy` as normal, but with IaC resources (e.g. `binding`)