### PR TITLE
feat(cloudflare): Worker RPC binding types

### DIFF
--- a/alchemy/src/cloudflare/bound.ts
+++ b/alchemy/src/cloudflare/bound.ts
@@ -13,6 +13,7 @@ import type { HyperdriveResource as _Hyperdrive } from "./hyperdrive.js";
 import type { PipelineResource as _Pipeline } from "./pipeline.js";
 import type { QueueResource as _Queue } from "./queue.js";
 import type { VectorizeIndexResource as _VectorizeIndex } from "./vectorize-index.js";
+import type { Worker as _Worker } from "./worker.js";
 import type { Workflow as _Workflow } from "./workflow.js";
 
 export type Bound<T extends Binding> = T extends _DurableObjectNamespace<
@@ -21,38 +22,47 @@ export type Bound<T extends Binding> = T extends _DurableObjectNamespace<
   ? DurableObjectNamespace<O>
   : T extends { type: "kv_namespace" }
     ? KVNamespace
-    : T extends { type: "service" }
-      ? Service
-      : T extends _R2Bucket
-        ? R2Bucket
-        : T extends _AiGateway
-          ? AiGateway
-          : T extends _Hyperdrive
-            ? Hyperdrive
-            : T extends Secret
-              ? string
-              : T extends Assets
-                ? Service
-                : T extends _Workflow<infer P>
-                  ? Workflow<P>
-                  : T extends D1DatabaseResource
-                    ? D1Database
-                    : T extends _VectorizeIndex
-                      ? VectorizeIndex
-                      : T extends _Queue<infer Body>
-                        ? Queue<Body>
-                        : T extends _AnalyticsEngineDataset
-                          ? AnalyticsEngineDataset
-                          : T extends _Pipeline<infer R>
-                            ? Pipeline<R>
-                            : T extends string
-                              ? string
-                              : T extends BrowserRendering
-                                ? Fetcher
-                                : T extends _Ai<infer M>
-                                  ? Ai<M>
-                                  : T extends Self
-                                    ? Service
-                                    : T extends Json<infer T>
-                                      ? T
-                                      : Service;
+    : T extends _Worker<any, infer RPC>
+      ? Service<RPC> & {
+          // cloudflare's Rpc.Provider type loses mapping between properties (jump to definition)
+          // we fix that using Pick to re-connect mappings
+          [property in keyof Pick<
+            RPC,
+            Extract<keyof Rpc.Provider<RPC, "fetch" | "connect">, keyof RPC>
+          >]: Rpc.Provider<RPC, "fetch" | "connect">[property];
+        }
+      : T extends { type: "service" }
+        ? Service
+        : T extends _R2Bucket
+          ? R2Bucket
+          : T extends _AiGateway
+            ? AiGateway
+            : T extends _Hyperdrive
+              ? Hyperdrive
+              : T extends Secret
+                ? string
+                : T extends Assets
+                  ? Service
+                  : T extends _Workflow<infer P>
+                    ? Workflow<P>
+                    : T extends D1DatabaseResource
+                      ? D1Database
+                      : T extends _VectorizeIndex
+                        ? VectorizeIndex
+                        : T extends _Queue<infer Body>
+                          ? Queue<Body>
+                          : T extends _AnalyticsEngineDataset
+                            ? AnalyticsEngineDataset
+                            : T extends _Pipeline<infer R>
+                              ? Pipeline<R>
+                              : T extends string
+                                ? string
+                                : T extends BrowserRendering
+                                  ? Fetcher
+                                  : T extends _Ai<infer M>
+                                    ? Ai<M>
+                                    : T extends Self
+                                      ? Service
+                                      : T extends Json<infer T>
+                                        ? T
+                                        : Service;

--- a/alchemy/src/cloudflare/worker-metadata.ts
+++ b/alchemy/src/cloudflare/worker-metadata.ts
@@ -1,11 +1,18 @@
 import type { Context } from "../context.js";
 import { slugify } from "../util/slugify.js";
-import { Self, type Bindings, type WorkerBindingSpec } from "./bindings.js";
-import type { DurableObjectNamespace } from "./durable-object-namespace.js";
+import {
+  Self,
+  type Bindings,
+  type WorkerBindingDurableObjectNamespace,
+  type WorkerBindingSpec,
+} from "./bindings.js";
+import {
+  isDurableObjectNamespace,
+  type DurableObjectNamespace,
+} from "./durable-object-namespace.js";
 import { createAssetConfig, type AssetUploadResult } from "./worker-assets.js";
 import type { SingleStepMigration } from "./worker-migration.js";
 import type { AssetsConfig, Worker, WorkerProps } from "./worker.js";
-import type { Workflow } from "./workflow.js";
 
 /**
  * Metadata returned by Cloudflare API for a worker script
@@ -186,7 +193,8 @@ export interface WorkerMetadata {
 
 export async function prepareWorkerMetadata<B extends Bindings>(
   ctx: Context<Worker<B>>,
-  oldBindings: Bindings | undefined,
+  oldBindings: WorkerBindingSpec[] | undefined,
+  oldTags: string[] | undefined,
   props: WorkerProps & {
     compatibilityDate: string;
     compatibilityFlags: string[];
@@ -194,20 +202,75 @@ export async function prepareWorkerMetadata<B extends Bindings>(
   },
   assetUploadResult?: AssetUploadResult,
 ): Promise<WorkerMetadata> {
-  const deletedClasses = Object.entries(oldBindings ?? {})
-    .filter(([key]) => !props.bindings?.[key])
-    .flatMap(([_, binding]) => {
-      if (
-        binding &&
-        typeof binding === "object" &&
-        binding.type === "durable_object_namespace" &&
-        (binding.scriptName === undefined ||
-          binding.scriptName === props.workerName)
-      ) {
-        return [binding.className];
+  // we use Cloudflare Worker tags to store a mapping between Alchemy's stable identifier and the binding name
+  // e.g.
+  // {
+  //   BINDING_NAME: new DurableObjectNamespace("stable-id")
+  // }
+  // will be stored as alchemy:do:stable-id:BINDING_NAME
+  // TODO(sam): should we base64 encode to ensure no `:` collision risk?
+  const bindingNameToStableId = Object.fromEntries(
+    oldTags?.flatMap((tag) => {
+      // alchemy:do:{stableId}:{bindingName}
+      if (tag.startsWith("alchemy:do:")) {
+        const [, , stableId, bindingName] = tag.split(":");
+        return [[bindingName, stableId]];
       }
       return [];
-    });
+    }) ?? [],
+  );
+
+  const deletedClasses = oldBindings?.flatMap((oldBinding) => {
+    if (
+      oldBinding.type === "durable_object_namespace" &&
+      (oldBinding.script_name === undefined ||
+        // if this a cross-script binding, we don't need to do migrations in the remote worker
+        oldBinding.script_name === props.workerName)
+    ) {
+      // reverse the stableId from our tag-encoded metadata
+      const stableId = bindingNameToStableId[oldBinding.name];
+      if (stableId) {
+        if (props.bindings === undefined) {
+          // all classes are deleted
+          return [oldBinding.class_name];
+        }
+        // we created this worker on latest version, we can now intelligently determine migrations
+
+        // try and find the DO binding by stable id
+        const object = Object.values(props.bindings).find(
+          (binding): binding is DurableObjectNamespace<any> =>
+            isDurableObjectNamespace(binding) && binding.id === stableId,
+        );
+        if (object) {
+          // we found the corresponding object, it should not be deleted
+          return [];
+        } else {
+          // it was not found, we will now delete it
+          return [oldBinding.class_name];
+        }
+      } else {
+        // ok, we were unable to find the stableId, this worker must have been created by an old alchemy or outside of alchemy
+        // let's now apply a herusitic based on binding name (assume binding name is consistent)
+        // TODO(sam): this has a chance of being wrong, is that OK? Users should be encouraged to upgrade alchemy version and re-deploy
+        const object = props.bindings?.[oldBinding.name];
+        if (object && isDurableObjectNamespace(object)) {
+          if (object.className === oldBinding.class_name) {
+            // this is relatively safe to assume is the right match, do not delete
+            return [];
+          } else {
+            // the class name has changed, this could indicate one of:
+            // 1. the user has changed the class name and we should migrate it
+            // 2. the user deleted the DO a long time ago and this is unrelated (we should just create a new one)
+            return [oldBinding.class_name];
+          }
+        } else {
+          // we didn't find it, so delete it
+          return [oldBinding.class_name];
+        }
+      }
+    }
+    return [];
+  });
 
   // Prepare metadata with bindings
   const meta: WorkerMetadata = {
@@ -218,11 +281,22 @@ export async function prepareWorkerMetadata<B extends Bindings>(
       enabled: props.observability?.enabled !== false,
     },
     // TODO(sam): base64 encode instead? 0 collision risk vs readability.
-    tags: [`alchemy:id:${slugify(ctx.fqn)}`],
+    tags: [
+      `alchemy:id:${slugify(ctx.fqn)}`,
+      // encode a mapping table of Durable Object stable ID -> binding name
+      // we use this to reliably compute class migrations based on server-side state
+      ...Object.entries(props.bindings ?? {}).flatMap(
+        ([bindingName, binding]) =>
+          isDurableObjectNamespace(binding)
+            ? // TODO(sam): base64 encode if contains `:`?
+              [`alchemy:do:${binding.id}:${bindingName}`]
+            : [],
+      ),
+    ],
     migrations: {
       new_classes: props.migrations?.new_classes ?? [],
       deleted_classes: [
-        ...deletedClasses,
+        ...(deletedClasses ?? []),
         ...(props.migrations?.deleted_classes ?? []),
       ],
       renamed_classes: props.migrations?.renamed_classes ?? [],
@@ -303,7 +377,7 @@ export async function prepareWorkerMetadata<B extends Bindings>(
         binding.scriptName === props.workerName
       ) {
         // we do not need configure class migrations for cross-script bindings
-        configureClassMigration(binding, binding.id, binding.className);
+        configureClassMigration(bindingName, binding);
       }
     } else if (binding.type === "r2_bucket") {
       meta.bindings.push({
@@ -393,29 +467,46 @@ export async function prepareWorkerMetadata<B extends Bindings>(
   }
 
   function configureClassMigration(
-    binding: DurableObjectNamespace<any> | Workflow,
-    stableId: string,
-    className: string,
+    bindingName: string,
+    newBinding: DurableObjectNamespace<any>,
   ) {
-    const oldBinding: DurableObjectNamespace<any> | Workflow | undefined =
-      Object.values(oldBindings ?? {})
-        ?.filter(
-          (b) =>
-            typeof b === "object" &&
-            (b.type === "durable_object_namespace" || b.type === "workflow"),
-        )
-        ?.find((b) => b.id === stableId);
-
-    if (!oldBinding) {
-      if (binding.type === "durable_object_namespace" && binding.sqlite) {
-        meta.migrations!.new_sqlite_classes!.push(className);
-      } else {
-        meta.migrations!.new_classes!.push(className);
+    let prevBinding: WorkerBindingDurableObjectNamespace | undefined;
+    if (oldBindings) {
+      // try and find the prev binding for this
+      for (const oldBinding of oldBindings) {
+        if (oldBinding.type === "durable_object_namespace") {
+          const stableId = bindingNameToStableId[oldBinding.name];
+          if (stableId) {
+            // (happy case)
+            // great, this Worker was created with Alchemy and we can map stable ids
+            if (stableId === newBinding.id) {
+              prevBinding = oldBinding;
+              break;
+            }
+          } else {
+            // (heuristic case)
+            // we were unable to find the stableId, this Worker must not have been created with Alchemy
+            // now, try and resolve by assuming 1:1 binding name correspondence
+            // WARNING: this is an imperfect assumption. Users are advised to upgrade alchemy and re-deploy
+            if (oldBinding.name === bindingName) {
+              prevBinding = oldBinding;
+              break;
+            }
+          }
+        }
       }
-    } else if (oldBinding.className !== className) {
+    }
+
+    if (!prevBinding) {
+      if (newBinding.sqlite) {
+        meta.migrations!.new_sqlite_classes!.push(newBinding.className);
+      } else {
+        meta.migrations!.new_classes!.push(newBinding.className);
+      }
+    } else if (prevBinding.class_name !== newBinding.className) {
       meta.migrations!.renamed_classes!.push({
-        from: oldBinding.className,
-        to: className,
+        from: prevBinding.class_name,
+        to: newBinding.className,
       });
     }
   }

--- a/alchemy/src/cloudflare/worker.ts
+++ b/alchemy/src/cloudflare/worker.ts
@@ -485,6 +485,7 @@ export function Worker<const B extends Bindings>(
 ): Promise<Worker<B>> {
   const [id, meta, props] =
     args.length === 2 ? [args[0], undefined, args[1]] : args;
+
   if (("fetch" in props && props.fetch) || ("queue" in props && props.queue)) {
     const scope = Scope.current;
 

--- a/alchemy/src/cloudflare/worker.ts
+++ b/alchemy/src/cloudflare/worker.ts
@@ -18,7 +18,12 @@ import {
   createCloudflareApi,
 } from "./api.js";
 import type { Assets } from "./assets.js";
-import { type Binding, type Bindings, Json } from "./bindings.js";
+import {
+  type Binding,
+  type Bindings,
+  Json,
+  type WorkerBindingSpec,
+} from "./bindings.js";
 import type { Bound } from "./bound.js";
 import { isBucket } from "./bucket.js";
 import { bundleWorkerScript } from "./bundle/bundle-worker.js";
@@ -697,7 +702,11 @@ export const _Worker = Resource(
     const compatibilityFlags = props.compatibilityFlags ?? [];
 
     const uploadWorkerScript = async (props: WorkerProps<B>) => {
-      const oldBindings = await this.get<Bindings>("bindings");
+      const [oldBindings, oldMetadata] = await Promise.all([
+        getWorkerBindings(api, workerName),
+        getWorkerScriptMetadata(api, workerName),
+      ]);
+      const oldTags = oldMetadata?.default_environment?.script?.tags;
 
       // Get the script content - either from props.script, or by bundling
       const scriptContent =
@@ -744,6 +753,7 @@ export const _Worker = Resource(
       const scriptMetadata = await prepareWorkerMetadata(
         this,
         oldBindings,
+        oldTags,
         {
           ...props,
           compatibilityDate,
@@ -754,9 +764,6 @@ export const _Worker = Resource(
       );
 
       await putWorker(api, workerName, scriptContent, scriptMetadata);
-
-      // TODO: it is less than ideal that this can fail, resulting in state problem
-      await this.set("bindings", props.bindings);
 
       for (const workflow of workflowsBindings) {
         await upsertWorkflow(api, {
@@ -1125,34 +1132,49 @@ export async function getWorkerScriptMetadata(
   return ((await response.json()) as any).result as WorkerScriptMetadata;
 }
 
-export async function _getWorkerBindings(
-  api: CloudflareApi,
-  workerName: string,
-  environment = "production",
-) {
+async function getWorkerBindings(api: CloudflareApi, workerName: string) {
+  // Fetch the bindings for a worker by calling the Cloudflare API endpoint:
+  // GET /accounts/:account_id/workers/scripts/:script_name/bindings
+  // See: https://developers.cloudflare.com/api/resources/workers/subresources/scripts/subresources/script_and_version_settings/methods/get/
   const response = await api.get(
-    `/accounts/${api.accountId}/workers/services/${workerName}/environments/${environment}/bindings`,
-    {
-      headers: {
-        Authorization: `Bearer ${process.env.CLOUDFLARE_API_TOKEN}`,
-        "Content-Type": "application/json",
-      },
-    },
+    `/accounts/${api.accountId}/workers/scripts/${workerName}/settings`,
   );
-
   if (response.status === 404) {
     return undefined;
   }
-
   if (!response.ok) {
     throw new Error(
-      `Failed to fetch bindings: ${response.status} ${response.statusText}`,
+      `Error getting worker bindings: ${response.status} ${response.statusText}`,
     );
   }
-
-  const data: any = await response.json();
-
-  return data.result;
+  // The result is an object with a "result" property containing the bindings array
+  const { result, success, errors } = (await response.json()) as {
+    result: {
+      bindings: WorkerBindingSpec[];
+      compatibility_date: string;
+      compatibility_flags: string[];
+      [key: string]: any;
+    };
+    success: boolean;
+    errors: Array<{
+      code: number;
+      message: string;
+      documentation_url: string;
+      [key: string]: any;
+    }>;
+    messages: Array<{
+      code: number;
+      message: string;
+      documentation_url: string;
+      [key: string]: any;
+    }>;
+  };
+  if (!success) {
+    throw new Error(
+      `Error getting worker bindings: ${response.status} ${response.statusText}\nErrors:\n${errors.map((e) => `- [${e.code}] ${e.message} (${e.documentation_url})`).join("\n")}`,
+    );
+  }
+  return result.bindings;
 }
 
 /**

--- a/alchemy/src/cloudflare/worker.ts
+++ b/alchemy/src/cloudflare/worker.ts
@@ -8,6 +8,7 @@ import { bootstrapPlugin } from "../runtime/plugin.js";
 import { Scope } from "../scope.js";
 import { Secret, secret } from "../secret.js";
 import { serializeScope } from "../serde.js";
+import type { type } from "../type.js";
 import { withExponentialBackoff } from "../util/retry.js";
 import { slugify } from "../util/slugify.js";
 import { CloudflareApiError, handleApiError } from "./api-error.js";
@@ -94,8 +95,10 @@ export interface AssetsConfig {
   serve_directly?: boolean;
 }
 
-export interface BaseWorkerProps<B extends Bindings | undefined = undefined>
-  extends CloudflareApiOptions {
+export interface BaseWorkerProps<
+  B extends Bindings | undefined = undefined,
+  RPC extends Rpc.WorkerEntrypointBranded = Rpc.WorkerEntrypointBranded,
+> extends CloudflareApiOptions {
   /**
    * Bundle options when using entryPoint
    *
@@ -202,17 +205,27 @@ export interface BaseWorkerProps<B extends Bindings | undefined = undefined>
    * Can include queues, streams, or other event sources.
    */
   eventSources?: EventSource[];
+
+  /**
+   * The RPC class to use for the worker.
+   *
+   * This is only used when using the rpc property.
+   */
+  rpc?: (new (...args: any[]) => RPC) | type<RPC>;
 }
 
-export interface InlineWorkerProps<B extends Bindings | undefined = Bindings>
-  extends BaseWorkerProps<B> {
+export interface InlineWorkerProps<
+  B extends Bindings | undefined = Bindings,
+  RPC extends Rpc.WorkerEntrypointBranded = Rpc.WorkerEntrypointBranded,
+> extends BaseWorkerProps<B, RPC> {
   script: string;
   entrypoint?: undefined;
 }
 
 export interface EntrypointWorkerProps<
   B extends Bindings | undefined = Bindings,
-> extends BaseWorkerProps<B> {
+  RPC extends Rpc.WorkerEntrypointBranded = Rpc.WorkerEntrypointBranded,
+> extends BaseWorkerProps<B, RPC> {
   entrypoint: string;
   script?: undefined;
 }
@@ -220,9 +233,10 @@ export interface EntrypointWorkerProps<
 /**
  * Properties for creating or updating a Worker
  */
-export type WorkerProps<B extends Bindings | undefined = Bindings> =
-  | InlineWorkerProps<B>
-  | EntrypointWorkerProps<B>;
+export type WorkerProps<
+  B extends Bindings | undefined = Bindings,
+  RPC extends Rpc.WorkerEntrypointBranded = Rpc.WorkerEntrypointBranded,
+> = InlineWorkerProps<B, RPC> | EntrypointWorkerProps<B, RPC>;
 
 export type FetchWorkerProps<
   B extends Bindings = Bindings,
@@ -270,65 +284,70 @@ export function isWorker(resource: Resource): resource is Worker<any> {
 /**
  * Output returned after Worker creation/update
  */
-export type Worker<B extends Bindings | undefined = Bindings | undefined> =
-  Resource<"cloudflare::Worker"> &
-    Omit<WorkerProps<B>, "url" | "script"> &
-    globalThis.Service & {
-      type: "service";
+export type Worker<
+  B extends Bindings | undefined = Bindings | undefined,
+  RPC extends Rpc.WorkerEntrypointBranded = Rpc.WorkerEntrypointBranded,
+> = Resource<"cloudflare::Worker"> &
+  Omit<WorkerProps<B>, "url" | "script"> &
+  globalThis.Service & {
+    /** @internal phantom property */
+    __rpc__?: RPC;
 
-      /**
-       * The ID of the worker
-       */
-      id: string;
+    type: "service";
 
-      /**
-       * The name of the worker
-       */
-      name: string;
+    /**
+     * The ID of the worker
+     */
+    id: string;
 
-      /**
-       * Time at which the worker was created
-       */
-      createdAt: number;
+    /**
+     * The name of the worker
+     */
+    name: string;
 
-      /**
-       * Time at which the worker was last updated
-       */
-      updatedAt: number;
+    /**
+     * Time at which the worker was created
+     */
+    createdAt: number;
 
-      /**
-       * The worker's URL if enabled
-       * Format: {name}.{subdomain}.workers.dev
-       */
-      url?: string;
+    /**
+     * Time at which the worker was last updated
+     */
+    updatedAt: number;
 
-      /**
-       * The bindings that were created
-       */
-      bindings: B;
+    /**
+     * The worker's URL if enabled
+     * Format: {name}.{subdomain}.workers.dev
+     */
+    url?: string;
 
-      /**
-       * Configuration for static assets
-       */
-      assets?: AssetsConfig;
+    /**
+     * The bindings that were created
+     */
+    bindings: B;
 
-      // phantom property (for typeof myWorker.Env)
-      Env: B extends Bindings
-        ? {
-            [bindingName in keyof B]: Bound<B[bindingName]>;
-          }
-        : undefined;
+    /**
+     * Configuration for static assets
+     */
+    assets?: AssetsConfig;
 
-      /**
-       * The compatibility date for the worker
-       */
-      compatibilityDate: string;
+    // phantom property (for typeof myWorker.Env)
+    Env: B extends Bindings
+      ? {
+          [bindingName in keyof B]: Bound<B[bindingName]>;
+        }
+      : undefined;
 
-      /**
-       * The compatibility flags for the worker
-       */
-      compatibilityFlags: string[];
-    };
+    /**
+     * The compatibility date for the worker
+     */
+    compatibilityDate: string;
+
+    /**
+     * The compatibility flags for the worker
+     */
+    compatibilityFlags: string[];
+  };
 
 /**
  * A Cloudflare Worker is a serverless function that can be deployed to the Cloudflare network.
@@ -445,10 +464,10 @@ export type Worker<B extends Bindings | undefined = Bindings | undefined> =
  * @see
  * https://developers.cloudflare.com/workers/
  */
-export function Worker<const B extends Bindings>(
-  id: string,
-  props: WorkerProps<B>,
-): Promise<Worker<B>>;
+export function Worker<
+  const B extends Bindings,
+  RPC extends Rpc.WorkerEntrypointBranded,
+>(id: string, props: WorkerProps<B, RPC>): Promise<Worker<B, RPC>>;
 export function Worker<const B extends Bindings, const E extends EventSource[]>(
   id: string,
   meta: ImportMeta,

--- a/alchemy/src/cloudflare/workflow.ts
+++ b/alchemy/src/cloudflare/workflow.ts
@@ -1,5 +1,6 @@
 import { handleApiError } from "./api-error.js";
 import type { CloudflareApi } from "./api.js";
+import type { Binding } from "./bindings.js";
 
 export interface WorkflowProps {
   /**
@@ -18,6 +19,10 @@ export interface WorkflowProps {
    * @default - workflowName if provided, otherwise id
    */
   className?: string;
+}
+
+export function isWorkflow(binding: Binding): binding is Workflow {
+  return typeof binding === "object" && binding.type === "workflow";
 }
 
 export class Workflow<PARAMS = unknown> {

--- a/alchemy/src/cloudflare/wrangler.json.ts
+++ b/alchemy/src/cloudflare/wrangler.json.ts
@@ -17,7 +17,7 @@ export interface WranglerJsonProps {
   /**
    * The worker to generate the wrangler.json file for
    */
-  worker: Worker;
+  worker: Worker<any>;
   /**
    * Path to write the wrangler.json file to
    *
@@ -393,6 +393,10 @@ function processBindings(
   }
   // Process each binding
   for (const [bindingName, binding] of Object.entries(bindings)) {
+    if (typeof binding === "function") {
+      // this is only reachable in the
+      throw new Error(`Invalid binding ${bindingName} is a function`);
+    }
     if (typeof binding === "string") {
       // Plain text binding - add to vars
       if (!spec.vars) {

--- a/alchemy/src/index.ts
+++ b/alchemy/src/index.ts
@@ -5,6 +5,7 @@ export type * from "./scope.js";
 export * from "./secret.js";
 export * from "./serde.js";
 export * from "./state.js";
+export * from "./type.js";
 export * from "./util/ignore.js";
 
 import { alchemy } from "./alchemy.js";

--- a/alchemy/src/type.ts
+++ b/alchemy/src/type.ts
@@ -1,0 +1,9 @@
+export type type<T> = typeof type<T>;
+/**
+ * Used to construct type-level alias information.
+ */
+export const type = ((): any => {
+  throw new Error("Should never be called, purely for type-level aliasing");
+}) as (<T>() => T) &
+  // we also want to make this a "class type" so that syntax highlighting is always as a type
+  (new <T>() => T);

--- a/examples/cloudflare-worker/alchemy.run.ts
+++ b/examples/cloudflare-worker/alchemy.run.ts
@@ -7,9 +7,9 @@ import {
   Workflow,
   WranglerJson,
 } from "../../alchemy/src/cloudflare/index.js";
-import alchemy from "../../alchemy/src/index.js";
+import alchemy, { type } from "../../alchemy/src/index.js";
 import type { HelloWorldDO } from "./src/do.js";
-import { MyRPC } from "./src/rpc.js";
+import type MyRPC from "./src/rpc.js";
 
 const BRANCH_PREFIX = process.env.BRANCH_PREFIX ?? "";
 const app = await alchemy("cloudflare-worker", {
@@ -31,7 +31,7 @@ export const queue = await Queue<{
 
 export const rpc = await Worker(`cloudflare-worker-rpc${BRANCH_PREFIX}`, {
   entrypoint: "./src/rpc.ts",
-  rpc: MyRPC,
+  rpc: type<MyRPC>,
 });
 
 export const worker = await Worker(`cloudflare-worker-worker${BRANCH_PREFIX}`, {

--- a/examples/cloudflare-worker/alchemy.run.ts
+++ b/examples/cloudflare-worker/alchemy.run.ts
@@ -9,6 +9,7 @@ import {
 } from "../../alchemy/src/cloudflare/index.js";
 import alchemy from "../../alchemy/src/index.js";
 import type { HelloWorldDO } from "./src/do.js";
+import { MyRPC } from "./src/rpc.js";
 
 const BRANCH_PREFIX = process.env.BRANCH_PREFIX ?? "";
 const app = await alchemy("cloudflare-worker", {
@@ -28,6 +29,11 @@ export const queue = await Queue<{
   adopt: true,
 });
 
+export const rpc = await Worker(`cloudflare-worker-rpc${BRANCH_PREFIX}`, {
+  entrypoint: "./src/rpc.ts",
+  rpc: MyRPC,
+});
+
 export const worker = await Worker(`cloudflare-worker-worker${BRANCH_PREFIX}`, {
   entrypoint: "./src/worker.ts",
   bindings: {
@@ -44,6 +50,7 @@ export const worker = await Worker(`cloudflare-worker-worker${BRANCH_PREFIX}`, {
       className: "HelloWorldDO",
       sqlite: true,
     }),
+    RPC: rpc,
   },
   url: true,
   eventSources: [queue],

--- a/examples/cloudflare-worker/src/rpc.ts
+++ b/examples/cloudflare-worker/src/rpc.ts
@@ -1,0 +1,10 @@
+import { WorkerEntrypoint } from "cloudflare:workers";
+
+export class MyRPC extends WorkerEntrypoint {
+  /**
+   * Hello world
+   */
+  async hello(name: string) {
+    return `Hello, ${name}!`;
+  }
+}

--- a/examples/cloudflare-worker/src/rpc.ts
+++ b/examples/cloudflare-worker/src/rpc.ts
@@ -1,10 +1,13 @@
 import { WorkerEntrypoint } from "cloudflare:workers";
 
-export class MyRPC extends WorkerEntrypoint {
+export default class MyRPC extends WorkerEntrypoint {
   /**
    * Hello world
    */
   async hello(name: string) {
     return `Hello, ${name}!`;
+  }
+  async fetch() {
+    return new Response("Hello from Worker B");
   }
 }

--- a/examples/cloudflare-worker/src/worker.ts
+++ b/examples/cloudflare-worker/src/worker.ts
@@ -18,6 +18,8 @@ export default {
     }
     await obj.fetch(new Request("https://example.com"));
 
+    await env.RPC.hello("John Doe");
+
     return new Response("Ok");
   },
   async queue(batch: typeof queue.Batch, _env: typeof worker.Env) {


### PR DESCRIPTION
```ts
export const rpc = await Worker(`cloudflare-worker-rpc${BRANCH_PREFIX}`, {
  entrypoint: "./src/rpc.ts",
  rpc: MyRPC,
  // or use a type alias if MyRPC can't be imported (e.g. it imports clouflare:workeres)
  // rpc: type<MyRPC> 
});

export const worker = await Worker(`cloudflare-worker-worker${BRANCH_PREFIX}`, {
    RPC: rpc,
  },
});
````