### PR TITLE
fix(cloudflare): allow D1 update read replication mode when primary location hint is explcitly set

### DIFF
--- a/alchemy/src/cloudflare/d1-database.ts
+++ b/alchemy/src/cloudflare/d1-database.ts
@@ -276,6 +276,15 @@ export const D1DatabaseResource = Resource(
     } else {
       // Update operation
       if (this.output?.id) {
+        // Only read_replication can be modified in update
+        if (
+          props.primaryLocationHint &&
+          props.primaryLocationHint !== this.output?.primaryLocationHint
+        ) {
+          throw new Error(
+            `Cannot update primaryLocationHint from '${this.output.primaryLocationHint}' to '${props.primaryLocationHint}' after database creation.`,
+          );
+        }
         console.log("Updating D1 database:", databaseName);
         // Update the database with new properties
         dbData = await updateDatabase(api, this.output.id, props);
@@ -480,19 +489,6 @@ export async function updateDatabase(
   databaseId: string,
   props: D1DatabaseProps,
 ): Promise<CloudflareD1Response> {
-  // Get current database state to check for non-mutable changes
-  const currentDB = await getDatabase(api, databaseId);
-
-  // Only read_replication can be modified in update
-  if (
-    props.primaryLocationHint &&
-    props.primaryLocationHint !== currentDB.result.primary_location_hint
-  ) {
-    throw new Error(
-      "Cannot update primaryLocationHint after database creation. Only readReplication.mode can be modified.",
-    );
-  }
-
   const updatePayload: any = {};
 
   // Only include read_replication in update payload

--- a/alchemy/test/cloudflare/d1-database.test.ts
+++ b/alchemy/test/cloudflare/d1-database.test.ts
@@ -81,6 +81,7 @@ describe("D1 Database Resource", async () => {
       let database = await D1Database(replicationDb, {
         name: replicationDb,
         adopt: true,
+        primaryLocationHint: "wnam",
       });
 
       expect(database.name).toEqual(replicationDb);
@@ -93,10 +94,23 @@ describe("D1 Database Resource", async () => {
           mode: "disabled",
         },
         adopt: true,
+        primaryLocationHint: "wnam",
       });
 
       // Verify the update
       expect(database.readReplication?.mode).toEqual("disabled");
+
+      // Update the database with disabled read replication
+      database = await D1Database(replicationDb, {
+        name: replicationDb,
+        readReplication: {
+          mode: "auto",
+        },
+        adopt: true,
+        primaryLocationHint: "wnam",
+      });
+
+      expect(database.readReplication?.mode).toEqual("auto");
     } finally {
       await alchemy.destroy(scope);
     }


### PR DESCRIPTION
There was a bug caused by GetDatabase not returning `primaryLocationHint` and our invalid-update detection assuming it did. This change uses the actual input properties instead.