### PR TITLE
feat(cloudflare): Durable Object RPC types

### DIFF
--- a/alchemy/src/cloudflare/bindings.ts
+++ b/alchemy/src/cloudflare/bindings.ts
@@ -41,7 +41,7 @@ export type Binding =
   | Assets
   | D1DatabaseResource
   | AnalyticsEngineDataset
-  | DurableObjectNamespace
+  | DurableObjectNamespace<any>
   | HyperdriveResource
   | KVNamespaceResource
   | PipelineResource

--- a/alchemy/src/cloudflare/bound.ts
+++ b/alchemy/src/cloudflare/bound.ts
@@ -15,8 +15,10 @@ import type { QueueResource as _Queue } from "./queue.js";
 import type { VectorizeIndexResource as _VectorizeIndex } from "./vectorize-index.js";
 import type { Workflow as _Workflow } from "./workflow.js";
 
-export type Bound<T extends Binding> = T extends _DurableObjectNamespace
-  ? DurableObjectNamespace
+export type Bound<T extends Binding> = T extends _DurableObjectNamespace<
+  infer O
+>
+  ? DurableObjectNamespace<O>
   : T extends { type: "kv_namespace" }
     ? KVNamespace
     : T extends { type: "service" }

--- a/alchemy/src/cloudflare/durable-object-namespace.ts
+++ b/alchemy/src/cloudflare/durable-object-namespace.ts
@@ -31,7 +31,10 @@ export interface DurableObjectNamespaceInput {
  *   environment: "production"
  * });
  */
-export class DurableObjectNamespace implements DurableObjectNamespaceInput {
+export class DurableObjectNamespace<
+  T extends Rpc.DurableObjectBranded | undefined = undefined,
+> implements DurableObjectNamespaceInput
+{
   public readonly type = "durable_object_namespace" as const;
   // alias for bindingName to be consistent with other bindings
   public readonly className: string;
@@ -39,6 +42,9 @@ export class DurableObjectNamespace implements DurableObjectNamespaceInput {
   public readonly environment?: string | undefined;
   public readonly sqlite?: boolean | undefined;
   public readonly namespaceId?: string | undefined;
+
+  // @ts-ignore - phantom type
+  protected readonly __service__: T;
 
   constructor(
     public readonly id: string,

--- a/examples/cloudflare-worker/alchemy.run.ts
+++ b/examples/cloudflare-worker/alchemy.run.ts
@@ -8,6 +8,7 @@ import {
   WranglerJson,
 } from "../../alchemy/src/cloudflare/index.js";
 import alchemy from "../../alchemy/src/index.js";
+import type { HelloWorldDO } from "./src/do.js";
 
 const BRANCH_PREFIX = process.env.BRANCH_PREFIX ?? "";
 const app = await alchemy("cloudflare-worker", {
@@ -39,7 +40,7 @@ export const worker = await Worker(`cloudflare-worker-worker${BRANCH_PREFIX}`, {
       className: "OFACWorkflow",
       workflowName: "ofac-workflow",
     }),
-    DO: new DurableObjectNamespace("HelloWorldDO", {
+    DO: new DurableObjectNamespace<HelloWorldDO>("HelloWorldDO", {
       className: "HelloWorldDO",
       sqlite: true,
     }),

--- a/examples/cloudflare-worker/src/do.ts
+++ b/examples/cloudflare-worker/src/do.ts
@@ -1,8 +1,19 @@
+import { DurableObject } from "cloudflare:workers";
+
 /**
  * A simple Hello World Durable Object
  */
-export class HelloWorldDO implements DurableObject {
-  constructor(private readonly state: DurableObjectState) {}
+export class HelloWorldDO extends DurableObject {
+  constructor(
+    private readonly state: DurableObjectState,
+    env: CloudflareEnv,
+  ) {
+    super(state, env);
+  }
+
+  async hello() {
+    return "Hello World";
+  }
 
   /**
    * Handle HTTP requests to the Durable Object

--- a/examples/cloudflare-worker/src/env.d.ts
+++ b/examples/cloudflare-worker/src/env.d.ts
@@ -2,10 +2,13 @@
 
 import type { worker } from "../alchemy.run.js";
 
-export type CloudFlareEnv = typeof worker.Env;
+
+declare global {
+  export type CloudflareEnv = typeof worker.Env;
+}
 
 declare module "cloudflare:workers" {
   namespace Cloudflare {
-    export interface Env extends CloudFlareEnv {}
+    export interface Env extends CloudflareEnv {}
   }
 }

--- a/examples/cloudflare-worker/src/worker.ts
+++ b/examples/cloudflare-worker/src/worker.ts
@@ -8,6 +8,10 @@ export default {
       name: "John Doe",
       email: "john.doe@example.com",
     });
+
+    const obj = env.DO.get(env.DO.idFromName("foo"));
+    await obj.hello();
+
     return new Response("Ok");
   },
   async queue(batch: typeof queue.Batch, _env: typeof worker.Env) {


### PR DESCRIPTION
You can now pass the type of the Durable Object to the `DurableObjectNamespace` binding to enable type-inference with RPC methods.

```ts
new DurableObjectNamespace<HelloWorldDO>("HelloWorldDO", {
  className: "HelloWorldDO",
  sqlite: true,
}),
```