### PR TITLE
fix(cloudflare): improve error message when failing to resolve Cloudflare Account ID

### DIFF
--- a/alchemy/src/cloudflare/api-error.ts
+++ b/alchemy/src/cloudflare/api-error.ts
@@ -46,7 +46,7 @@ export async function handleApiError(
   response: Response,
   action: string,
   resourceType: string,
-  resourceName: string,
+  resourceName?: string,
 ): Promise<never> {
   const text = await response.text();
   let json: any;
@@ -58,6 +58,6 @@ export async function handleApiError(
   const errors: { message: string }[] = json?.errors || [
     { message: response.statusText },
   ];
-  const errorMessage = `Error ${response.status} ${action} ${resourceType} '${resourceName}': ${errors[0]?.message || response.statusText}`;
+  const errorMessage = `Error ${response.status} ${action} ${resourceType}${resourceName ? ` '${resourceName}'` : ""}: ${errors[0]?.message || response.statusText}`;
   throw new CloudflareApiError(errorMessage, response, errors);
 }

--- a/alchemy/src/cloudflare/user.ts
+++ b/alchemy/src/cloudflare/user.ts
@@ -1,5 +1,5 @@
-import { handleApiError } from "../neon/api-error.js";
 import type { Secret } from "../secret.js";
+import { CloudflareApiError } from "./api-error.js";
 import {
   getCloudflareAuthHeaders,
   type CloudflareAuthOptions,
@@ -79,7 +79,10 @@ export async function getCloudflareAccounts(
   if (accounts.ok) {
     return (accountCache[cacheKey] ??= ((await accounts.json()) as any).result);
   } else {
-    return await handleApiError(accounts, "get", "accounts");
+    throw new CloudflareApiError(
+      `Failed to get accounts for authorized user, please make sure you're authenticated (see: https://alchemy.run/docs/guides/cloudflare-auth.html) or explicitly set the Cloudflare Account ID (see: https://alchemy.run/docs/guides/cloudflare-auth.html#account-id)`,
+      accounts,
+    );
   }
 }
 


### PR DESCRIPTION
We were mistakenly using Neon's `handleApiError` and providing a useless error message. 