### PR TITLE
fix(cloudflare): do not include eventSources when uploading stub worker during delete phase

### DIFF
--- a/alchemy/src/cloudflare/worker.ts
+++ b/alchemy/src/cloudflare/worker.ts
@@ -779,6 +779,9 @@ export const _Worker = Resource(
             ? "addEventListener('fetch', event => { event.respondWith(new Response('hello world')); });"
             : "export default { fetch(request) { return new Response('hello world'); } }",
         bindings: {} as B,
+        // we are writing a stub worker (to remove binding/event source dependencies)
+        // queue consumers will no longer exist by this point
+        eventSources: undefined,
       });
 
       await withExponentialBackoff(


### PR DESCRIPTION
Ran into a bug where it was trying to upload event sources when deleting the worker