### PR TITLE
fix(cloudflare): allow no-op update of vectorize index and metadata index

### DIFF
--- a/alchemy/src/cloudflare/vectorize-index.ts
+++ b/alchemy/src/cloudflare/vectorize-index.ts
@@ -151,6 +151,34 @@ export const VectorizeIndex = Resource(
         }
       }
     } else {
+      if (props.delete !== this.props.delete) {
+        // Only allow changing the delete property
+        if (!this.quiet) {
+          console.warn(
+            `Attempted to update Vectorize index ${indexName} but only the delete property can be changed.`,
+          );
+        }
+        return this({
+          ...this.output,
+          delete: props.delete,
+        });
+      }
+
+      // Check if this is a no-op update
+      if (
+        props.name === this.props.name &&
+        props.description === this.props.description &&
+        props.dimensions === this.props.dimensions &&
+        props.metric === this.props.metric
+      ) {
+        if (!this.quiet) {
+          console.warn(
+            `Attempted to update Vectorize index ${indexName} but it was a no-op.`,
+          );
+        }
+        return this(this.output);
+      }
+
       // Update operation is not supported by Vectorize API
       throw new Error(
         "Updating Vectorize indexes is not supported by the Cloudflare API. " +

--- a/alchemy/src/cloudflare/vectorize-metadata-index.ts
+++ b/alchemy/src/cloudflare/vectorize-metadata-index.ts
@@ -107,6 +107,20 @@ export const VectorizeMetadataIndex = Resource(
       return this.destroy();
     }
     if (this.phase === "update") {
+      if (
+        props.email === this.props.email &&
+        props.index?.id === this.props.index?.id &&
+        props.propertyName === this.props.propertyName &&
+        props.indexType === this.props.indexType
+      ) {
+        // Update operation is not supported
+        if (!this.scope.quiet) {
+          console.warn(
+            `Attempted to update Vectorize metadata index ${this.props.propertyName} but it was a no-op.`,
+          );
+        }
+        return this(this.output);
+      }
       // Update operation is not supported
       throw new Error(
         "Updating Vectorize metadata indexes is not supported by the Cloudflare API. " +

--- a/alchemy/src/context.ts
+++ b/alchemy/src/context.ts
@@ -87,6 +87,7 @@ export function context<
   seq,
   state,
   replace,
+  props,
 }: {
   scope: Scope;
   phase: "create" | "update" | "delete";
@@ -130,7 +131,7 @@ export function context<
     fqn: fqn,
     phase,
     output: state.output,
-    props: state.props,
+    props,
     replace,
     get: (key: string) => state.data[key],
     set: async (key: string, value: any) => {


### PR DESCRIPTION
We recently changed the way symbols are used in a Resource's properties which has triggered no-op updates because it counts as the properties changing (it's a diff) https://github.com/sam-goodwin/alchemy/pull/177

This change updates the VectorizeIndex and VectorizeMetadataIndex which do not allow updates to check if the properties have actually changed so that these "no-op" updates can still flow through.