### PR TITLE
feat: support scope.run(id, func)

### DIFF
--- a/alchemy/src/alchemy.ts
+++ b/alchemy/src/alchemy.ts
@@ -100,6 +100,7 @@ async function _alchemy(
     const [appName, options] = args as [string, AlchemyOptions?];
     const root = new Scope({
       ...options,
+      parent: null,
       appName,
       stage: options?.stage,
     });

--- a/alchemy/src/scope.ts
+++ b/alchemy/src/scope.ts
@@ -10,7 +10,7 @@ const scopeStorage = new AsyncLocalStorage<Scope>();
 export type ScopeOptions = {
   appName?: string;
   stage?: string;
-  parent?: Scope;
+  parent?: Scope | null;
   scopeName?: string;
   password?: string;
   stateStore?: StateStoreType;
@@ -48,7 +48,8 @@ export class Scope {
     this.appName = options.appName;
     this.stage = options?.stage ?? DEFAULT_STAGE;
     this.scopeName = options.scopeName ?? null;
-    this.parent = options.parent ?? Scope.get();
+    this.parent =
+      options.parent === null ? undefined : (options.parent ?? Scope.get());
     this.quiet = options.quiet ?? this.parent?.quiet ?? false;
     if (this.parent && !this.scopeName) {
       throw new Error("Scope name is required when creating a child scope");

--- a/alchemy/src/scope.ts
+++ b/alchemy/src/scope.ts
@@ -86,8 +86,22 @@ export class Scope {
     this.isErrored = true;
   }
 
-  public enter() {
-    scopeStorage.enterWith(this);
+  public scope(id: string): Scope {
+    return this.enter(id);
+  }
+
+  public enter(id?: string): Scope {
+    if (id) {
+      const scope = new Scope({
+        scopeName: id,
+        parent: this,
+      });
+      scopeStorage.enterWith(scope);
+      return scope;
+    } else {
+      scopeStorage.enterWith(this);
+      return this;
+    }
   }
 
   public async init() {

--- a/alchemy/test/scope.test.ts
+++ b/alchemy/test/scope.test.ts
@@ -30,4 +30,28 @@ describe("Scope", () => {
       await destroy(scope);
     }
   });
+
+  test("multiple apps", async (scope) => {
+    const app1 = await alchemy("app");
+    const app2 = await alchemy("app");
+
+    expect(app1.parent).toBeUndefined();
+    expect(app2.parent).toBeUndefined();
+  });
+
+  test("chained scopes", async (scope) => {
+    const app = await alchemy("app");
+
+    await app.run("nested", async (scope) => {
+      expect(scope.parent).toBeUndefined();
+      expect(scope).toEqual(app);
+    });
+  });
+
+  test("can't run a new scope inside a finalized scope", async (scope) => {
+    await scope.finalize();
+    expect(scope.run(async () => {})).rejects.toThrow();
+    expect(scope.run("nested", async () => {})).rejects.toThrow();
+    expect(scope.run("nested", {}, async () => {})).rejects.toThrow();
+  });
 });

--- a/stacks/app.ts
+++ b/stacks/app.ts
@@ -1,0 +1,14 @@
+import alchemy, { type AlchemyOptions } from "../alchemy/src";
+import { R2RestStateStore } from "../alchemy/src/cloudflare";
+
+export const app = await alchemy("alchemy", {
+  stage: "prod",
+  phase: process.argv.includes("--destroy") ? "destroy" : "up",
+  // pass the password in (you can get it from anywhere, e.g. stdin)
+  password: process.env.SECRET_PASSPHRASE,
+  quiet: process.argv.includes("--quiet"),
+  stateStore:
+    process.env.ALCHEMY_STATE_STORE === "cloudflare"
+      ? (scope) => new R2RestStateStore(scope)
+      : undefined,
+} satisfies AlchemyOptions);

--- a/stacks/docs.run.ts
+++ b/stacks/docs.run.ts
@@ -3,62 +3,59 @@ import path from "node:path";
 import "../alchemy/src/fs";
 import "../alchemy/src/web/vitepress";
 
-import alchemy from "../alchemy/src";
 import { CopyFile } from "../alchemy/src/fs/copy-file";
 import { Folder } from "../alchemy/src/fs/folder";
 import { Providers } from "../alchemy/src/internal/docs/providers";
 import { VitepressProject } from "../alchemy/src/web/vitepress";
-import env from "./env";
+import { app } from "./app";
 
-const app = await alchemy("alchemy:docs", env);
+export default app.run("docs", async (scope) => {
+  const project = await VitepressProject("vitepress", {
+    name: "alchemy-web",
+    delete: true,
+  });
 
-const project = await VitepressProject("vitepress", {
-  name: "alchemy-web",
-  delete: true,
+  const docs = await Folder("docs", {
+    path: path.join(project.dir, "docs"),
+  });
+
+  const [pub, blogs, guides, providers, conceptsDir] = await Promise.all([
+    Folder("public", {
+      path: path.join(project.dir, "public"),
+    }),
+    Folder("blogs", {
+      path: path.join(project.dir, "blogs"),
+    }),
+    Folder("guides", {
+      path: path.join(docs.path, "guides"),
+    }),
+    Folder("providers", {
+      path: path.join(docs.path, "providers"),
+    }),
+    Folder("concepts", {
+      path: path.join(docs.path, "concepts"),
+    }),
+  ]);
+
+  await CopyFile("docs-public-alchemist", {
+    src: path.join(process.cwd(), "public", "alchemist.webp"),
+    dest: path.join(pub.path, "alchemist.webp"),
+  });
+
+  const filterIdx = process.argv.findIndex((arg) => arg === "--filter");
+
+  await Providers({
+    srcDir: path.join("alchemy", "src"),
+    outDir: providers.path,
+    // anthropic throttles are painful, so we'll run them serially
+    parallel: false,
+    filter:
+      process.argv[filterIdx + 1] === "true"
+        ? true
+        : filterIdx > -1
+          ? isNaN(parseInt(process.argv[filterIdx + 1]))
+            ? false
+            : parseInt(process.argv[filterIdx + 1])
+          : false,
+  });
 });
-
-const docs = await Folder("docs", {
-  path: path.join(project.dir, "docs"),
-});
-
-const [pub, blogs, guides, providers, conceptsDir] = await Promise.all([
-  Folder("public", {
-    path: path.join(project.dir, "public"),
-  }),
-  Folder("blogs", {
-    path: path.join(project.dir, "blogs"),
-  }),
-  Folder("guides", {
-    path: path.join(docs.path, "guides"),
-  }),
-  Folder("providers", {
-    path: path.join(docs.path, "providers"),
-  }),
-  Folder("concepts", {
-    path: path.join(docs.path, "concepts"),
-  }),
-]);
-
-await CopyFile("docs-public-alchemist", {
-  src: path.join(process.cwd(), "public", "alchemist.webp"),
-  dest: path.join(pub.path, "alchemist.webp"),
-});
-
-const filterIdx = process.argv.findIndex((arg) => arg === "--filter");
-
-await Providers({
-  srcDir: path.join("alchemy", "src"),
-  outDir: providers.path,
-  // anthropic throttles are painful, so we'll run them serially
-  parallel: false,
-  filter:
-    process.argv[filterIdx + 1] === "true"
-      ? true
-      : filterIdx > -1
-        ? isNaN(parseInt(process.argv[filterIdx + 1]))
-          ? false
-          : parseInt(process.argv[filterIdx + 1])
-        : false,
-});
-
-await app.finalize();

--- a/stacks/env.ts
+++ b/stacks/env.ts
@@ -1,6 +1,4 @@
 import alchemy from "../alchemy/src";
-import type { AlchemyOptions } from "../alchemy/src/alchemy";
-import { R2RestStateStore } from "../alchemy/src/cloudflare";
 
 export const CLOUDFLARE_EMAIL = await alchemy.env.CLOUDFLARE_EMAIL;
 
@@ -13,15 +11,3 @@ export const STRIPE_API_KEY = await alchemy.secret.env.STRIPE_API_KEY;
 export const OPENAI_API_KEY = await alchemy.secret.env.OPENAI_API_KEY;
 
 export const NEON_API_KEY = await alchemy.secret.env.NEON_API_KEY;
-
-export default {
-  stage: "prod",
-  phase: process.argv.includes("--destroy") ? "destroy" : "up",
-  // pass the password in (you can get it from anywhere, e.g. stdin)
-  password: process.env.SECRET_PASSPHRASE,
-  quiet: process.argv.includes("--quiet"),
-  stateStore:
-    process.env.ALCHEMY_STATE_STORE === "cloudflare"
-      ? (scope) => new R2RestStateStore(scope)
-      : undefined,
-} satisfies AlchemyOptions;

--- a/stacks/repo.run.ts
+++ b/stacks/repo.run.ts
@@ -13,7 +13,8 @@ import {
   R2Bucket,
 } from "../alchemy/src/cloudflare";
 import { GitHubSecret, RepositoryEnvironment } from "../alchemy/src/github";
-import env, {
+import { app } from "./app";
+import {
   CLOUDFLARE_ACCOUNT_ID,
   CLOUDFLARE_API_KEY,
   CLOUDFLARE_EMAIL,
@@ -22,7 +23,7 @@ import env, {
   STRIPE_API_KEY,
 } from "./env";
 
-const app = await alchemy("alchemy:repo", env);
+const scope = app.enter("repo");
 
 const awsAccountId = await AccountId();
 
@@ -120,4 +121,4 @@ await Promise.all([
   }),
 ]);
 
-await app.finalize();
+await scope.finalize();

--- a/stacks/website.run.ts
+++ b/stacks/website.run.ts
@@ -5,12 +5,11 @@ import "../alchemy/src/dns";
 import "../alchemy/src/os";
 
 import path from "node:path";
-import alchemy from "../alchemy/src";
 import { Assets, CustomDomain, Worker, Zone } from "../alchemy/src/cloudflare";
 import { Exec } from "../alchemy/src/os";
-import options from "./env";
+import { app } from "./app";
 
-const app = await alchemy("alchemy:website", options);
+const scope = app.scope("website");
 
 const zone = await Zone("alchemy.run", {
   name: "alchemy.run",
@@ -56,4 +55,4 @@ await CustomDomain("alchemy-web-domain", {
 
 console.log(`https://alchemy.run`);
 
-await app.finalize();
+await scope.finalize();


### PR DESCRIPTION
This will make the following patterns possible
```ts
// infra/app.ts
export const app = await alchemy("my-app");
```
```ts
// infra/global.ts
import { app } from "./app.ts"

export const { db } = await app.run("global", async () => {
  const db = await NeonProject(..);
  return { db };
});
```
```ts
// infra/backend.ts
import { app } from "./app.ts"
import { DB } from "./backend.ts";

export const { branch } = await app.run("backend", async () => {
  const worker = await Worker(.., {
    bindings: {
      DB
    }
  });
  return { worker };
});
```
State:
```sh
.alchemy/
  global/
  backend/
```

> [!CAUTION]
> Need to figure out what to do with `stage`. 
>
> ```ts
> await app.stage.run("backend", ..)
> ```
> Translate to this?
> ```sh
> .alchemy/
>   my-app/
>     prod/
>       backend
> ```