### PR TITLE
feat(core): replace Resource

### DIFF
--- a/alchemy-web/docs/concepts/phase.md
+++ b/alchemy-web/docs/concepts/phase.md
@@ -2,10 +2,7 @@
 order: 2
 ---
 
-
 # Phase
-
-## Phases
 
 An Alchemy app can run in one of three phases:
 1. `"up"` - resources should be created, updated and deleted as necessary.

--- a/alchemy-web/docs/concepts/replace.md
+++ b/alchemy-web/docs/concepts/replace.md
@@ -1,0 +1,124 @@
+---
+order: 3
+---
+
+# Replace
+
+Some Cloud Resources do not allow all properties to be updated, e.g. an AWS DynamoDB Table's name cannot change after creation.
+
+To support changing these properties, an Alchemy Resource's lifecycle handler can call `this.replace()` to mark the resource for deletion and then create a new one.
+
+Alchemy will delete the replaced resource once it is safe to do so.
+
+## Trigger Replacement
+
+During the `"update"` phase of your Resource lifecycle handler, check for cases that cannot be updated and then call `this.replace()` before creating a new instance.
+
+For example, the following code detects that our Table's name has changed.
+
+```ts
+if (this.phase === "update") {
+  // if the table's name has changed, we must replace
+  if (props.name !== this.props.name) {
+    // signal to alchemy that this resource is being replaced
+    this.replace();
+  }
+}
+```
+
+> [!NOTE]
+> `this.props` contains the `props` of when this resource was originaly created or last updated.
+
+After triggering replacement, your Resource lifecycle handler should proceed through the typical creation flow.
+
+```ts
+// continue with the ordinary create flow
+const table = await createNewTable(props);
+return this(table)
+```
+
+## Replacement Lifecycle
+
+A replaced Resource will be deleted after all `create` and `update` operations complete when you call `app.finalize()`:
+
+```ts
+const app = await alchemy("my-app");
+
+// resoruces
+
+await app.finalize(); // <- will finalize all resoruces, including deleting repalced ones
+```
+
+It is not deleted immediately because Alchemy must guarantee that all references to the old Resource have been updated.
+
+Consider the following example:
+```ts
+const table = await Table("table", { name: "my-table" });
+
+const function = await Function("function", {
+  env: {
+    TABLE_NAME: table.tableName
+  }
+});
+```
+
+If we deleted the `table` before updating the `function`, the `TABLE_NAME` reference would be left "dangling". 
+
+In some cases, the API will even reject its deletion, leading to a "bricked" Stack that can't proceed.
+
+To avoid this, Alchemy delays deletion until after the application state has flushed.
+
+## Full Example
+
+This simple example demonstrates a pattern for replaceable resources. 
+
+```ts
+const Table = Resource(
+  "dynamodb::Table",
+  async function(this, id, props) {
+    if (this.phase === "delete") {
+      // call delete APIs
+      await deleteTable(this.output)
+      return this.destroy();
+    } else if (this.phase === "update") {
+      if (props.name !== this.props.name) {
+        // Uh oh! We need to replace this table because the name changed
+        this.replace();
+      } else {
+        // we can safely update the table, let's just call the API
+        const table = await updateTable(props);
+        // and then return early
+        return this(table);
+      }
+    }
+    // create a new table during `"create"` or when 
+    const table = await createTable(props);
+    return this(table);
+  }
+);
+```
+
+
+## Limitations
+
+> [!CAUTION]
+> You cannot replace a Resource that has child resources.
+> 
+> ```ts
+> const MyResource = Resource(
+>   "MyResource",
+>   async function(this, id, props) {
+>     if (this.phase === "update" && props.name !== this.props.name) {
+>       // will throw because this Resource has a child, `table` Resource.
+>       this.replace();
+>     }
+>     const table = await Table("child");
+>     return this({
+>       tableName: table.tableName
+>     });
+>   }
+> );
+> ```
+
+> [!NOTE]
+> This constraint may be relaxed later.

--- a/alchemy-web/docs/guides/custom-state-store.md
+++ b/alchemy-web/docs/guides/custom-state-store.md
@@ -214,16 +214,7 @@ export class InMemoryStateStore implements StateStore {
     }
     
     // Deserialize the state
-    const state = await deserialize(this.scope, serializedState) as State;
-    
-    // Ensure scope is set on output
-    return {
-      ...state,
-      output: {
-        ...(state.output || {}),
-        Scope: this.scope,
-      },
-    };
+    return await deserialize(this.scope, serializedState) as State;
   }
 
   // Get multiple states
@@ -316,19 +307,6 @@ Be sure to handle common errors gracefully:
 - Throw clear errors for authentication/permission issues
 - Consider implementing retry logic for transient failures
 
-### 5. Setting Scope on Output
-
-When returning a state, always ensure the scope is set on the output:
-
-```typescript
-return {
-  ...state,
-  output: {
-    ...(state.output || {}),
-    Scope: this.scope,
-  },
-};
-```
 
 ## Using a Custom State Store
 

--- a/alchemy/src/alchemy.ts
+++ b/alchemy/src/alchemy.ts
@@ -354,7 +354,8 @@ async function run<T>(
     }
     return await scope.run(async () => fn.bind(scope)(scope));
   } catch (error) {
-    scope.fail();
+    // console.error(error);
+    scope.fail(error);
     throw error;
   }
 }

--- a/alchemy/src/apply.ts
+++ b/alchemy/src/apply.ts
@@ -146,6 +146,14 @@ export async function apply<Out extends Resource>(
       console.log(`${phase === "create" ? "Created" : "Updated"}: "${fqn}"`);
     }
 
+    console.log(
+      isReplaced
+        ? {
+            // output: oldOutput,
+            props: oldProps,
+          }
+        : undefined,
+    );
     await scope.state.set(id, {
       kind,
       id,

--- a/alchemy/src/apply.ts
+++ b/alchemy/src/apply.ts
@@ -1,12 +1,17 @@
-import { alchemy } from "./alchemy.js";
 import { context } from "./context.js";
 import {
   PROVIDERS,
+  ResourceFQN,
+  ResourceID,
+  ResourceKind,
+  ResourceScope,
+  ResourceSeq,
   type PendingResource,
   type Provider,
   type Resource,
   type ResourceProps,
 } from "./resource.js";
+import { Scope } from "./scope.js";
 import { serialize } from "./serde.js";
 import type { State } from "./state.js";
 
@@ -20,42 +25,50 @@ export async function apply<Out extends Resource>(
   props: ResourceProps | undefined,
   options?: ApplyOptions,
 ): Promise<Awaited<Out>> {
-  const scope = resource.Scope;
+  const scope = resource[ResourceScope];
+  const id = resource[ResourceID];
+  const kind = resource[ResourceKind];
+  const fqn = resource[ResourceFQN];
+  const seq = resource[ResourceSeq];
   try {
     const quiet = props?.quiet ?? scope.quiet;
     await scope.init();
-    let state: State | undefined = (await scope.state.get(resource.ID))!;
-    const provider: Provider = PROVIDERS.get(resource.Kind);
+    let state: State | undefined = (await scope.state.get(id))!;
+    const provider: Provider = PROVIDERS.get(kind);
     if (provider === undefined) {
-      throw new Error(`Provider "${resource.Kind}" not found`);
+      throw new Error(`Provider "${kind}" not found`);
     }
     if (scope.phase === "read") {
       if (state === undefined) {
         throw new Error(
-          `Resource "${resource.FQN}" not found and running in 'read' phase.`,
+          `Resource "${fqn}" not found and running in 'read' phase.`,
+        );
+      } else if (state.status === "creating" && state.output === undefined) {
+        throw new Error(
+          `Resource "${fqn}" did not finish creating, you must run in 'up' phase successfully before running in 'read' phase.`,
         );
       }
       return state.output as Awaited<Out>;
     }
     if (state === undefined) {
       state = {
-        kind: resource.Kind,
-        id: resource.ID,
-        fqn: resource.FQN,
-        seq: resource.Seq,
+        kind,
+        id,
+        fqn,
+        seq,
         status: "creating",
         data: {},
         output: {
-          ID: resource.ID,
-          FQN: resource.FQN,
-          Kind: resource.Kind,
-          Scope: scope,
-          Seq: resource.Seq,
+          [ResourceID]: id,
+          [ResourceFQN]: fqn,
+          [ResourceKind]: kind,
+          [ResourceSeq]: seq,
+          [ResourceScope]: scope,
         },
         // deps: [...deps],
         props,
       };
-      await scope.state.set(resource.ID, state);
+      await scope.state.set(id, state);
     }
 
     const alwaysUpdate =
@@ -82,67 +95,76 @@ export async function apply<Out extends Resource>(
 
     const phase = state.status === "creating" ? "create" : "update";
     state.status = phase === "create" ? "creating" : "updating";
-    state.oldProps = state.props;
+    const oldProps = state.props;
+    const oldOutput = state.output;
+    state.oldProps = oldProps;
     state.props = props;
 
     if (!quiet) {
-      console.log(
-        `${phase === "create" ? "Create" : "Update"}:  "${resource.FQN}"`,
-      );
+      console.log(`${phase === "create" ? "Create" : "Update"}:  "${fqn}"`);
     }
 
-    await scope.state.set(resource.ID, state);
+    await scope.state.set(id, state);
 
     let isReplaced = false;
 
-    const ctx = context({
-      scope,
-      phase,
-      kind: resource.Kind,
-      id: resource.ID,
-      fqn: resource.FQN,
-      seq: resource.Seq,
-      props: state.oldProps,
-      state,
-      replace: () => {
-        if (isReplaced) {
-          console.warn(
-            `Resource ${resource.Kind} ${resource.FQN} is already marked as REPLACE`,
-          );
-          return;
-        }
-        isReplaced = true;
-      },
+    const resourceScope = await Scope.create({
+      parent: scope,
+      scopeName: id,
+      seq,
     });
 
-    const output = await alchemy.run(
-      resource.ID,
-      {
-        isResource: true,
-      },
-      async () => provider.handler.bind(ctx)(resource.ID, props),
-    );
+    const output = await resourceScope.run(async (scope) => {
+      const children = await scope.state.list();
+      return provider.handler.bind(
+        context({
+          scope,
+          phase,
+          kind,
+          id,
+          fqn,
+          seq,
+          props: state.oldProps,
+          state,
+          replace: () => {
+            if (children.length > 0) {
+              // TODO(sam): we need to determine how to make it possible to replace resources with children
+              // e.g. we can move the children resources and delete them later
+              // ... but, this seems like it could lead to tricky bugs where the replacement resource creates children
+              // ... that then conflict with the replaced resource's children and are either deleted or brick the stack
+              // For now, we just disallow it.
+              throw new Error(
+                `Resource "${fqn}" has children and cannot be replaced.`,
+              );
+            }
+            isReplaced = true;
+          },
+        }),
+      )(id, props);
+    });
     if (!quiet) {
-      console.log(
-        `${phase === "create" ? "Created" : "Updated"}: "${resource.FQN}"`,
-      );
+      console.log(`${phase === "create" ? "Created" : "Updated"}: "${fqn}"`);
     }
 
-    await scope.state.set(resource.ID, {
-      kind: resource.Kind,
-      id: resource.ID,
-      fqn: resource.FQN,
-      seq: resource.Seq,
+    await scope.state.set(id, {
+      kind,
+      id,
+      fqn,
+      seq,
       data: state.data,
       status: phase === "create" ? "created" : "updated",
       output,
       props,
-      // deps: [...deps],
+      // TOOD(sam): what happens if we fail to set the state here?
+      // next pass, we've lost track of the replacement resource
+      replace: isReplaced
+        ? {
+            output: oldOutput,
+            props: oldProps,
+          }
+        : undefined,
     });
-    // if (output !== undefined) {
-    //   resource[Provide](output as Out);
-    // }
-    return output as any;
+    return output as Awaited<Out>;
   } catch (error) {
     scope.fail();
     throw error;

--- a/alchemy/src/cloudflare/r2-rest-state-store.ts
+++ b/alchemy/src/cloudflare/r2-rest-state-store.ts
@@ -36,6 +36,7 @@ export class R2RestStateStore implements StateStore {
   private prefix: string;
   private bucketName: string;
   private initialized = false;
+  private readonly cache: Map<string, State>;
 
   /**
    * Create a new CloudflareR2StateStore
@@ -57,6 +58,8 @@ export class R2RestStateStore implements StateStore {
 
     // We'll initialize the API in init() to allow for async creation
     this.api = null as any;
+
+    this.cache = new Map<string, State>();
   }
 
   /**
@@ -177,6 +180,10 @@ export class R2RestStateStore implements StateStore {
   async get(key: string): Promise<State | undefined> {
     await this.ensureInitialized();
 
+    if (this.cache.has(key)) {
+      return this.cache.get(key);
+    }
+
     try {
       const response = await withExponentialBackoff(
         async () => {
@@ -205,13 +212,15 @@ export class R2RestStateStore implements StateStore {
       const state = (await deserialize(this.scope, rawData)) as State;
 
       // Create a new state object with proper output
-      return {
+      const reified = {
         ...state,
         output: {
           ...(state.output || {}),
           Scope: this.scope,
         },
       };
+      this.cache.set(key, reified);
+      return reified;
     } catch (error: any) {
       if (error.message?.includes("404")) {
         return undefined;
@@ -288,6 +297,7 @@ export class R2RestStateStore implements StateStore {
       5, // 5 retry attempts
       1000, // Start with 1 second delay
     );
+    this.cache.set(key, value);
   }
 
   /**

--- a/alchemy/src/cloudflare/r2-rest-state-store.ts
+++ b/alchemy/src/cloudflare/r2-rest-state-store.ts
@@ -211,16 +211,8 @@ export class R2RestStateStore implements StateStore {
       const rawData = await response.json();
       const state = (await deserialize(this.scope, rawData)) as State;
 
-      // Create a new state object with proper output
-      const reified = {
-        ...state,
-        output: {
-          ...(state.output || {}),
-          Scope: this.scope,
-        },
-      };
-      this.cache.set(key, reified);
-      return reified;
+      this.cache.set(key, state);
+      return state;
     } catch (error: any) {
       if (error.message?.includes("404")) {
         return undefined;

--- a/alchemy/src/context.ts
+++ b/alchemy/src/context.ts
@@ -123,7 +123,10 @@ export function context<
     phase,
     output: state.output,
     props: state.props,
-    replace,
+    replace: () => {
+      scope.replace();
+      return replace();
+    },
     get: (key: string) => state.data[key],
     set: async (key: string, value: any) => {
       state.data[key] = value;

--- a/alchemy/src/context.ts
+++ b/alchemy/src/context.ts
@@ -1,10 +1,12 @@
 import { DestroyedSignal } from "./destroy.js";
-import type {
-  Resource,
+import {
   ResourceFQN,
   ResourceID,
   ResourceKind,
-  ResourceProps,
+  ResourceScope,
+  ResourceSeq,
+  type Resource,
+  type ResourceProps,
 } from "./resource.js";
 import type { Scope } from "./scope.js";
 import type { State } from "./state.js";
@@ -94,7 +96,7 @@ export function context<
   seq: number;
   props: Props;
   state: State<Kind, Props, Out>;
-  replace: () => void;
+  replace?: () => void;
 }): Context<Out> {
   function create(props: Omit<Out, "Kind" | "ID" | "Scope">): Out;
   function create(id: string, props: Omit<Out, "Kind" | "ID" | "Scope">): Out;
@@ -108,25 +110,22 @@ export function context<
 
     return {
       ...props,
-      Kind: kind,
-      ID,
-      FQN: fqn,
-      Scope: scope,
-      Seq: seq,
+      [ResourceKind]: kind,
+      [ResourceID]: ID,
+      [ResourceFQN]: fqn,
+      [ResourceScope]: scope,
+      [ResourceSeq]: seq,
     } as Out;
   }
   return Object.assign(create, {
     stage: scope.stage,
-    scope,
+    scope: scope,
     id: id,
     fqn: fqn,
-    phase,
+    phase: phase,
     output: state.output,
     props: state.props,
-    replace: () => {
-      scope.replace();
-      return replace();
-    },
+    replace: () => replace?.(),
     get: (key: string) => state.data[key],
     set: async (key: string, value: any) => {
       state.data[key] = value;

--- a/alchemy/src/context.ts
+++ b/alchemy/src/context.ts
@@ -140,5 +140,5 @@ export function context<
       throw new DestroyedSignal();
     },
     create,
-  }) as Context<Out>;
+  }) as Context<any>;
 }

--- a/alchemy/src/destroy.ts
+++ b/alchemy/src/destroy.ts
@@ -106,7 +106,7 @@ export async function destroy<Type extends string>(
         instance.ID,
         {
           // TODO(sam): this is an awful hack to differentiate between naked scopes and resources
-          isResource: instance.Kind !== "alchemy::Scope",
+          isResource: instance.Kind !== Scope.KIND,
           parent: scope,
         },
         async (scope) => {

--- a/alchemy/src/destroy.ts
+++ b/alchemy/src/destroy.ts
@@ -1,6 +1,15 @@
-import { alchemy } from "./alchemy.js";
 import { context } from "./context.js";
-import { PROVIDERS, type Provider, type Resource } from "./resource.js";
+import {
+  PROVIDERS,
+  ResourceFQN,
+  ResourceID,
+  ResourceKind,
+  ResourceScope,
+  ResourceSeq,
+  type Provider,
+  type Resource,
+  type ResourceProps,
+} from "./resource.js";
 import { Scope } from "./scope.js";
 
 export class DestroyedSignal extends Error {}
@@ -8,6 +17,14 @@ export class DestroyedSignal extends Error {}
 export interface DestroyOptions {
   quiet?: boolean;
   strategy?: "sequential" | "parallel";
+  /**
+   * This destroy operation is for a replaced resource
+   *
+   * The state of the resource should not be unpersisted.
+   */
+  replace?: {
+    props: ResourceProps | undefined;
+  };
 }
 
 function isScopeArgs(a: any): a is [scope: Scope, options?: DestroyOptions] {
@@ -28,58 +45,80 @@ export async function destroy<Type extends string>(
       strategy: "sequential",
       ...(args[1] ?? {}),
     } satisfies DestroyOptions;
-
-    // destroy all active resources
-    await destroy.all(Array.from(scope.resources.values()), options);
-
-    // then detect orphans and destroy them
-    const orphans = await scope.state.all();
-    await destroy.all(
-      Object.values(orphans).map((orphan) => ({
-        ...orphan.output,
-        Scope: scope,
-      })),
-      options,
-    );
-    // finally, destroy the scope container
-    await scope.deinit();
-    return;
+    return await destroyScope(scope, options);
+  } else {
+    const [instance, options] = args;
+    if (!instance) {
+      return;
+    }
+    return await destroyResource(instance, options);
   }
+}
 
-  const [instance, options] = args;
+export async function destroyScope(
+  scope: Scope,
+  options: DestroyOptions | undefined,
+) {
+  // destroy all active resources
+  const resources = Array.from(scope.resources.values());
+  await destroy.all(resources, options);
+  // then detect orphans and destroy them
+  const orphans = await scope.state.all();
+  await destroy.all(
+    Object.values(orphans).map((orphan) => ({
+      ...orphan.output,
+      [ResourceScope]: scope,
+    })),
+    options,
+  );
+  // finally, destroy the scope container
+  await scope.deinit();
+}
 
+export async function destroyResource(
+  instance: Resource,
+  options: DestroyOptions | undefined,
+) {
   if (!instance) {
     return;
   }
 
-  if (instance.Kind === "alchemy::Scope") {
-    const scope = new Scope({
-      parent: instance.Scope,
-      scopeName: instance.ID,
-    });
-    console.log("Destroying scope", scope.chain.join("/"));
-    return await destroy(scope, options);
-  }
+  const id = instance[ResourceID];
+  const kind = instance[ResourceKind];
+  const fqn = instance[ResourceFQN];
+  const seq = instance[ResourceSeq];
 
-  const Provider: Provider<Type> | undefined = PROVIDERS.get(instance.Kind);
-  if (!Provider) {
-    throw new Error(
-      `Cannot destroy resource "${instance.FQN}" type ${instance.Kind} - no provider found. You may need to import the provider in your alchemy.config.ts.`,
+  if (kind === "alchemy::Scope") {
+    return await destroyScope(
+      new Scope({
+        parent: instance[ResourceScope],
+        scopeName: id,
+      }),
+      options,
     );
   }
 
-  const scope = instance.Scope;
+  const Provider: Provider | undefined = PROVIDERS.get(kind);
+  if (!Provider) {
+    // console.log(instance);
+    throw new Error(
+      `Cannot destroy resource "${fqn}" type "${kind}" - no provider found. You may need to import the provider in your alchemy.config.ts.`,
+    );
+  }
+
+  // the scope containing this resource
+  const scope = instance[ResourceScope];
   if (!scope) {
-    console.warn(`Resource "${instance.FQN}" has no scope`);
+    console.warn(`Resource "${fqn}" has no scope`);
   }
   const quiet = options?.quiet ?? scope.quiet;
 
   try {
     if (!quiet) {
-      console.log(`Delete:  "${instance.FQN}"`);
+      console.log(`Delete:  "${fqn}"`);
     }
 
-    const state = await scope.state.get(instance.ID);
+    const state = await scope.state.get(id);
 
     if (state === undefined) {
       return;
@@ -88,10 +127,10 @@ export async function destroy<Type extends string>(
     const ctx = context({
       scope,
       phase: "delete",
-      kind: instance.Kind,
-      id: instance.ID,
-      fqn: instance.FQN,
-      seq: instance.Seq,
+      kind,
+      id,
+      fqn,
+      seq,
       props: state.props,
       state,
       replace: () => {
@@ -99,21 +138,23 @@ export async function destroy<Type extends string>(
       },
     });
 
-    let nestedScope: Scope | undefined;
+    // the scope of this resource instance
+    const resourceScope = new Scope({
+      parent: scope,
+      scopeName: id,
+      seq,
+    });
     try {
+      // TODO(sam): i forgot what this bug refers to
       // BUG: this does not restore persisted scope
-      await alchemy.run(
-        instance.ID,
-        {
-          // TODO(sam): this is an awful hack to differentiate between naked scopes and resources
-          isResource: instance.Kind !== Scope.KIND,
-          parent: scope,
-        },
-        async (scope) => {
-          nestedScope = scope;
-          return await Provider.handler.bind(ctx)(instance.ID, state.props);
-        },
-      );
+      await resourceScope.run(async () => {
+        return Provider.handler.bind(ctx)(
+          id,
+          // if replace is undefined, then this is a replace
+          // replace.props could still be undefined
+          options?.replace ? options.replace.props : state.props,
+        );
+      });
     } catch (err) {
       if (err instanceof DestroyedSignal) {
         // TODO: should we fail if the DestroyedSignal is not thrown?
@@ -122,14 +163,16 @@ export async function destroy<Type extends string>(
       }
     }
 
-    if (nestedScope) {
-      await destroy(nestedScope, options);
+    // if this is not the delete of a replaced resource, then destroy the resource scope
+    if (options?.replace === undefined) {
+      // destroy it
+      await destroy(resourceScope, options);
+      // delete it from the scope state
+      await scope.delete(id);
     }
 
-    await scope.delete(instance.ID);
-
     if (!quiet) {
-      console.log(`Deleted: "${instance.FQN}"`);
+      console.log(`Deleted: "${fqn}"`);
     }
   } catch (error) {
     console.error(error);
@@ -140,7 +183,7 @@ export async function destroy<Type extends string>(
 export namespace destroy {
   export async function all(resources: Resource[], options?: DestroyOptions) {
     if (options?.strategy !== "parallel") {
-      const sorted = resources.sort((a, b) => b.Seq - a.Seq);
+      const sorted = resources.sort((a, b) => b[ResourceSeq] - a[ResourceSeq]);
       for (const resource of sorted) {
         await destroy(resource, options);
       }

--- a/alchemy/src/destroy.ts
+++ b/alchemy/src/destroy.ts
@@ -127,7 +127,6 @@ export async function destroyResource(
   // TODO(sam): could we delete in parallel?
   if (options?.replace === undefined && state.replace !== undefined) {
     // we're destroying a resource that also has a pending replace
-    console.log("Deleting pending resource", state.id);
     await destroy(state.replace.output, {
       replace: state.replace,
     });

--- a/alchemy/src/fs/file-system-state-store.ts
+++ b/alchemy/src/fs/file-system-state-store.ts
@@ -57,7 +57,6 @@ export class FileSystemStateStore implements StateStore {
       if (state.output === undefined) {
         state.output = {} as any;
       }
-      state.output.Scope = this.scope;
       return state;
     } catch (error: any) {
       if (error.code === "ENOENT") {

--- a/alchemy/src/resource.ts
+++ b/alchemy/src/resource.ts
@@ -125,7 +125,7 @@ export function Resource<
     }
 
     // get a sequence number (unique within the scope) for the resource
-    const seq = scope.seq();
+    const seq = scope.nextSeq();
     const meta = {
       Kind: type,
       ID: resourceID,

--- a/alchemy/src/resource.ts
+++ b/alchemy/src/resource.ts
@@ -29,6 +29,12 @@ export type Provider<
     handler: F;
   };
 
+export const ResourceKind = Symbol.for("Resource.Kind");
+export const ResourceID = Symbol.for("Resource.ID");
+export const ResourceFQN = Symbol.for("Resource.FQN");
+export const ResourceScope = Symbol.for("Resource.Scope");
+export const ResourceSeq = Symbol.for("Resource.Seq");
+
 export type PendingResource<
   Out = unknown,
   Kind extends ResourceKind = ResourceKind,
@@ -37,12 +43,11 @@ export type PendingResource<
   Scope extends _Scope = _Scope,
   Seq extends number = number,
 > = Promise<Out> & {
-  Kind: Kind;
-  ID: ID;
-  FQN: FQN;
-  Seq: Seq;
-  Scope: Scope;
-  signal: () => void;
+  [ResourceKind]: Kind;
+  [ResourceID]: ID;
+  [ResourceFQN]: FQN;
+  [ResourceSeq]: Seq;
+  [ResourceScope]: Scope;
 };
 
 export interface Resource<
@@ -54,11 +59,11 @@ export interface Resource<
   Seq extends number = number,
 > {
   // use capital letters to avoid collision with conventional camelCase typescript properties
-  Kind: Kind;
-  ID: ID;
-  FQN: FQN;
-  Scope: Scope;
-  Seq: Seq;
+  [ResourceKind]: Kind;
+  [ResourceID]: ID;
+  [ResourceFQN]: FQN;
+  [ResourceScope]: Scope;
+  [ResourceSeq]: Seq;
 }
 
 // helper for semantic syntax highlighting (color as a type/class instead of function/value)
@@ -113,10 +118,10 @@ export function Resource<
       // TODO(sam): do we want to throw?
       // it's kind of awesome that you can re-create a resource and call apply
       const otherResource = scope.resources.get(resourceID);
-      if (otherResource?.Kind !== type) {
+      if (otherResource?.[ResourceKind] !== type) {
         scope.fail();
         throw new Error(
-          `Resource ${resourceID} already exists in the stack and is of a different type: '${otherResource?.Kind}' !== '${type}'`,
+          `Resource ${resourceID} already exists in the stack and is of a different type: '${otherResource?.[ResourceKind]}' !== '${type}'`,
         );
       }
       // console.warn(
@@ -127,11 +132,11 @@ export function Resource<
     // get a sequence number (unique within the scope) for the resource
     const seq = scope.nextSeq();
     const meta = {
-      Kind: type,
-      ID: resourceID,
-      FQN: scope.fqn(resourceID),
-      Seq: seq,
-      Scope: scope,
+      [ResourceKind]: type,
+      [ResourceID]: resourceID,
+      [ResourceFQN]: scope.fqn(resourceID),
+      [ResourceSeq]: seq,
+      [ResourceScope]: scope,
     } as any as PendingResource<Out>;
     const promise = apply(meta, props, options);
     const resource = Object.assign(promise, meta);

--- a/alchemy/src/scope.ts
+++ b/alchemy/src/scope.ts
@@ -231,7 +231,6 @@ export class Scope {
               // this is an edge case that indicates that we failed to delete a replaced resource
               // .. and then later orphaned the replacement resource
               // this leaves us with two resource that must be deleted
-              // TODO(sam): what order should we delete them in?
               // TODO(sam): we are using the sequence order of the replacement instead of the replaced resource, is that a problem?
               await destroy(state.replace.output, {
                 replace: state.replace,

--- a/alchemy/src/state.ts
+++ b/alchemy/src/state.ts
@@ -22,6 +22,7 @@ export type State<
   props: Props;
   oldProps?: Props;
   output: Out;
+  replace?: boolean;
 };
 
 export type StateStoreType = (scope: Scope) => StateStore;

--- a/alchemy/src/state.ts
+++ b/alchemy/src/state.ts
@@ -1,4 +1,12 @@
-import type { Resource, ResourceProps } from "./resource.js";
+import {
+  ResourceFQN,
+  ResourceID,
+  ResourceKind,
+  ResourceScope,
+  ResourceSeq,
+  type Resource,
+  type ResourceProps,
+} from "./resource.js";
 import type { Scope } from "./scope.js";
 
 export type State<
@@ -22,7 +30,12 @@ export type State<
   props: Props;
   oldProps?: Props;
   output: Out;
-  replace?: boolean;
+  replace?: {
+    // the repalce
+    output: Out;
+    // props to pass in when deleting the replaced resource
+    props: Props;
+  };
 };
 
 export type StateStoreType = (scope: Scope) => StateStore;
@@ -41,4 +54,70 @@ export interface StateStore {
   all(): Promise<Record<string, State>>;
   set(key: string, value: State): Promise<void>;
   delete(key: string): Promise<void>;
+}
+
+/**
+ * Wraps a State Store to hydrate State with Scope and other internal IDs.
+ */
+export class HydratingStateStore implements StateStore {
+  constructor(
+    private readonly scope: Scope,
+    private readonly store: StateStore,
+  ) {}
+
+  private hydrate(state: State | State[]): any {
+    if (Array.isArray(state)) {
+      return state.map((state) => this.hydrate(state));
+    }
+    const hydrate = (output: Resource) => {
+      output[ResourceScope] = this.scope;
+      output[ResourceID] = state.id;
+      output[ResourceKind] = state.kind;
+      output[ResourceFQN] = state.fqn;
+      output[ResourceSeq] = state.seq;
+    };
+    hydrate(state.output);
+    if (state.replace) {
+      hydrate(state.replace.output);
+    }
+  }
+
+  init?(): Promise<void> {
+    return this.store.init?.() ?? Promise.resolve();
+  }
+  deinit?(): Promise<void> {
+    return this.store.deinit?.() ?? Promise.resolve();
+  }
+  list(): Promise<string[]> {
+    return this.store.list();
+  }
+  count(): Promise<number> {
+    return this.store.count();
+  }
+  async get(key: string): Promise<State | undefined> {
+    const state = await this.store.get(key);
+    if (state) {
+      this.hydrate(state);
+    }
+    return state;
+  }
+
+  async getBatch(ids: string[]): Promise<Record<string, State>> {
+    const batch = await this.store.getBatch(ids);
+    for (const state of Object.values(batch)) {
+      this.hydrate(state);
+    }
+    return batch;
+  }
+  async all(): Promise<Record<string, State>> {
+    const all = await this.store.all();
+    this.hydrate(Object.values(all));
+    return all;
+  }
+  set(key: string, value: State): Promise<void> {
+    return this.store.set(key, value);
+  }
+  delete(key: string): Promise<void> {
+    return this.store.delete(key);
+  }
 }

--- a/alchemy/test/replace.test.ts
+++ b/alchemy/test/replace.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect } from "bun:test";
+import { alchemy } from "../src/alchemy.js";
+import type { Context } from "../src/context.js";
+import { destroy } from "../src/destroy.js";
+import { Resource } from "../src/resource.js";
+import { BRANCH_PREFIX } from "./util.js";
+
+import "../src/test/bun.js";
+
+const test = alchemy.test(import.meta, {
+  prefix: BRANCH_PREFIX,
+});
+
+let i = 0;
+const deleted = new Set<number>();
+
+const Replacable = Resource(
+  "Replacable",
+  async function (
+    this: Context<any, any>,
+    _id: string,
+    props: {
+      name: string;
+    },
+  ) {
+    if (this.phase === "delete") {
+      deleted.add(i);
+      return this.destroy();
+    } else if (this.phase === "update") {
+      if (props.name !== this.output.name) {
+        this.replace();
+        return this({
+          name: `${props.name}-${++i}`,
+        });
+      }
+    }
+    return this({
+      name: `${props.name}-${i}`,
+    });
+  },
+);
+
+describe("Replace", () => {
+  test("replace should flush through to downstream resources", async (scope) => {
+    try {
+      let resource = await Replacable("replacable", {
+        name: "foo",
+      });
+      expect(deleted.size).toBe(0);
+      expect(resource.name).toBe("foo-0");
+      resource = await Replacable("replacable", {
+        name: "bar",
+      });
+      // the output should have changed
+      expect(resource.name).toBe("bar-1");
+      // but the resource should not have been deleted
+      expect(deleted.size).toBe(0);
+      // now, we finalize the scope
+      await scope.finalize();
+      // the delete of the replaced resource should have been flushed through
+      expect(deleted.has(0)).toBe(true);
+    } finally {
+      await destroy(scope);
+    }
+  });
+});

--- a/alchemy/test/replace.test.ts
+++ b/alchemy/test/replace.test.ts
@@ -1,18 +1,17 @@
 import { describe, expect } from "bun:test";
 import { alchemy } from "../src/alchemy.js";
 import type { Context } from "../src/context.js";
-import { destroy } from "../src/destroy.js";
 import { Resource } from "../src/resource.js";
 import { BRANCH_PREFIX } from "./util.js";
 
+import { destroy } from "../src/destroy.js";
 import "../src/test/bun.js";
 
 const test = alchemy.test(import.meta, {
   prefix: BRANCH_PREFIX,
 });
 
-let i = 0;
-const deleted = new Set<number>();
+const deleted = new Set<string>();
 
 const Replacable = Resource(
   "Replacable",
@@ -23,19 +22,18 @@ const Replacable = Resource(
       name: string;
     },
   ) {
+    console.log("PHASE", this.phase);
     if (this.phase === "delete") {
-      deleted.add(i);
+      deleted.add(props.name);
+      console.log(`deleted.add(${props.name})`);
       return this.destroy();
     } else if (this.phase === "update") {
       if (props.name !== this.output.name) {
         this.replace();
-        return this({
-          name: `${props.name}-${++i}`,
-        });
       }
     }
     return this({
-      name: `${props.name}-${i}`,
+      name: props.name,
     });
   },
 );
@@ -47,18 +45,47 @@ describe("Replace", () => {
         name: "foo",
       });
       expect(deleted.size).toBe(0);
-      expect(resource.name).toBe("foo-0");
+      expect(resource.name).toBe("foo");
       resource = await Replacable("replacable", {
         name: "bar",
       });
       // the output should have changed
-      expect(resource.name).toBe("bar-1");
+      expect(resource.name).toBe("bar");
       // but the resource should not have been deleted
       expect(deleted.size).toBe(0);
       // now, we finalize the scope
       await scope.finalize();
       // the delete of the replaced resource should have been flushed through
-      expect(deleted.has(0)).toBe(true);
+      expect(deleted.has("foo")).toBe(true);
+    } finally {
+      await destroy(scope);
+    }
+  });
+
+  test("replace 2", async (scope) => {
+    try {
+      let resource = await alchemy.run("foo", () =>
+        Replacable("replacable", {
+          name: "foo-1",
+        }),
+      );
+      expect(deleted.has("foo-1")).toBe(false);
+      expect(resource.name).toBe("foo-1");
+      resource = await alchemy.run("foo", () =>
+        Replacable("replacable", {
+          name: "bar-1",
+        }),
+      );
+      // the output should have changed
+      expect(resource.name).toBe("bar-1");
+      // but the resource should not have been deleted
+      expect(deleted.has("foo-1")).toBe(false);
+      expect(deleted.has("bar-1")).toBe(false);
+      // now, we finalize the scope
+      await scope.finalize();
+      // the delete of the replaced resource should have been flushed through
+      expect(deleted.has("foo-1")).toBe(true);
+      expect(deleted.has("bar-1")).toBe(false);
     } finally {
       await destroy(scope);
     }

--- a/alchemy/test/serde.test.ts
+++ b/alchemy/test/serde.test.ts
@@ -10,7 +10,7 @@ const test = alchemy.test(import.meta, {
   prefix: BRANCH_PREFIX,
 });
 
-describe("serde", () => {
+describe("serde", async () => {
   test("serializes and deserializes primitive values", async (scope) => {
     // Test primitive values
     const testCases = [42, "hello", true, null, undefined];
@@ -68,7 +68,9 @@ describe("serde", () => {
 
     const serialized = await serialize(scope, objWithScope);
     expect(serialized).toEqual({
-      scope: undefined,
+      scope: {
+        "@scope": null,
+      },
       data: "test",
     });
   });
@@ -107,8 +109,77 @@ describe("serde", () => {
       name: "alchemy.run",
       type: "full",
     };
+    const serialized = await serialize(scope, props);
+    expect(serialized).toEqual(props);
+  });
+
+  test("symbol property", async (scope) => {
+    const props = {
+      [Symbol.for("foo")]: "bar",
+    };
 
     const serialized = await serialize(scope, props);
-    console.log(serialized);
+    expect(serialized).toEqual({
+      "Symbol(foo)": "bar",
+    });
+    expect(await deserialize(scope, serialized)).toEqual(props);
+  });
+
+  test("symbol value", async (scope) => {
+    const props = {
+      foo: Symbol.for("bar"),
+    };
+
+    const serialized = await serialize(scope, props);
+    expect(serialized).toEqual({
+      foo: {
+        "@symbol": "Symbol(bar)",
+      },
+    });
+    expect(await deserialize(scope, serialized)).toEqual(props);
+  });
+
+  test("unique symbol property should error", async (scope) => {
+    expect(
+      serialize(scope, {
+        [Symbol()]: "bar",
+      }),
+    ).rejects.toThrow();
+    expect(
+      serialize(scope, {
+        [Symbol("foo")]: "bar",
+      }),
+    ).rejects.toThrow();
+  });
+
+  test("unique symbol value should error", async (scope) => {
+    expect(
+      serialize(scope, {
+        foo: Symbol(),
+      }),
+    ).rejects.toThrow();
+    expect(
+      serialize(scope, {
+        foo: Symbol("bar"),
+      }),
+    ).rejects.toThrow();
+  });
+
+  test("key that looks like a symbol errors", async (scope) => {
+    expect(
+      serialize(scope, {
+        "Symbol(foo)": "bar",
+      }),
+    ).rejects.toThrow();
+    expect(
+      serialize(scope, {
+        "Symbol()": "bar",
+      }),
+    ).rejects.toThrow();
+    expect(
+      serialize(scope, {
+        "Symbol(Symbol.asyncDispose)": "bar",
+      }),
+    ).rejects.toThrow();
   });
 });


### PR DESCRIPTION
The `replace` operation allows a Resource to mark a resource as being replaced and enqueue deletion of the old resource.

The old resource will be deleted after `app.finalize()` is called to ensure the new resource has flushed through to downstream resources (e.g. a new Table's ARN has propagated through and it is now safe to delete the old Table)

```ts
const Replacable = Resource(
  "Replacable",
  async function (
    this: Context<any, any>,
    _id: string,
    props: {
      name: string;
    },
  ) {
    if (this.phase === "delete") {
      // destrory logic
      return this.destroy();
    } else if (this.phase === "update") {
      if (props.name !== this.output.name) {
        // detect a change in `update` that requires creation of a new resource and deletion of the old
        this.replace();
        // return the new resource
        return this({
          name: `${props.name}-${++i}`,
        });
      }
    }
    return this({
      name: `${props.name}-${i}`,
    });
  },
);```