### PR TITLE
Add preview_* properties

### DIFF
--- a/alchemy/src/cloudflare/wrangler.json.ts
+++ b/alchemy/src/cloudflare/wrangler.json.ts
@@ -170,6 +170,10 @@ export interface WranglerJsonSpec {
   kv_namespaces?: {
     binding: string;
     id: string;
+    /**
+     * The ID of the KV namespace used during `wrangler dev`
+     */
+    preview_id?: string;
   }[];
 
   /**
@@ -190,6 +194,10 @@ export interface WranglerJsonSpec {
   r2_buckets?: {
     binding: string;
     bucket_name: string;
+    /**
+     * The preview name of this R2 bucket at the edge.
+     */
+    preview_bucket_name?: string;
   }[];
 
   /**
@@ -246,6 +254,10 @@ export interface WranglerJsonSpec {
     database_id: string;
     database_name: string;
     migrations_dir?: string;
+    /**
+     * The ID of the D1 database used during `wrangler dev`
+     */
+    preview_database_id?: string;
   }[];
 
   /**


### PR DESCRIPTION
I noticed these values were missing compared to the `wrangler/config-schema.json`:

```json
"r2_buckets": {
          "type": "array",
          "items": {
            "type": "object",
            "properties": {
              "binding": {
                "type": "string",
                "description": "The binding name used to refer to the R2 bucket in the Worker."
              },
              "bucket_name": {
                "type": "string",
                "description": "The name of this R2 bucket at the edge."
              },
              "preview_bucket_name": {
                "type": "string",
                "description": "The preview name of this R2 bucket at the edge."
              },
              "jurisdiction": {
                "type": "string",
                "description": "The jurisdiction that the bucket exists in. Default if not present."
              }
            },
            "required": [
              "binding"
            ],
            "additionalProperties": false
          },
          "description": "Specifies R2 buckets that are bound to this Worker environment.\n\nNOTE: This field is not automatically inherited from the top level environment, and so must be specified in every named environment.",
          "default": []
        },
        "d1_databases": {
          "type": "array",
          "items": {
            "type": "object",
            "properties": {
              "binding": {
                "type": "string",
                "description": "The binding name used to refer to the D1 database in the Worker."
              },
              "database_name": {
                "type": "string",
                "description": "The name of this D1 database."
              },
              "database_id": {
                "type": "string",
                "description": "The UUID of this D1 database (not required)."
              },
              "preview_database_id": {
                "type": "string",
                "description": "The UUID of this D1 database for Wrangler Dev (if specified)."
              },
              "migrations_table": {
                "type": "string",
                "description": "The name of the migrations table for this D1 database (defaults to 'd1_migrations')."
              },
              "migrations_dir": {
                "type": "string",
                "description": "The path to the directory of migrations for this D1 database (defaults to './migrations')."
              },
              "database_internal_env": {
                "type": "string",
                "description": "Internal use only."
              }
            },
            "required": [
              "binding"
            ],
            "additionalProperties": false
          },
          "description": "Specifies D1 databases that are bound to this Worker environment.\n\nNOTE: This field is not automatically inherited from the top level environment, and so must be specified in every named environment.",
          "default": []
        },
		...
		"kv_namespaces": {
          "type": "array",
          "items": {
            "type": "object",
            "properties": {
              "binding": {
                "type": "string",
                "description": "The binding name used to refer to the KV Namespace"
              },
              "id": {
                "type": "string",
                "description": "The ID of the KV namespace"
              },
              "preview_id": {
                "type": "string",
                "description": "The ID of the KV namespace used during `wrangler dev`"
              }
            },
            "required": [
              "binding"
            ],
            "additionalProperties": false
          },
          "description": "These specify any Workers KV Namespaces you want to access from inside your Worker.\n\nTo learn more about KV Namespaces, see the documentation at https://developers.cloudflare.com/workers/learning/how-kv-works\n\nNOTE: This field is not automatically inherited from the top level environment, and so must be specified in every named environment.",
          "default": []
        },
```