### PR TITLE
fix: VercelProject 400 with gitRepository

### DIFF
--- a/alchemy/src/vercel/project.ts
+++ b/alchemy/src/vercel/project.ts
@@ -400,7 +400,7 @@ export const Project = Resource(
 
         // 409 Conflict: Can't update name, so remove it from the props
         // 400 Invalid Request: Should NOT have additional property `environmentVariables`
-        const { name, environmentVariables, ...rest } = props;
+        const { name, environmentVariables, gitRepository, ...rest } = props;
         const response = await api.patch(`/projects/${this.output.id}`, rest);
         const data = (await response.json()) as Project;
 


### PR DESCRIPTION
Just discovered this bug.  Some settings cannot be updated on a Vercel Project after creation.

I missed this one in my testing:


```console
@packages/infra:build: Update:  "vercel/production/project"
@packages/infra:build: 62 |         if (!response.ok) {
@packages/infra:build: 63 |             let error = new Error(`API error: ${response.statusText}`, {
@packages/infra:build: 64 |                 cause: response,
@packages/infra:build: 65 |             });
@packages/infra:build: 66 |             try {
@packages/infra:build: 67 |                 error = Object.assign(new Error(response.statusText, { cause: response }), (await response.json())?.error);
@packages/infra:build:                                            ^
@packages/infra:build: error: Invalid request: should NOT have additional property `gitRepository`.
@packages/infra:build:  code: "bad_request"
@packages/infra:build: 
@packages/infra:build:       at fetch (/Users/eric/Projects/ericclemmons/bmarks/node_modules/alchemy/lib/vercel/api.js:67:39)
```