### PR TITLE
Write triggers.cron cron schedule to wrangler.json for CF Worker resource

### DIFF
--- a/alchemy-web/docs/providers/cloudflare/wrangler.json.md
+++ b/alchemy-web/docs/providers/cloudflare/wrangler.json.md
@@ -61,3 +61,18 @@ await WranglerJson("wrangler", {
   worker
 });
 ```
+
+## With Cron Triggers
+
+If the Worker has scheduled crons, they are written to `wrangler.json` under the
+`triggers` field:
+
+```ts
+const worker = await Worker("cron", {
+  name: "cron-worker",
+  entrypoint: "./src/cron.ts",
+  crons: ["*/3 * * * *", "0 15 1 * *", "59 23 LW * *"],
+});
+
+await WranglerJson("wrangler", { worker });
+```

--- a/alchemy/src/cloudflare/wrangler.json.ts
+++ b/alchemy/src/cloudflare/wrangler.json.ts
@@ -103,6 +103,10 @@ export const WranglerJson = Resource(
       spec.vars = { ...worker.env };
     }
 
+    if (worker.crons && worker.crons.length > 0) {
+      spec.triggers = { crons: worker.crons };
+    }
+
     await StaticJsonFile(filePath, spec);
 
     // Return the resource
@@ -149,6 +153,13 @@ export interface WranglerJsonSpec {
    * Routes to attach to the worker
    */
   routes?: string[];
+
+  /**
+   * Scheduled triggers for the worker
+   */
+  triggers?: {
+    crons: string[];
+  };
 
   /**
    * AI bindings

--- a/alchemy/test/cloudflare/wrangler-json.test.ts
+++ b/alchemy/test/cloudflare/wrangler-json.test.ts
@@ -344,7 +344,36 @@ describe("WranglerJson Resource", () => {
         expect(spec.workflows?.length).toEqual(1);
         expect(spec.workflows?.[0].name).toEqual("test-workflow");
         expect(spec.workflows?.[0].binding).toEqual("WF");
-        expect(spec.workflows?.[0].class_name).toEqual("TestWorkflow");
+      expect(spec.workflows?.[0].class_name).toEqual("TestWorkflow");
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+      await destroy(scope);
+    }
+    });
+
+    test("with cron triggers", async (scope) => {
+      const name = `${BRANCH_PREFIX}-test-worker-cron-json`;
+      const tempDir = path.join(".out", "alchemy-cron-json-test");
+      const entrypoint = path.join(tempDir, "worker.ts");
+
+      try {
+        await fs.rm(tempDir, { recursive: true, force: true });
+        await fs.mkdir(tempDir, { recursive: true });
+        await fs.writeFile(entrypoint, esmWorkerScript);
+
+        const worker = await Worker(name, {
+          format: "esm",
+          entrypoint,
+          crons: ["*/3 * * * *", "0 15 1 * *", "59 23 LW * *"],
+        });
+
+        const { spec } = await WranglerJson(
+          `${BRANCH_PREFIX}-test-wrangler-json-cron`,
+          { worker },
+        );
+
+        expect(spec.triggers).toBeDefined();
+        expect(spec.triggers?.crons).toEqual(worker.crons);
       } finally {
         await fs.rm(tempDir, { recursive: true, force: true });
         await destroy(scope);


### PR DESCRIPTION
- support cron triggers in generated wrangler.json files
- document cron triggers in WranglerJson docs
- test WranglerJson with cron triggers

(Codex wrote this code but couldn't run test - Please check if it works)