### PR TITLE
chore(cloudflare): simplify unenv bundling

### DIFF
--- a/alchemy/src/cloudflare/bundle/nodejs-compat.ts
+++ b/alchemy/src/cloudflare/bundle/nodejs-compat.ts
@@ -4,7 +4,7 @@
 
 import type { Plugin, PluginBuild } from "esbuild";
 import assert from "node:assert";
-import { builtinModules, createRequire } from "node:module";
+import module, { createRequire } from "node:module";
 import nodePath from "node:path";
 import { dedent } from "../../util/dedent.js";
 
@@ -39,7 +39,18 @@ export async function nodeJsCompatPlugin(): Promise<Plugin> {
   };
 }
 
-const NODEJS_MODULES_RE = new RegExp(`^(node:)?(${builtinModules.join("|")})$`);
+const NODEJS_MODULES_RE = new RegExp(
+  `^(node:)?(${module.builtinModules
+    .filter(
+      (m) =>
+        ![
+          // in some runtimes (like bun), `ws` is a built-in module but is not in `node`
+          // bundling for `nodejs_compat` should not polyfill these modules
+          "ws",
+        ].includes(m),
+    )
+    .join("|")})$`,
+);
 
 /**
  * If we are bundling a "Service Worker" formatted Worker, imports of external modules,

--- a/alchemy/test/cloudflare/bundle-handler.ts
+++ b/alchemy/test/cloudflare/bundle-handler.ts
@@ -13,6 +13,7 @@ export default {
     console.log(crypto.randomBytes(10));
     console.log(crypto2.randomBytes(10));
     console.log(logger);
+    require("ws");
     return new Response("Hello World!");
   },
 };

--- a/alchemy/test/cloudflare/bundle.test.ts
+++ b/alchemy/test/cloudflare/bundle.test.ts
@@ -24,6 +24,7 @@ describe("Bundle Worker Test", () => {
         format: "esm", // Assuming bundle-handler.ts is ESM
         url: true, // Enable workers.dev URL to test the worker
         compatibilityFlags: ["nodejs_compat"],
+        adopt: true,
       });
 
       await new Promise((resolve) => setTimeout(resolve, 1000));
@@ -48,6 +49,7 @@ describe("Bundle Worker Test", () => {
         format: "esm", // Assuming bundle-handler.ts is ESM
         url: true, // Enable workers.dev URL to test the worker
         compatibilityFlags: ["nodejs_als"],
+        adopt: true,
       });
 
       await new Promise((resolve) => setTimeout(resolve, 1000));
@@ -73,6 +75,7 @@ describe("Bundle Worker Test", () => {
           url: true,
           compatibilityDate: "2024-09-22", // v1 mode (before Sept 23rd 2024)
           compatibilityFlags: ["nodejs_compat"],
+          adopt: true,
         }),
       ).rejects.toThrow(
         "You must set your compatibilty date >= 2024-09-23 when using 'nodejs_compat' compatibility flag",


### PR DESCRIPTION
Didn't take it all the way, but am hoping to simplify how we use unenv with esbuild and minimize the number of esbuild plugins we have (that were inherited from wrangler)