### PR TITLE
feat(cloudflare): auto-resolve permission group IDs in AccountApiToken

### DIFF
--- a/alchemy/src/cloudflare/permission-groups.ts
+++ b/alchemy/src/cloudflare/permission-groups.ts
@@ -32,6 +32,14 @@ interface PermissionGroupsResponse {
   messages: any[];
 }
 
+export type PermissionGroupName = R2PermissionGroups;
+
+export type R2PermissionGroups =
+  | "Workers R2 Storage Write"
+  | "Workers R2 Storage Read"
+  | "Workers R2 Storage Bucket Item Write"
+  | "Workers R2 Storage Bucket Item Read";
+
 /**
  * All Cloudflare permission groups mapped by name to ID
  *

--- a/stacks/repo.run.ts
+++ b/stacks/repo.run.ts
@@ -9,8 +9,7 @@ import { AccountId, Role } from "../alchemy/src/aws";
 import { GitHubOIDCProvider } from "../alchemy/src/aws/oidc";
 import {
   AccountApiToken,
-  PermissionGroups,
-  R2Bucket,
+  R2Bucket
 } from "../alchemy/src/cloudflare";
 import { GitHubSecret, RepositoryEnvironment } from "../alchemy/src/github";
 import env, {
@@ -67,17 +66,12 @@ const testEnvironment = await RepositoryEnvironment("test environment", {
   },
 });
 
-const permissions = await PermissionGroups("cloudflare-permissions", {
-  // TODO: remove this once we have a way to get the account ID from the API
-  accountId: CLOUDFLARE_ACCOUNT_ID,
-});
-
 const accountAccessToken = await AccountApiToken("account-access-token", {
   name: "alchemy-account-access-token",
   policies: [
     {
       effect: "allow",
-      permissionGroups: [{ id: permissions["Workers R2 Storage Write"].id }],
+      permissionGroups: ["Workers R2 Storage Write"],
       resources: {
         [`com.cloudflare.api.account.${CLOUDFLARE_ACCOUNT_ID}`]: "*",
       },


### PR DESCRIPTION
Allow permission groups to be referred to by name and auto-resolve their IDs in the AccountApiToken resource.

```ts
const accountAccessToken = await AccountApiToken("account-access-token", {
  name: "alchemy-account-access-token",
  policies: [
    {
      effect: "allow",
      permissionGroups: ["Workers R2 Storage Write"],
      resources: {
        [`com.cloudflare.api.account.${CLOUDFLARE_ACCOUNT_ID}`]: "*",
      },
    },
  ],
});
```