### PR TITLE
feat(os): memoize exec from file patterns

### DIFF
--- a/alchemy-web/docs/providers/os/exec.md
+++ b/alchemy-web/docs/providers/os/exec.md
@@ -39,6 +39,8 @@ const build = await Exec("build-project", {
 
 ## Command Memoization 
 
+### Basic Memoization
+
 Cache command output and only re-run when the command changes:
 
 ```ts
@@ -47,6 +49,39 @@ import { Exec } from "alchemy/os";
 const status = await Exec("git-status", {
   command: "git status",
   memoize: true
+});
+```
+
+### File-Based Memoization
+
+Memoize commands based on file contents. The command will be re-executed if either:
+1. The command string changes, or
+2. The contents of any files matching the glob patterns change
+
+```ts
+import { Exec } from "alchemy/os";
+
+// Memoize database migrations based on schema files
+const migrate = await Exec("db-migrate", {
+  command: "drizzle-kit push:pg",
+  memoize: {
+    patterns: ["./src/db/schema/**"]
+  }
+});
+```
+
+### Build Commands with Memoization
+
+When using memoization with build commands, be aware that build outputs won't be produced if the command is memoized. For build commands, consider disabling memoization in CI environments:
+
+```ts
+import { Exec } from "alchemy/os";
+
+const build = await Exec("build", {
+  command: "vite build",
+  memoize: process.env.CI ? false : {
+    patterns: ["./src/**"]
+  }
 });
 ```
 

--- a/alchemy/src/os/exec.ts
+++ b/alchemy/src/os/exec.ts
@@ -1,6 +1,5 @@
 import { spawn, type SpawnOptions } from "node:child_process";
 import { createHash } from "node:crypto";
-import { glob, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { Context } from "../context.js";
 import { Resource } from "../resource.js";
@@ -301,6 +300,8 @@ export async function exec(
 }
 
 async function hashInputs(cwd: string, patterns: string[]) {
+  const { glob, readFile } = await import("node:fs/promises");
+
   const hashes = new Map<string, string>();
 
   await Promise.all(

--- a/alchemy/src/os/exec.ts
+++ b/alchemy/src/os/exec.ts
@@ -23,6 +23,19 @@ export interface ExecProps {
    * 1. The command string changes, or
    * 2. The contents of any files matching the glob patterns change
    *
+   * ⚠️ **Important Note**: When using memoization with build commands, the build outputs
+   * will not be produced if the command is memoized. This is because the command is not
+   * actually executed when memoized. Consider disabling memoization in CI environments:
+   *
+   * @example
+   * // Disable memoization in CI to ensure build outputs are always produced
+   * await Exec("build", {
+   *   command: "vite build",
+   *   memoize: process.env.CI ? false : {
+   *     patterns: ["./src/**"]
+   *   }
+   * });
+   *
    * @default false
    */
   memoize?: boolean | { patterns: string[] };
@@ -121,6 +134,26 @@ export interface Exec extends Resource<"os::Exec">, ExecProps {
  * await Exec("status-check", {
  *   command: "git status",
  *   memoize: true
+ * });
+ *
+ * @example
+ * // Memoize a build command with file patterns, but disable in CI
+ * // This ensures build outputs are always produced in CI
+ * const build = await Exec("build", {
+ *   command: "vite build",
+ *   memoize: process.env.CI ? false : {
+ *     patterns: ["./src/**"]
+ *   }
+ * });
+ *
+ * @example
+ * // Memoize a database migration command based on schema files
+ * // This is safe to memoize since it's idempotent
+ * const migrate = await Exec("db-migrate", {
+ *   command: "drizzle-kit push:pg",
+ *   memoize: {
+ *     patterns: ["./src/db/schema/**"]
+ *   }
  * });
  */
 export const Exec = Resource(


### PR DESCRIPTION
## Changes

1. Enhanced `ExecProps.memoize` to support file-based memoization:
   - Previously: `memoize?: boolean`
   - Now: `memoize?: boolean | { patterns: string[] }`
   - Patterns can be an array of file names or globs, relative to the given working directory if provided or `process.cwd()` otherwise (uses `glob` from `fs/promises`, compatible with Bun and Node.js >= 22)
2. Added tests verifying the new file pattern functionality:
   - Commands are memoized when files haven't changed
   - Commands are re-executed when files are modified

## Example

```typescript
const result = await Exec("build", {
  command: "npm run build",
  memoize: { patterns: ["src/**/*.ts", "package.json"] }
});
```