### PR TITLE
Add cloudflare workers analytics engine binding

### DIFF
--- a/alchemy/src/cloudflare/analytics-engine.ts
+++ b/alchemy/src/cloudflare/analytics-engine.ts
@@ -1,0 +1,35 @@
+import type { Context } from "../context.js";
+import { Resource } from "../resource.js";
+import type { CloudflareApiOptions } from "./api.js";
+
+/**
+ * Properties for creating an Analytics Engine binding
+ */
+export interface AnalyticsEngineProps extends CloudflareApiOptions {
+  /**
+   * The name of the dataset to bind to
+   */
+  dataset: string;
+}
+
+export interface AnalyticsEngine
+  extends Resource<"cloudflare::AnalyticsEngineBinding">,
+    AnalyticsEngineProps {
+  type: "analytics_engine";
+}
+
+export const AnalyticsEngine = Resource(
+  "cloudflare::AnalyticsEngine",
+  async function (
+    this: Context<AnalyticsEngine>,
+    id: string,
+    props: AnalyticsEngineProps,
+  ): Promise<AnalyticsEngine> {
+    // Analytics engine datasets are not created or deleted by the api
+    // they are created when used, and removed when the data becomes 3 months old
+    return this({
+      type: "analytics_engine",
+      dataset: props.dataset,
+    });
+  },
+);

--- a/alchemy/src/cloudflare/analytics-engine.ts
+++ b/alchemy/src/cloudflare/analytics-engine.ts
@@ -1,35 +1,26 @@
-import type { Context } from "../context.js";
-import { Resource } from "../resource.js";
-import type { CloudflareApiOptions } from "./api.js";
-
-/**
- * Properties for creating an Analytics Engine binding
- */
-export interface AnalyticsEngineProps extends CloudflareApiOptions {
+export interface AnalyticsEngineDatasetProps {
   /**
-   * The name of the dataset to bind to
+   * The name of the dataset to bind to -
+   * becomes the table name to query via the api in the FROM clause
    */
   dataset: string;
 }
 
-export interface AnalyticsEngine
-  extends Resource<"cloudflare::AnalyticsEngineBinding">,
-    AnalyticsEngineProps {
-  type: "analytics_engine";
-}
+/**
+ * @example
+ * // Create a binding for an Analytics Engine dataset
+ * const dataset = new AnalyticsEngineDataset("ae-dataset", {
+ *   dataset: "WEATHER",
+ * });
+ */
+export class AnalyticsEngineDataset {
+  public readonly type = "analytics_engine" as const;
+  public readonly dataset: string;
 
-export const AnalyticsEngine = Resource(
-  "cloudflare::AnalyticsEngine",
-  async function (
-    this: Context<AnalyticsEngine>,
-    id: string,
-    props: AnalyticsEngineProps,
-  ): Promise<AnalyticsEngine> {
-    // Analytics engine datasets are not created or deleted by the api
-    // they are created when used, and removed when the data becomes 3 months old
-    return this({
-      type: "analytics_engine",
-      dataset: props.dataset,
-    });
-  },
-);
+  constructor(
+    public readonly id: string,
+    input: AnalyticsEngineDatasetProps,
+  ) {
+    this.dataset = input.dataset;
+  }
+}

--- a/alchemy/src/cloudflare/bindings.ts
+++ b/alchemy/src/cloudflare/bindings.ts
@@ -6,7 +6,7 @@
 import type { Secret } from "../secret.js";
 import type { AiGateway } from "./ai-gateway.js";
 import type { Ai } from "./ai.js";
-import type { AnalyticsEngine } from "./analytics-engine.js";
+import type { AnalyticsEngineDataset } from "./analytics-engine.js";
 import type { Assets } from "./assets.js";
 import type { Bound } from "./bound.js";
 import type { BrowserRendering } from "./browser-rendering.js";
@@ -38,7 +38,7 @@ export type Binding =
   | Ai
   | AiGateway
   | Assets
-  | AnalyticsEngine
+  | AnalyticsEngineDataset
   | D1Database
   | DurableObjectNamespace
   | Hyperdrive

--- a/alchemy/src/cloudflare/bindings.ts
+++ b/alchemy/src/cloudflare/bindings.ts
@@ -6,6 +6,7 @@
 import type { Secret } from "../secret.js";
 import type { AiGateway } from "./ai-gateway.js";
 import type { Ai } from "./ai.js";
+import type { AnalyticsEngine } from "./analytics-engine.js";
 import type { Assets } from "./assets.js";
 import type { Bound } from "./bound.js";
 import type { BrowserRendering } from "./browser-rendering.js";
@@ -37,6 +38,7 @@ export type Binding =
   | Ai
   | AiGateway
   | Assets
+  | AnalyticsEngine
   | D1Database
   | DurableObjectNamespace
   | Hyperdrive

--- a/alchemy/src/cloudflare/bound.ts
+++ b/alchemy/src/cloudflare/bound.ts
@@ -2,6 +2,7 @@ import type { Pipeline } from "cloudflare:pipelines";
 import type { Secret } from "../secret.js";
 import type { AiGateway as _AiGateway } from "./ai-gateway.js";
 import type { Ai as _Ai } from "./ai.js";
+import type { AnalyticsEngineDataset as _AnalyticsEngineDataset } from "./analytics-engine.js";
 import type { Assets } from "./assets.js";
 import type { Binding, Self } from "./bindings.js";
 import type { BrowserRendering } from "./browser-rendering.js";
@@ -42,12 +43,14 @@ export type Bound<T extends Binding> = T extends _DurableObjectNamespace
                         ? Queue<Body>
                         : T extends _Pipeline<infer R>
                           ? Pipeline<R>
-                          : T extends string
-                            ? string
-                            : T extends BrowserRendering
-                              ? Fetcher
-                              : T extends _Ai<infer M>
-                                ? Ai<M>
-                                : T extends Self
-                                  ? Service
-                                  : Service;
+                          : T extends _AnalyticsEngineDataset
+                            ? AnalyticsEngineDataset
+                            : T extends string
+                              ? string
+                              : T extends BrowserRendering
+                                ? Fetcher
+                                : T extends _Ai<infer M>
+                                  ? Ai<M>
+                                  : T extends Self
+                                    ? Service
+                                    : Service;

--- a/alchemy/src/cloudflare/worker.ts
+++ b/alchemy/src/cloudflare/worker.ts
@@ -895,6 +895,12 @@ async function prepareWorkerMetadata<B extends Bindings>(
         type: "ai",
         name: bindingName,
       });
+    } else if (binding.type === "analytics_engine") {
+      meta.bindings.push({
+        type: "analytics_engine",
+        name: bindingName,
+        dataset: binding.dataset,
+      });
     } else {
       // @ts-expect-error - we should never reach here
       throw new Error(`Unsupported binding type: ${binding.type}`);

--- a/alchemy/src/cloudflare/wrangler.json.ts
+++ b/alchemy/src/cloudflare/wrangler.json.ts
@@ -1,6 +1,7 @@
 import type { Context } from "../context.js";
 import { StaticJsonFile } from "../fs/static-json-file.js";
 import { Resource } from "../resource.js";
+import { assertNever } from "../util/assert-never.js";
 import { Self, type Bindings } from "./bindings.js";
 import type { DurableObjectNamespace } from "./durable-object-namespace.js";
 import type { EventSource } from "./event-source.js";
@@ -291,6 +292,21 @@ export interface WranglerJsonSpec {
    * Whether to minify the worker script
    */
   minify?: boolean;
+
+  /**
+   * Analytics Engine datasets
+   */
+  analytics_engine_datasets?: { binding: string; dataset: string }[];
+
+  /**
+   * Hyperdrive bindings
+   */
+  hyperdrive?: { binding: string; id: string; localConnectionString: string }[];
+
+  /**
+   * Pipelines
+   */
+  pipelines?: { binding: string; pipeline: string }[];
 }
 
 /**
@@ -340,6 +356,13 @@ function processBindings(
   const new_classes: string[] = [];
 
   const vectorizeIndexes: { binding: string; index_name: string }[] = [];
+  const analyticsEngineDatasets: { binding: string; dataset: string }[] = [];
+  const hyperdrive: {
+    binding: string;
+    id: string;
+    localConnectionString: string;
+  }[] = [];
+  const pipelines: { binding: string; pipeline: string }[] = [];
 
   for (const eventSource of eventSources ?? []) {
     if (isQueueEventSource(eventSource)) {
@@ -450,6 +473,31 @@ function processBindings(
       spec.ai = {
         binding: bindingName,
       };
+    } else if (binding.type === "analytics_engine") {
+      analyticsEngineDatasets.push({
+        binding: bindingName,
+        dataset: binding.dataset,
+      });
+    } else if (binding.type === "ai_gateway") {
+      // no-op
+    } else if (binding.type === "hyperdrive") {
+      const password =
+        "password" in binding.origin
+          ? binding.origin.password.unencrypted
+          : binding.origin.access_client_secret.unencrypted;
+      hyperdrive.push({
+        binding: bindingName,
+        id: binding.hyperdriveId,
+        localConnectionString: `${binding.origin.scheme || "postgres"}://${binding.origin.user}:${password}@${binding.origin.host}:${binding.origin.port || 5432}/${binding.origin.database}`,
+      });
+    } else if (binding.type === "pipeline") {
+      pipelines.push({
+        binding: bindingName,
+        pipeline: binding.name,
+      });
+    } else {
+      // biome-ignore lint/correctness/noVoidTypeReturn: it returns never
+      return assertNever(binding);
     }
   }
 
@@ -496,5 +544,17 @@ function processBindings(
 
   if (workflows.length > 0) {
     spec.workflows = workflows;
+  }
+
+  if (analyticsEngineDatasets.length > 0) {
+    spec.analytics_engine_datasets = analyticsEngineDatasets;
+  }
+
+  if (hyperdrive.length > 0) {
+    spec.hyperdrive = hyperdrive;
+  }
+
+  if (pipelines.length > 0) {
+    spec.pipelines = pipelines;
   }
 }

--- a/alchemy/src/util/assert-never.ts
+++ b/alchemy/src/util/assert-never.ts
@@ -1,0 +1,3 @@
+export function assertNever(value: never): never {
+  throw new Error(`Unexpected value: ${value}`);
+}


### PR DESCRIPTION
Adds the ability to bind to cloudflare worker analytics engine datasets

https://developers.cloudflare.com/analytics/analytics-engine/

Odd kind of binding, since there is no iteraction with cloudflare's API.

- New datasets get created when they get used
- Old datasets die when the data in them gets 3 months old
- No ability to delete data or datasets