### PR TITLE
Filter orphans without output

### DIFF
--- a/alchemy/src/scope.ts
+++ b/alchemy/src/scope.ts
@@ -3,7 +3,7 @@ import type { Phase } from "./alchemy.js";
 import { destroy } from "./destroy.js";
 import { FileSystemStateStore } from "./fs/file-system-state-store.js";
 import type { PendingResource, ResourceID } from "./resource.js";
-import type { StateStore, StateStoreType } from "./state.js";
+import type { State, StateStore, StateStoreType } from "./state.js";
 
 const scopeStorage = new AsyncLocalStorage<Scope>();
 
@@ -130,9 +130,12 @@ export class Scope {
       const orphanIds = Array.from(
         resourceIds.filter((id) => !aliveIds.has(id)),
       );
-      const orphans = await Promise.all(
-        orphanIds.map(async (id) => (await this.state.get(id))!.output),
-      );
+      const orphans = (
+        await Promise.all(
+          orphanIds.map(async (id) => (await this.state.get(id))?.output),
+        )
+      ).filter((r): r is State["output"] => r !== undefined);
+
       await destroy.all(orphans, {
         quiet: this.quiet,
         strategy: "sequential",


### PR DESCRIPTION
When working with custom Resources, I found that there can be situations where state wasn't correctly persisted or _something_, causing this error:

```console
90 |         if (!this.isErrored) {
91 |             // TODO: need to detect if it is in error
92 |             const resourceIds = await this.state.list();
93 |             const aliveIds = new Set(this.resources.keys());
94 |             const orphanIds = Array.from(resourceIds.filter((id) => !aliveIds.has(id)));
95 |             const orphans = await Promise.all(orphanIds.map(async (id) => (await this.state.get(id)).output));
                                                                                                       ^
TypeError: undefined is not an object (evaluating '(await this.state.get(id)).output')
      at <anonymous> (/Users/eric/Projects/ericclemmons/bmarks/packages/infra/node_modules/alchemy/lib/scope.js:95:99)
```

When I locally patched this to use `?.output`, the error went away & the app worked as expected.