### PR TITLE
feat(cloudflare): support binding to a DO hosted in another Worker

### DIFF
--- a/alchemy-web/docs/providers/cloudflare/worker.md
+++ b/alchemy-web/docs/providers/cloudflare/worker.md
@@ -120,10 +120,7 @@ const apiWorker = await Worker("api-worker", {
   entrypoint: "./src/api.ts", 
   bindings: {
     // Cross-script binding to the data worker's durable object
-    SHARED_STORAGE: new DurableObjectNamespace("shared-storage", {
-      className: "DataStorage",
-      scriptName: dataWorker.name  // References the other worker
-    })
+    SHARED_STORAGE: dataWorker.bindings.STORAGE
   }
 });
 ```

--- a/alchemy-web/docs/providers/cloudflare/worker.md
+++ b/alchemy-web/docs/providers/cloudflare/worker.md
@@ -95,6 +95,39 @@ const frontend = await Worker("frontend", {
 });
 ```
 
+## Cross-Script Durable Object Binding
+
+Share durable objects between workers by defining them in one worker and accessing them from another:
+
+```ts
+import { Worker, DurableObjectNamespace } from "alchemy/cloudflare";
+
+// Worker that defines and owns the durable object
+const dataWorker = await Worker("data-worker", {
+  name: "data-worker",
+  entrypoint: "./src/data.ts",
+  bindings: {
+    // Bind to its own durable object
+    STORAGE: new DurableObjectNamespace("storage", {
+      className: "DataStorage"
+    })
+  }
+});
+
+// Worker that accesses the durable object from another worker
+const apiWorker = await Worker("api-worker", {
+  name: "api-worker",
+  entrypoint: "./src/api.ts", 
+  bindings: {
+    // Cross-script binding to the data worker's durable object
+    SHARED_STORAGE: new DurableObjectNamespace("shared-storage", {
+      className: "DataStorage",
+      scriptName: dataWorker.name  // References the other worker
+    })
+  }
+});
+```
+
 ## With Custom Domain Routing
 
 ```ts

--- a/alchemy/src/cloudflare/durable-object-namespace.ts
+++ b/alchemy/src/cloudflare/durable-object-namespace.ts
@@ -1,3 +1,5 @@
+import type { Binding } from "./bindings.js";
+
 /**
  * Properties for creating a Durable Object Namespace
  */
@@ -7,6 +9,14 @@ export interface DurableObjectNamespaceInput {
   environment?: string | undefined;
   sqlite?: boolean | undefined;
   namespaceId?: string | undefined;
+}
+
+export function isDurableObjectNamespace(
+  binding: Binding,
+): binding is DurableObjectNamespace {
+  return (
+    typeof binding === "object" && binding.type === "durable_object_namespace"
+  );
 }
 
 /**

--- a/alchemy/src/cloudflare/worker-metadata.ts
+++ b/alchemy/src/cloudflare/worker-metadata.ts
@@ -200,7 +200,9 @@ export async function prepareWorkerMetadata<B extends Bindings>(
       if (
         binding &&
         typeof binding === "object" &&
-        binding.type === "durable_object_namespace"
+        binding.type === "durable_object_namespace" &&
+        (binding.scriptName === undefined ||
+          binding.scriptName === props.workerName)
       ) {
         return [binding.className];
       }
@@ -295,7 +297,14 @@ export async function prepareWorkerMetadata<B extends Bindings>(
         environment: binding.environment,
         namespace_id: binding.namespaceId,
       });
-      configureClassMigration(binding, binding.id, binding.className);
+      if (
+        binding.scriptName === undefined ||
+        // TODO(sam): not sure if Cloudflare Api would like us using `this` worker name here
+        binding.scriptName === props.workerName
+      ) {
+        // we do not need configure class migrations for cross-script bindings
+        configureClassMigration(binding, binding.id, binding.className);
+      }
     } else if (binding.type === "r2_bucket") {
       meta.bindings.push({
         type: "r2_bucket",

--- a/alchemy/src/cloudflare/worker.ts
+++ b/alchemy/src/cloudflare/worker.ts
@@ -412,6 +412,32 @@ export type Worker<B extends Bindings = Bindings> =
  *   crons: ['* 15 * * *', '0 0 * * *', '0 12 * * MON']
  * })
  *
+ * @example
+ * // Create cross-script durable object binding where one worker
+ * // defines the durable object and another worker accesses it:
+ * const dataWorker = await Worker("data-worker", {
+ *   name: "data-worker",
+ *   entrypoint: "./src/data.ts",
+ *   bindings: {
+ *     // Bind to its own durable object
+ *     STORAGE: new DurableObjectNamespace("storage", {
+ *       className: "DataStorage"
+ *     })
+ *   }
+ * });
+ *
+ * const apiWorker = await Worker("api-worker", {
+ *   name: "api-worker",
+ *   entrypoint: "./src/api.ts",
+ *   bindings: {
+ *     // Cross-script binding to the data worker's durable object
+ *     SHARED_STORAGE: new DurableObjectNamespace("shared-storage", {
+ *       className: "DataStorage",
+ *       scriptName: "data-worker"  // References the other worker
+ *     })
+ *   }
+ * });
+ *
  * @see
  * https://developers.cloudflare.com/workers/
  */

--- a/alchemy/test/cloudflare/worker.test.ts
+++ b/alchemy/test/cloudflare/worker.test.ts
@@ -1826,7 +1826,7 @@ describe("Worker Resource", () => {
     const targetWorkerName = `${BRANCH_PREFIX}-target-worker`;
     const callerWorkerName = `${BRANCH_PREFIX}-caller-worker`;
 
-    // Sample script for the target worker
+    // Script for the target worker
     const targetWorkerScript = `
       export default {
         async fetch(request, env, ctx) {
@@ -1857,7 +1857,7 @@ describe("Worker Resource", () => {
       };
     `;
 
-    // Sample script for the caller worker that will use the worker binding
+    // Script for the caller worker that will use the worker binding
     const callerWorkerScript = `
       export default {
         async fetch(request, env, ctx) {
@@ -2113,4 +2113,234 @@ describe("Worker Resource", () => {
       await assertWorkerDoesNotExist(workerName);
     }
   }, 60000); // Increase timeout for Worker operations
+
+  test("create and test worker with cross-script durable object binding", async (scope) => {
+    // Create names for both workers
+    const doWorkerName = `${BRANCH_PREFIX}-do-provider-worker`;
+    const clientWorkerName = `${BRANCH_PREFIX}-do-client-worker`;
+
+    // Script for the worker that defines the durable object
+    const doProviderWorkerScript = `
+      export class SharedCounter {
+        constructor(state, env) {
+          this.state = state;
+          this.env = env;
+          this.counter = 0;
+        }
+
+        async fetch(request) {
+          const url = new URL(request.url);
+          
+          if (url.pathname === '/increment') {
+            this.counter++;
+            return new Response(JSON.stringify({
+              action: 'increment',
+              counter: this.counter,
+              worker: '${doWorkerName}'
+            }), {
+              headers: { 'Content-Type': 'application/json' }
+            });
+          }
+
+          if (url.pathname === '/get') {
+            return new Response(JSON.stringify({
+              action: 'get',
+              counter: this.counter,
+              worker: '${doWorkerName}'
+            }), {
+              headers: { 'Content-Type': 'application/json' }
+            });
+          }
+
+          return new Response('SharedCounter DO is running!', { status: 200 });
+        }
+      }
+
+      export default {
+        async fetch(request, env, ctx) {
+          return new Response('DO Provider Worker is running!', {
+            status: 200,
+            headers: { 'Content-Type': 'text/plain' }
+          });
+        }
+      };
+    `;
+
+    // Script for the worker that uses the cross-script durable object
+    const clientWorkerScript = `
+      export default {
+        async fetch(request, env, ctx) {
+          const url = new URL(request.url);
+          
+          if (url.pathname === '/increment') {
+            try {
+              // Get the durable object instance and increment
+              const id = env.SHARED_COUNTER.idFromName('test-counter');
+              const stub = env.SHARED_COUNTER.get(id);
+              const response = await stub.fetch(new Request('https://example.com/increment'));
+              const data = await response.json();
+              
+              return Response.json({
+                success: true,
+                clientWorker: '${clientWorkerName}',
+                result: data,
+                crossScriptWorking: true
+              });
+            } catch (error) {
+              return Response.json({
+                success: false,
+                error: error.message,
+                crossScriptWorking: false
+              }, { status: 500 });
+            }
+          }
+
+          if (url.pathname === '/get') {
+            try {
+              // Get the current counter value
+              const id = env.SHARED_COUNTER.idFromName('test-counter');
+              const stub = env.SHARED_COUNTER.get(id);
+              const response = await stub.fetch(new Request('https://example.com/get'));
+              const data = await response.json();
+              
+              return Response.json({
+                success: true,
+                clientWorker: '${clientWorkerName}',
+                result: data
+              });
+            } catch (error) {
+              return Response.json({
+                success: false,
+                error: error.message
+              }, { status: 500 });
+            }
+          }
+
+          return new Response('DO Client Worker is running!', {
+            status: 200,
+            headers: { 'Content-Type': 'text/plain' }
+          });
+        }
+      };
+    `;
+
+    let doProviderWorker: Worker | undefined;
+    let clientWorker: Worker | undefined;
+
+    try {
+      // First create the worker that defines the durable object with its own binding
+      doProviderWorker = await Worker(doWorkerName, {
+        name: doWorkerName,
+        script: doProviderWorkerScript,
+        format: "esm",
+        url: true, // Enable workers.dev URL
+        bindings: {
+          // Create a durable object namespace for the provider worker
+          SHARED_COUNTER: new DurableObjectNamespace(
+            "provider-counter-namespace",
+            {
+              className: "SharedCounter",
+              // No scriptName means it binds to its own script
+            },
+          ), // Bind to its own durable object
+        },
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+
+      expect(doProviderWorker.id).toBeTruthy();
+      expect(doProviderWorker.name).toEqual(doWorkerName);
+      expect(doProviderWorker.url).toBeTruthy();
+
+      // Create the client worker with the cross-script durable object binding
+      clientWorker = await Worker(clientWorkerName, {
+        name: clientWorkerName,
+        script: clientWorkerScript,
+        format: "esm",
+        url: true, // Enable workers.dev URL
+        bindings: {
+          // Create a cross-script durable object namespace that references the first worker
+
+          SHARED_COUNTER: new DurableObjectNamespace(
+            "cross-script-counter-namespace",
+            {
+              className: "SharedCounter",
+              scriptName: doWorkerName, // This makes it cross-script
+            },
+          ), // Cross-script binding
+        },
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+
+      expect(clientWorker.id).toBeTruthy();
+      expect(clientWorker.name).toEqual(clientWorkerName);
+      expect(clientWorker.url).toBeTruthy();
+      expect(clientWorker.bindings?.SHARED_COUNTER).toBeDefined();
+
+      // Verify the binding configuration
+      const binding = clientWorker.bindings!.SHARED_COUNTER as any;
+      expect(binding.className).toEqual("SharedCounter");
+      expect(binding.scriptName).toEqual(doWorkerName);
+
+      // Test that both workers respond to basic requests
+      const doProviderResponse = await fetch(doProviderWorker.url!);
+      expect(doProviderResponse.status).toEqual(200);
+      const doProviderText = await doProviderResponse.text();
+      expect(doProviderText).toEqual("DO Provider Worker is running!");
+
+      const clientResponse = await fetch(clientWorker.url!);
+      expect(clientResponse.status).toEqual(200);
+      const clientText = await clientResponse.text();
+      expect(clientText).toEqual("DO Client Worker is running!");
+
+      // Test cross-script durable object functionality by calling increment
+      const incrementResponse = await fetch(`${clientWorker.url}/increment`);
+      expect(incrementResponse.status).toEqual(200);
+      const incrementData: any = await incrementResponse.json();
+
+      expect(incrementData).toMatchObject({
+        success: true,
+        clientWorker: clientWorkerName,
+        crossScriptWorking: true,
+        result: {
+          action: "increment",
+          worker: doWorkerName,
+        },
+      });
+
+      // Test getting the counter value
+      const getResponse = await fetch(`${clientWorker.url}/get`);
+      expect(getResponse.status).toEqual(200);
+      const getData: any = await getResponse.json();
+
+      expect(getData).toMatchObject({
+        success: true,
+        clientWorker: clientWorkerName,
+        result: {
+          action: "get",
+          worker: doWorkerName,
+        },
+      });
+
+      // Test state persistence by making multiple increment calls
+      const firstIncrement = await fetch(`${clientWorker.url}/increment`);
+      const firstData: any = await firstIncrement.json();
+
+      const secondIncrement = await fetch(`${clientWorker.url}/increment`);
+      const secondData: any = await secondIncrement.json();
+
+      const thirdIncrement = await fetch(`${clientWorker.url}/increment`);
+      const thirdData: any = await thirdIncrement.json();
+
+      // Verify that the counter is incrementing properly across calls
+      expect(firstData.result.counter).toBeLessThan(secondData.result.counter);
+      expect(secondData.result.counter).toBeLessThan(thirdData.result.counter);
+    } finally {
+      await destroy(scope);
+      // Verify both workers were deleted
+      await assertWorkerDoesNotExist(doWorkerName);
+      await assertWorkerDoesNotExist(clientWorkerName);
+    }
+  }, 120000); // Increased timeout for cross-script DO operations
 });

--- a/alchemy/test/cloudflare/worker.test.ts
+++ b/alchemy/test/cloudflare/worker.test.ts
@@ -2224,8 +2224,8 @@ describe("Worker Resource", () => {
       };
     `;
 
-    let doProviderWorker: Worker | undefined;
-    let clientWorker: Worker | undefined;
+    let doProviderWorker;
+    let clientWorker;
 
     try {
       // First create the worker that defines the durable object with its own binding
@@ -2260,7 +2260,6 @@ describe("Worker Resource", () => {
         url: true, // Enable workers.dev URL
         bindings: {
           // Create a cross-script durable object namespace that references the first worker
-
           SHARED_COUNTER: new DurableObjectNamespace(
             "cross-script-counter-namespace",
             {
@@ -2279,7 +2278,234 @@ describe("Worker Resource", () => {
       expect(clientWorker.bindings?.SHARED_COUNTER).toBeDefined();
 
       // Verify the binding configuration
-      const binding = clientWorker.bindings!.SHARED_COUNTER as any;
+      const binding = clientWorker.bindings.SHARED_COUNTER;
+      expect(binding.className).toEqual("SharedCounter");
+      expect(binding.scriptName).toEqual(doWorkerName);
+
+      // Test that both workers respond to basic requests
+      const doProviderResponse = await fetch(doProviderWorker.url!);
+      expect(doProviderResponse.status).toEqual(200);
+      const doProviderText = await doProviderResponse.text();
+      expect(doProviderText).toEqual("DO Provider Worker is running!");
+
+      const clientResponse = await fetch(clientWorker.url!);
+      expect(clientResponse.status).toEqual(200);
+      const clientText = await clientResponse.text();
+      expect(clientText).toEqual("DO Client Worker is running!");
+
+      // Test cross-script durable object functionality by calling increment
+      const incrementResponse = await fetch(`${clientWorker.url}/increment`);
+      expect(incrementResponse.status).toEqual(200);
+      const incrementData: any = await incrementResponse.json();
+
+      expect(incrementData).toMatchObject({
+        success: true,
+        clientWorker: clientWorkerName,
+        crossScriptWorking: true,
+        result: {
+          action: "increment",
+          worker: doWorkerName,
+        },
+      });
+
+      // Test getting the counter value
+      const getResponse = await fetch(`${clientWorker.url}/get`);
+      expect(getResponse.status).toEqual(200);
+      const getData: any = await getResponse.json();
+
+      expect(getData).toMatchObject({
+        success: true,
+        clientWorker: clientWorkerName,
+        result: {
+          action: "get",
+          worker: doWorkerName,
+        },
+      });
+
+      // Test state persistence by making multiple increment calls
+      const firstIncrement = await fetch(`${clientWorker.url}/increment`);
+      const firstData: any = await firstIncrement.json();
+
+      const secondIncrement = await fetch(`${clientWorker.url}/increment`);
+      const secondData: any = await secondIncrement.json();
+
+      const thirdIncrement = await fetch(`${clientWorker.url}/increment`);
+      const thirdData: any = await thirdIncrement.json();
+
+      // Verify that the counter is incrementing properly across calls
+      expect(firstData.result.counter).toBeLessThan(secondData.result.counter);
+      expect(secondData.result.counter).toBeLessThan(thirdData.result.counter);
+    } finally {
+      await destroy(scope);
+      // Verify both workers were deleted
+      await assertWorkerDoesNotExist(doWorkerName);
+      await assertWorkerDoesNotExist(clientWorkerName);
+    }
+  }, 120000); // Increased timeout for cross-script DO operations
+
+  test("create and test worker with cross-script durable object binding using re-exported syntax", async (scope) => {
+    // Create names for both workers
+    const doWorkerName = `${BRANCH_PREFIX}-do-provider-worker-re-exported`;
+    const clientWorkerName = `${BRANCH_PREFIX}-do-client-worker-re-exported`;
+
+    // Script for the worker that defines the durable object
+    const doProviderWorkerScript = `
+      export class SharedCounter {
+        constructor(state, env) {
+          this.state = state;
+          this.env = env;
+          this.counter = 0;
+        }
+
+        async fetch(request) {
+          const url = new URL(request.url);
+          
+          if (url.pathname === '/increment') {
+            this.counter++;
+            return new Response(JSON.stringify({
+              action: 'increment',
+              counter: this.counter,
+              worker: '${doWorkerName}'
+            }), {
+              headers: { 'Content-Type': 'application/json' }
+            });
+          }
+
+          if (url.pathname === '/get') {
+            return new Response(JSON.stringify({
+              action: 'get',
+              counter: this.counter,
+              worker: '${doWorkerName}'
+            }), {
+              headers: { 'Content-Type': 'application/json' }
+            });
+          }
+
+          return new Response('SharedCounter DO is running!', { status: 200 });
+        }
+      }
+
+      export default {
+        async fetch(request, env, ctx) {
+          return new Response('DO Provider Worker is running!', {
+            status: 200,
+            headers: { 'Content-Type': 'text/plain' }
+          });
+        }
+      };
+    `;
+
+    // Script for the worker that uses the cross-script durable object
+    const clientWorkerScript = `
+      export default {
+        async fetch(request, env, ctx) {
+          const url = new URL(request.url);
+          
+          if (url.pathname === '/increment') {
+            try {
+              // Get the durable object instance and increment
+              const id = env.SHARED_COUNTER.idFromName('test-counter');
+              const stub = env.SHARED_COUNTER.get(id);
+              const response = await stub.fetch(new Request('https://example.com/increment'));
+              const data = await response.json();
+              
+              return Response.json({
+                success: true,
+                clientWorker: '${clientWorkerName}',
+                result: data,
+                crossScriptWorking: true
+              });
+            } catch (error) {
+              return Response.json({
+                success: false,
+                error: error.message,
+                crossScriptWorking: false
+              }, { status: 500 });
+            }
+          }
+
+          if (url.pathname === '/get') {
+            try {
+              // Get the current counter value
+              const id = env.SHARED_COUNTER.idFromName('test-counter');
+              const stub = env.SHARED_COUNTER.get(id);
+              const response = await stub.fetch(new Request('https://example.com/get'));
+              const data = await response.json();
+              
+              return Response.json({
+                success: true,
+                clientWorker: '${clientWorkerName}',
+                result: data
+              });
+            } catch (error) {
+              return Response.json({
+                success: false,
+                error: error.message
+              }, { status: 500 });
+            }
+          }
+
+          return new Response('DO Client Worker is running!', {
+            status: 200,
+            headers: { 'Content-Type': 'text/plain' }
+          });
+        }
+      };
+    `;
+
+    let doProviderWorker;
+    let clientWorker;
+
+    try {
+      // First create the worker that defines the durable object with its own binding
+      doProviderWorker = await Worker(doWorkerName, {
+        name: doWorkerName,
+        script: doProviderWorkerScript,
+        format: "esm",
+        url: true, // Enable workers.dev URL
+        bindings: {
+          // Create a durable object namespace for the provider worker
+          SHARED_COUNTER: new DurableObjectNamespace(
+            "provider-counter-namespace",
+            {
+              className: "SharedCounter",
+              // No scriptName means it binds to its own script
+            },
+          ), // Bind to its own durable object
+        },
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+
+      expect(doProviderWorker.id).toBeTruthy();
+      expect(doProviderWorker.name).toEqual(doWorkerName);
+      expect(doProviderWorker.url).toBeTruthy();
+
+      expect(doProviderWorker.bindings.SHARED_COUNTER.scriptName).toEqual(
+        doWorkerName,
+      );
+
+      // Create the client worker with the cross-script durable object binding
+      clientWorker = await Worker(clientWorkerName, {
+        name: clientWorkerName,
+        script: clientWorkerScript,
+        format: "esm",
+        url: true, // Enable workers.dev URL
+        bindings: {
+          // Create a cross-script durable object namespace that references the first worker
+          SHARED_COUNTER: doProviderWorker.bindings.SHARED_COUNTER,
+        },
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+
+      expect(clientWorker.id).toBeTruthy();
+      expect(clientWorker.name).toEqual(clientWorkerName);
+      expect(clientWorker.url).toBeTruthy();
+      expect(clientWorker.bindings?.SHARED_COUNTER).toBeDefined();
+
+      // Verify the binding configuration
+      const binding = clientWorker.bindings.SHARED_COUNTER;
       expect(binding.className).toEqual("SharedCounter");
       expect(binding.scriptName).toEqual(doWorkerName);
 

--- a/biome.json
+++ b/biome.json
@@ -13,7 +13,8 @@
       "!**/node_modules",
       "!examples/cloudflare-tanstack-start/src/routeTree.gen.ts",
       "!examples/cloudflare-redwood/worker-configuration.d.ts",
-      "!./alchemy/src/aws/control/types.d.ts"
+      "!./alchemy/src/aws/control/types.d.ts",
+      "!examples/cloudflare-tanstack-start/.output"
     ],
     "maxSize": 10000000
   },


### PR DESCRIPTION
## Cross-Script Durable Object Binding

Share durable objects between workers by defining them in one worker and accessing them from another:

```ts
import { Worker, DurableObjectNamespace } from "alchemy/cloudflare";

// Worker that defines and owns the durable object
const dataWorker = await Worker("data-worker", {
  name: "data-worker",
  entrypoint: "./src/data.ts",
  bindings: {
    // Bind to its own durable object
    STORAGE: new DurableObjectNamespace("storage", {
      className: "DataStorage"
    })
  }
});

// Worker that accesses the durable object from another worker
const apiWorker = await Worker("api-worker", {
  name: "api-worker",
  entrypoint: "./src/api.ts", 
  bindings: {
    // Cross-script binding to the data worker's durable object
    SHARED_STORAGE: dataWorker.bindings.STORAGE
  }
});
```