### PR TITLE
fix(cloudflare): update vectorize_indexes to vectorize in wrangler.json.ts

### DIFF
--- a/alchemy/src/cloudflare/wrangler.json.ts
+++ b/alchemy/src/cloudflare/wrangler.json.ts
@@ -236,7 +236,7 @@ export interface WranglerJsonSpec {
   /**
    * Vectorize index bindings
    */
-  vectorize_indexes?: {
+  vectorize?: {
     binding: string;
     index_name: string;
   }[];
@@ -481,7 +481,7 @@ function processBindings(
   }
 
   if (vectorizeIndexes.length > 0) {
-    spec.vectorize_indexes = vectorizeIndexes;
+    spec.vectorize = vectorizeIndexes;
   }
 
   if (new_sqlite_classes.length > 0 || new_classes.length > 0) {


### PR DESCRIPTION
Updates Vectorize bindings from `vectorize_indexes` to `vectorize` in `wrangler.json` to match Cloudflare's [current API](https://developers.cloudflare.com/workers/wrangler/configuration/#vectorize-indexes).