### PR TITLE
fix: move core Resource properties to Symbols

### DIFF
--- a/alchemy/src/alchemy.ts
+++ b/alchemy/src/alchemy.ts
@@ -3,7 +3,14 @@ import path from "node:path";
 
 import { destroy, DestroyedSignal } from "./destroy.js";
 import { env } from "./env.js";
-import type { PendingResource } from "./resource.js";
+import {
+  ResourceFQN,
+  ResourceID,
+  ResourceKind,
+  ResourceScope,
+  ResourceSeq,
+  type PendingResource,
+} from "./resource.js";
 import { Scope } from "./scope.js";
 import { secret } from "./secret.js";
 import type { StateStoreType } from "./state.js";
@@ -325,11 +332,11 @@ async function run<T>(
       // TODO(sam): this is an awful hack to differentiate between naked scopes and resources
       const seq = _scope.parent.seq();
       const output = {
-        ID: id,
-        FQN: "",
-        Kind: Scope.KIND,
-        Scope: _scope,
-        Seq: seq,
+        [ResourceID]: id,
+        [ResourceFQN]: "",
+        [ResourceKind]: Scope.KIND,
+        [ResourceScope]: _scope,
+        [ResourceSeq]: seq,
       } as const;
       const resource = {
         kind: Scope.KIND,

--- a/alchemy/src/apply.ts
+++ b/alchemy/src/apply.ts
@@ -151,6 +151,7 @@ export async function apply<Out extends Resource>(
     // }
     return output as any;
   } catch (error) {
+    console.log(resource);
     scope.fail();
     throw error;
   }

--- a/alchemy/src/apply.ts
+++ b/alchemy/src/apply.ts
@@ -151,7 +151,6 @@ export async function apply<Out extends Resource>(
     // }
     return output as any;
   } catch (error) {
-    console.log(resource);
     scope.fail();
     throw error;
   }

--- a/alchemy/src/cloudflare/queue.ts
+++ b/alchemy/src/cloudflare/queue.ts
@@ -1,9 +1,9 @@
 import type { Context } from "../context.js";
-import { Resource } from "../resource.js";
+import { Resource, ResourceKind } from "../resource.js";
 import { CloudflareApiError, handleApiError } from "./api-error.js";
 import {
-  type CloudflareApi,
   createCloudflareApi,
+  type CloudflareApi,
   type CloudflareApiOptions,
 } from "./api.js";
 
@@ -59,7 +59,10 @@ export interface QueueProps extends CloudflareApiOptions {
 }
 
 export function isQueue(eventSource: any): eventSource is Queue {
-  return "Kind" in eventSource && eventSource.Kind === "cloudflare::Queue";
+  return (
+    ResourceKind in eventSource &&
+    eventSource[ResourceKind] === "cloudflare::Queue"
+  );
 }
 
 /**

--- a/alchemy/src/cloudflare/r2-rest-state-store.ts
+++ b/alchemy/src/cloudflare/r2-rest-state-store.ts
@@ -1,3 +1,4 @@
+import { ResourceScope } from "../resource.js";
 import type { Scope } from "../scope.js";
 import { deserialize, serialize } from "../serde.js";
 import type { State, StateStore } from "../state.js";
@@ -219,7 +220,7 @@ export class R2RestStateStore implements StateStore {
         ...state,
         output: {
           ...(state.output || {}),
-          Scope: this.scope,
+          [ResourceScope]: this.scope,
         },
       };
     } catch (error: any) {

--- a/alchemy/src/cloudflare/r2-rest-state-store.ts
+++ b/alchemy/src/cloudflare/r2-rest-state-store.ts
@@ -1,7 +1,7 @@
 import { ResourceScope } from "../resource.js";
 import type { Scope } from "../scope.js";
-import { deserialize, serialize } from "../serde.js";
-import type { State, StateStore } from "../state.js";
+import { serialize } from "../serde.js";
+import { deserializeState, type State, type StateStore } from "../state.js";
 import { withExponentialBackoff } from "../util/retry.js";
 import { CloudflareApiError, handleApiError } from "./api-error.js";
 import {
@@ -212,8 +212,7 @@ export class R2RestStateStore implements StateStore {
       }
 
       // Parse and deserialize the state data
-      const rawData = await response.json();
-      const state = (await deserialize(this.scope, rawData)) as State;
+      const state = await deserializeState(this.scope, await response.text());
 
       // Create a new state object with proper output
       return {

--- a/alchemy/src/context.ts
+++ b/alchemy/src/context.ts
@@ -98,12 +98,18 @@ export function context<
   state: State<Kind, Props, Out>;
   replace: () => void;
 }): Context<Out> {
-  function create(props: Omit<Out, "Kind" | "ID" | "Scope">): Out;
-  function create(id: string, props: Omit<Out, "Kind" | "ID" | "Scope">): Out;
+  type InternalSymbols =
+    | typeof ResourceID
+    | typeof ResourceKind
+    | typeof ResourceFQN
+    | typeof ResourceSeq
+    | typeof ResourceScope;
+  function create(props: Omit<Out, InternalSymbols>): Out;
+  function create(id: string, props: Omit<Out, InternalSymbols>): Out;
   function create(
     ...args:
-      | [props: Omit<Out, "Kind" | "ID" | "Scope">]
-      | [id: string, props: Omit<Out, "Kind" | "ID" | "Scope">]
+      | [props: Omit<Out, InternalSymbols>]
+      | [id: string, props: Omit<Out, InternalSymbols>]
   ): Out {
     const [ID, props] =
       typeof args[0] === "string" ? (args as [string, any]) : [id, args[0]];

--- a/alchemy/src/context.ts
+++ b/alchemy/src/context.ts
@@ -1,10 +1,12 @@
 import { DestroyedSignal } from "./destroy.js";
-import type {
-  Resource,
+import {
   ResourceFQN,
   ResourceID,
   ResourceKind,
-  ResourceProps,
+  ResourceScope,
+  ResourceSeq,
+  type Resource,
+  type ResourceProps,
 } from "./resource.js";
 import type { Scope } from "./scope.js";
 import type { State } from "./state.js";
@@ -108,11 +110,11 @@ export function context<
 
     return {
       ...props,
-      Kind: kind,
-      ID,
-      FQN: fqn,
-      Scope: scope,
-      Seq: seq,
+      [ResourceKind]: kind,
+      [ResourceID]: ID,
+      [ResourceFQN]: fqn,
+      [ResourceScope]: scope,
+      [ResourceSeq]: seq,
     } as Out;
   }
   return Object.assign(create, {
@@ -138,5 +140,5 @@ export function context<
       throw new DestroyedSignal();
     },
     create,
-  }) as Context<Out>;
+  }) as unknown as Context<Out>;
 }

--- a/alchemy/src/fs/file-system-state-store.ts
+++ b/alchemy/src/fs/file-system-state-store.ts
@@ -69,7 +69,7 @@ export class FileSystemStateStore implements StateStore {
     await this.init();
     await fs.promises.writeFile(
       this.getPath(key),
-      await serialize(this.scope, value),
+      JSON.stringify(await serialize(this.scope, value), null, 2),
     );
   }
 

--- a/alchemy/src/fs/file-system-state-store.ts
+++ b/alchemy/src/fs/file-system-state-store.ts
@@ -2,8 +2,8 @@ import fs from "node:fs";
 import path from "node:path";
 import { ResourceScope } from "../resource.js";
 import type { Scope } from "../scope.js";
-import { deserialize, serialize } from "../serde.js";
-import type { State, StateStore } from "../state.js";
+import { serialize } from "../serde.js";
+import { deserializeState, type State, type StateStore } from "../state.js";
 import { ignore } from "../util/ignore.js";
 
 const stateRootDir = path.join(process.cwd(), ".alchemy");
@@ -51,10 +51,7 @@ export class FileSystemStateStore implements StateStore {
   async get(key: string): Promise<State | undefined> {
     try {
       const content = await fs.promises.readFile(this.getPath(key), "utf8");
-      const state = (await deserialize(
-        this.scope,
-        JSON.parse(content),
-      )) as State;
+      const state = await deserializeState(this.scope, content);
       if (state.output === undefined) {
         state.output = {} as any;
       }
@@ -72,7 +69,7 @@ export class FileSystemStateStore implements StateStore {
     await this.init();
     await fs.promises.writeFile(
       this.getPath(key),
-      JSON.stringify(await serialize(this.scope, value), null, 2),
+      await serialize(this.scope, value),
     );
   }
 

--- a/alchemy/src/fs/file-system-state-store.ts
+++ b/alchemy/src/fs/file-system-state-store.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { ResourceScope } from "../resource.js";
 import type { Scope } from "../scope.js";
 import { deserialize, serialize } from "../serde.js";
 import type { State, StateStore } from "../state.js";
@@ -57,7 +58,7 @@ export class FileSystemStateStore implements StateStore {
       if (state.output === undefined) {
         state.output = {} as any;
       }
-      state.output.Scope = this.scope;
+      state.output[ResourceScope] = this.scope;
       return state;
     } catch (error: any) {
       if (error.code === "ENOENT") {

--- a/alchemy/src/resource.ts
+++ b/alchemy/src/resource.ts
@@ -131,11 +131,11 @@ export function Resource<
     // get a sequence number (unique within the scope) for the resource
     const seq = scope.seq();
     const meta = {
-      Kind: type,
-      ID: resourceID,
-      FQN: scope.fqn(resourceID),
-      Seq: seq,
-      Scope: scope,
+      [ResourceKind]: type,
+      [ResourceID]: resourceID,
+      [ResourceFQN]: scope.fqn(resourceID),
+      [ResourceSeq]: seq,
+      [ResourceScope]: scope,
     } as any as PendingResource<Out>;
     const promise = apply(meta, props, options);
     const resource = Object.assign(promise, meta);

--- a/alchemy/src/resource.ts
+++ b/alchemy/src/resource.ts
@@ -5,8 +5,13 @@ import { Scope as _Scope } from "./scope.js";
 export const PROVIDERS = new Map<ResourceKind, Provider<string, any>>();
 
 export type ResourceID = string;
+export const ResourceID = Symbol.for("alchemy::ResourceID");
 export type ResourceFQN = string;
+export const ResourceFQN = Symbol.for("alchemy::ResourceFQN");
 export type ResourceKind = string;
+export const ResourceKind = Symbol.for("alchemy::ResourceKind");
+export const ResourceScope = Symbol.for("alchemy::ResourceScope");
+export const ResourceSeq = Symbol.for("alchemy::ResourceSeq");
 
 export interface ProviderOptions {
   /**
@@ -37,12 +42,11 @@ export type PendingResource<
   Scope extends _Scope = _Scope,
   Seq extends number = number,
 > = Promise<Out> & {
-  Kind: Kind;
-  ID: ID;
-  FQN: FQN;
-  Seq: Seq;
-  Scope: Scope;
-  signal: () => void;
+  [ResourceKind]: Kind;
+  [ResourceID]: ID;
+  [ResourceFQN]: FQN;
+  [ResourceScope]: Scope;
+  [ResourceSeq]: Seq;
 };
 
 export interface Resource<
@@ -54,11 +58,11 @@ export interface Resource<
   Seq extends number = number,
 > {
   // use capital letters to avoid collision with conventional camelCase typescript properties
-  Kind: Kind;
-  ID: ID;
-  FQN: FQN;
-  Scope: Scope;
-  Seq: Seq;
+  [ResourceKind]: Kind;
+  [ResourceID]: ID;
+  [ResourceFQN]: FQN;
+  [ResourceScope]: Scope;
+  [ResourceSeq]: Seq;
 }
 
 // helper for semantic syntax highlighting (color as a type/class instead of function/value)
@@ -113,10 +117,10 @@ export function Resource<
       // TODO(sam): do we want to throw?
       // it's kind of awesome that you can re-create a resource and call apply
       const otherResource = scope.resources.get(resourceID);
-      if (otherResource?.Kind !== type) {
+      if (otherResource?.[ResourceKind] !== type) {
         scope.fail();
         throw new Error(
-          `Resource ${resourceID} already exists in the stack and is of a different type: '${otherResource?.Kind}' !== '${type}'`,
+          `Resource ${resourceID} already exists in the stack and is of a different type: '${otherResource?.[ResourceKind]}' !== '${type}'`,
         );
       }
       // console.warn(

--- a/alchemy/src/scope.ts
+++ b/alchemy/src/scope.ts
@@ -2,7 +2,7 @@ import { AsyncLocalStorage } from "node:async_hooks";
 import type { Phase } from "./alchemy.js";
 import { destroy } from "./destroy.js";
 import { FileSystemStateStore } from "./fs/file-system-state-store.js";
-import type { PendingResource, ResourceID } from "./resource.js";
+import { ResourceID, type PendingResource } from "./resource.js";
 import type { StateStore, StateStoreType } from "./state.js";
 
 const scopeStorage = new AsyncLocalStorage<Scope>();
@@ -157,7 +157,7 @@ export class Scope {
     return `Scope(
   chain=${this.chain.join("/")},
   resources=[${Array.from(this.resources.values())
-    .map((r) => r.ID)
+    .map((r) => r[ResourceID])
     .join(",\n  ")}]
 )`;
   }

--- a/alchemy/src/state.ts
+++ b/alchemy/src/state.ts
@@ -1,5 +1,14 @@
-import type { Resource, ResourceProps } from "./resource.js";
+import {
+  ResourceFQN,
+  ResourceID,
+  ResourceKind,
+  ResourceScope,
+  ResourceSeq,
+  type Resource,
+  type ResourceProps,
+} from "./resource.js";
 import type { Scope } from "./scope.js";
+import { deserialize } from "./serde.js";
 
 export type State<
   Kind extends string = string,
@@ -40,4 +49,31 @@ export interface StateStore {
   all(): Promise<Record<string, State>>;
   set(key: string, value: State): Promise<void>;
   delete(key: string): Promise<void>;
+}
+
+export async function deserializeState(
+  scope: Scope,
+  content: string,
+): Promise<State> {
+  const state = (await deserialize(scope, JSON.parse(content))) as State;
+
+  if (ResourceID in state.output) {
+    // this is a new state
+    return state;
+  }
+  const output: any = state.output;
+  delete output.Kind;
+  delete output.ID;
+  delete output.FQN;
+  delete output.Scope;
+  delete output.Seq;
+  output[ResourceKind] = state.kind;
+  output[ResourceID] = state.id;
+  output[ResourceFQN] = state.fqn;
+  output[ResourceScope] = scope;
+  output[ResourceSeq] = state.seq;
+  state.output = output;
+  // re-write the state with the migrated format
+  await scope.state.set(state.id, state);
+  return state;
 }

--- a/alchemy/src/state.ts
+++ b/alchemy/src/state.ts
@@ -7,7 +7,7 @@ import {
   type Resource,
   type ResourceProps,
 } from "./resource.js";
-import type { Scope } from "./scope.js";
+import { Scope } from "./scope.js";
 import { deserialize } from "./serde.js";
 
 export type State<
@@ -67,6 +67,10 @@ export async function deserializeState(
   delete output.FQN;
   delete output.Scope;
   delete output.Seq;
+  // fix this bug
+  if (state.kind === "scope") {
+    state.kind = Scope.KIND;
+  }
   output[ResourceKind] = state.kind;
   output[ResourceID] = state.id;
   output[ResourceFQN] = state.fqn;


### PR DESCRIPTION
We currently store properties like `ID`, `Scope`, `Kind` on the Resource's Output which can conflict with user-defined properties.

Usually we don't conflict because most properties are lower-case, but this is not always true - e.g. for the Control API https://github.com/sam-goodwin/alchemy/pull/132

Instead, now that `serde.ts` can serialize symbols, we move these to unique symbols to ensure they are totally isolated.

State is auto-migrated to the new format:
<img width="494" alt="image" src="https://github.com/user-attachments/assets/433c7588-d28d-4fbe-8bc9-979bb118d2b0" />
