### PR TITLE
Sam/workflow cross

### DIFF
--- a/alchemy-web/.vitepress/config.mts
+++ b/alchemy-web/.vitepress/config.mts
@@ -4,9 +4,10 @@ import footnotePlugin from "markdown-it-footnote";
 import path from "path";
 import { defineConfig } from "vitepress";
 import {
-	groupIconMdPlugin,
-	groupIconVitePlugin,
+    groupIconMdPlugin,
+    groupIconVitePlugin,
 } from "vitepress-plugin-group-icons";
+import { parse as parseYaml } from "yaml";
 import { processFrontmatterFiles } from "../../alchemy/src/web/vitepress";
 
 // Imports for OG Image Generation
@@ -280,22 +281,8 @@ export default defineConfig({
 				return result;
 			}
 
-			const frontmatterText = match[1];
-
-			// Parse frontmatter lines
-			frontmatterText.split("\n").forEach((line) => {
-				// Look for "key: value" patterns
-				const colonIndex = line.indexOf(":");
-				if (colonIndex > 0) {
-					const key = line.slice(0, colonIndex).trim();
-					const value = line.slice(colonIndex + 1).trim();
-
-					// Remove quotes if present
-					result[key] = value.replace(/^['"](.*)['"]$/, "$1");
-				}
-			});
-
-			return result;
+			// Parse the YAML frontmatter properly
+			return parseYaml(match[1]) || {};
 		}
 	},
 });

--- a/alchemy-web/docs/concepts/bindings.md
+++ b/alchemy-web/docs/concepts/bindings.md
@@ -60,11 +60,9 @@ export default {
 
 ## Type-Safe Bindings
 
-To make bindings type-safe, create an `env.d.ts` file:
+To make bindings type-safe, create an `env.ts` file:
 
 ```typescript
-/// <reference types="./env.d.ts" />
-
 import type { myWorker } from "./alchemy.run";
 
 export type WorkerEnv = typeof myWorker.Env;
@@ -72,6 +70,15 @@ export type WorkerEnv = typeof myWorker.Env;
 declare module "cloudflare:workers" {
   namespace Cloudflare {
     export interface Env extends WorkerEnv {}
+  }
+}
+```
+
+Register `env.ts` in your `tsconfig.json`'s `types`.
+```json
+{
+  "compilerOptions": {
+    "types": ["@cloudflare/workers-types", "./src/env.ts"]
   }
 }
 ```
@@ -89,6 +96,13 @@ export default {
     return new Response(`Value: ${value}`);
   }
 };
+```
+
+Or use the global import:
+```ts
+import { env } from "cloudflare:workers";
+
+await env.MY_KV.get("key")
 ```
 
 ## Binding Types

--- a/alchemy-web/docs/guides/cloudflare-durable-objects.md
+++ b/alchemy-web/docs/guides/cloudflare-durable-objects.md
@@ -124,4 +124,181 @@ declare module "cloudflare:workers" {
 ```
 
 > [!TIP]
-> See the [Bindings](../concepts/bindings.md) for more information. 
+> See the [Bindings](../concepts/bindings.md) for more information.
+
+## Cross-Script Durable Object Binding
+
+You can share Durable Objects across multiple Workers, allowing one Worker to access Durable Object instances defined in another Worker. This enables powerful patterns for building distributed systems where different Workers can coordinate through shared state.
+
+### Method 1: Using re-exported syntax
+
+You can directly reference the Durable Object binding from the provider Worker:
+
+```ts
+import { Worker, DurableObjectNamespace } from "alchemy/cloudflare";
+
+// Create the provider Worker with the Durable Object
+const host = await Worker("Host", {
+  entrypoint: "./do-provider.ts", 
+  bindings: {
+    SHARED_COUNTER: new DurableObjectNamespace("shared-counter", {
+      className: "SharedCounter",
+      sqlite: true,
+    }),
+  },
+});
+
+// Create the client Worker using the provider's Durable Object binding directly
+const client = await Worker("client", {
+  entrypoint: "./client-worker.ts",
+  bindings: {
+    // Re-use the exact same Durable Object binding from the provider worker
+    SHARED_COUNTER: host.bindings.SHARED_COUNTER,
+  },
+});
+```
+
+### Method 2: Using `scriptName` directly
+
+Alternatively, when creating a Durable Object binding in a client Worker, you can reference a Durable Object defined in another Worker by specifying the `scriptName`:
+
+```ts
+import { Worker, DurableObjectNamespace } from "alchemy/cloudflare";
+
+const hostWorkerName = "host"
+
+const durableObject = new DurableObjectNamespace("shared-counter", {
+  className: "SharedCounter",
+  scriptName: hostWorkerName,
+  sqlite: true,
+});
+
+// First, create the Worker that defines the Durable Object
+const host = await Worker("host", {
+  entrypoint: "./do-provider.ts",
+  name: hostWorkerName,
+  bindings: {
+    // Define the Durable Object in this worker
+    SHARED_COUNTER: durableObject,
+  },
+});
+
+// Then, create a client Worker that uses the cross-script Durable Object
+const client = await Worker("client", {
+  entrypoint: "./client-worker.ts",
+  bindings: {
+    // Reference the same Durable Object but specify which script it comes from
+    SHARED_COUNTER: durableObject,
+  },
+});
+```
+
+### Durable Object Provider Implementation
+
+The provider Worker implements the Durable Object class and optionally provides endpoints:
+
+```ts
+// do-provider.ts
+export class SharedCounter {
+  private state: DurableObjectState;
+  private counter: number;
+
+  constructor(state: DurableObjectState, env: any) {
+    this.state = state;
+    this.counter = 0;
+  }
+
+  async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+    
+    // Retrieve current count from durable storage
+    this.counter = await this.state.storage.get("count") || 0;
+
+    if (url.pathname === "/increment") {
+      this.counter++;
+      await this.state.storage.put("count", this.counter);
+      
+      return Response.json({
+        action: "increment",
+        counter: this.counter,
+        worker: "do-provider"
+      });
+    }
+
+    if (url.pathname === "/get") {
+      return Response.json({
+        action: "get", 
+        counter: this.counter,
+        worker: "do-provider"
+      });
+    }
+
+    return new Response("SharedCounter DO is running!", { status: 200 });
+  }
+}
+
+export default {
+  async fetch(request: Request): Promise<Response> {
+    return new Response('DO Provider Worker is running!');
+  }
+};
+```
+
+### Client Worker Implementation
+
+The client Worker can access the shared Durable Object without implementing the Durable Object class:
+
+```ts
+// client-worker.ts
+import { env } from "cloudflare:workers";
+
+export default {
+  async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+    
+    if (url.pathname === '/increment') {
+      try {
+        // Access the Durable Object defined in another worker
+        const id = env.SHARED_COUNTER.idFromName('global-counter');
+        const stub = env.SHARED_COUNTER.get(id);
+        const response = await stub.fetch(new Request('https://example.com/increment'));
+        const data = await response.json();
+        
+        return Response.json({
+          success: true,
+          clientWorker: 'client-worker',
+          result: data,
+          crossScriptWorking: true
+        });
+      } catch (error) {
+        return Response.json({
+          error: error.message,
+          crossScriptWorking: false
+        }, { status: 500 });
+      }
+    }
+
+    if (url.pathname === '/get') {
+      try {
+        // Get the current counter value
+        const id = env.SHARED_COUNTER.idFromName('global-counter');
+        const stub = env.SHARED_COUNTER.get(id);
+        const response = await stub.fetch(new Request('https://example.com/get'));
+        const data = await response.json();
+        
+        return Response.json({
+          success: true,
+          clientWorker: 'client-worker',
+          result: data
+        });
+      } catch (error) {
+        return Response.json({
+          error: error.message
+        }, { status: 500 });
+      }
+    }
+
+    return new Response('Client Worker is running!');
+  }
+};
+```

--- a/alchemy-web/docs/guides/cloudflare-vitejs.md
+++ b/alchemy-web/docs/guides/cloudflare-vitejs.md
@@ -1,5 +1,5 @@
 ---
-order: 1
+order: 1.5
 title: Vite.js
 description: Step-by-step guide to deploying Vite.js React applications with API endpoints to Cloudflare Workers using Alchemy's Infrastructure-as-Code approach.
 ---

--- a/alchemy-web/docs/guides/cloudflare-worker.md
+++ b/alchemy-web/docs/guides/cloudflare-worker.md
@@ -1,0 +1,189 @@
+---
+order: 1
+title: Worker
+description: Deploy serverless functions at the edge with Cloudflare Workers. Learn how to build fast, scalable applications with Alchemy's Cloudflare Worker resources.
+---
+
+# Cloudflare Workers
+
+Alchemy provides comprehensive support for Cloudflare Workers, enabling you to deploy serverless functions at the edge with powerful features like Durable Objects and Workflows.
+
+## Basic Worker
+
+Create a simple Cloudflare Worker with Alchemy:
+
+```ts
+import { Worker } from "alchemy/cloudflare";
+
+export const worker = await Worker("ApiWorker", {
+  name: "my-api",
+  entrypoint: "./src/worker.ts",
+  url: true, // Enable workers.dev subdomain
+});
+```
+
+Your worker script (`./src/worker.ts`):
+
+```ts
+export default {
+  async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+    
+    if (url.pathname === "/hello") {
+      return Response.json({ 
+        message: "Hello from the edge!",
+        location: request.cf?.colo 
+      });
+    }
+    
+    return new Response("Not Found", { status: 404 });
+  },
+};
+```
+
+## Environment Variables
+
+Configure environment variables for your workers:
+
+```ts
+export const worker = await Worker("ApiWorker", {
+  name: "my-api",
+  entrypoint: "./src/worker.ts",
+  env: {
+    API_KEY: "your-secret-key",
+    DEBUG: "true",
+  },
+});
+```
+
+
+## Durable Objects
+
+Add persistent state and coordination to your workers with Durable Objects:
+
+```ts
+import { Worker, DurableObjectNamespace } from "alchemy/cloudflare";
+
+const worker = await Worker("CounterApp", {
+  entrypoint: "./worker.ts",
+  bindings: {
+    COUNTER: new DurableObjectNamespace("counter", {
+      className: "Counter",
+      sqlite: true,
+    }),
+  },
+});
+
+// In your worker.ts
+export class Counter {
+  constructor(state, env) {
+    this.state = state;
+  }
+
+  async fetch(request) {
+    let count = await this.state.storage.get("count") || 0;
+    count++;
+    await this.state.storage.put("count", count);
+    return Response.json({ count });
+  }
+}
+```
+
+[Learn more about Durable Objects →](./cloudflare-durable-objects.md)
+
+## Workflows
+
+Orchestrate long-running, complex processes with Cloudflare Workflows:
+
+```ts
+import { Worker, Workflow } from "alchemy/cloudflare";
+
+const worker = await Worker("OrderProcessor", {
+  entrypoint: "./worker.ts", 
+  bindings: {
+    ORDER_WORKFLOW: new Workflow("order-processor", {
+      className: "OrderProcessor",
+      workflowName: "process-order-workflow",
+    }),
+  },
+});
+
+// In your worker.ts
+export class OrderProcessor {
+  async run(event, step) {
+    const payment = await step.do("process-payment", async () => {
+      return { success: true, transactionId: "tx_123" };
+    });
+    
+    const shipping = await step.do("schedule-shipping", async () => {
+      return { trackingNumber: "1Z999AA1234567890" };
+    });
+    
+    return { payment, shipping };
+  }
+}
+```
+
+[Learn more about Workflows →](./cloudflare-workflows.md)
+
+## Bindings
+
+Bindings connect your Workers to other resources like KV namespaces, Durable Objects, and environment variables. They provide type-safe access to external resources within your worker code:
+
+```ts
+import { Worker, KVNamespace } from "alchemy/cloudflare";
+
+// Create resources
+const myKV = await KVNamespace("UserSessions", {
+  title: "user-sessions"
+});
+
+// Bind resources to your worker
+const worker = await Worker("ApiWorker", {
+  name: "my-api",
+  entrypoint: "./src/worker.ts",
+  bindings: {
+    USER_SESSIONS: myKV,        // KV namespace binding
+    API_KEY: "secret-key",      // Environment variable
+    DEBUG_MODE: true,           // Boolean value
+  },
+});
+```
+
+Access bindings in your worker code:
+
+```ts
+// src/worker.ts
+import { env } from "cloudflare:workers";
+
+export default {
+  async fetch(request: Request): Promise<Response> {
+    // Use bound resources
+    const session = await env.USER_SESSIONS.get("user123");
+    const apiKey = env.API_KEY;
+    
+    return Response.json({ session, debug: env.DEBUG_MODE });
+  },
+};
+```
+
+[Learn more about Bindings →](../concepts/bindings.md)
+
+## Type Safety
+
+Configure TypeScript types for your worker environment:
+
+```ts
+// src/env.d.ts
+import type { worker } from "./alchemy.run";
+
+export type WorkerEnv = typeof worker.Env;
+
+declare module "cloudflare:workers" {
+  namespace Cloudflare {
+    export interface Env extends WorkerEnv {}
+  }
+}
+```
+
+This provides full type safety for bindings, environment variables, and Cloudflare-specific APIs.

--- a/alchemy-web/docs/providers/cloudflare/workflow.md
+++ b/alchemy-web/docs/providers/cloudflare/workflow.md
@@ -20,6 +20,20 @@ const workflow = await Workflow("my-workflow", {
 });
 ```
 
+## Use a Workflow Defined in Another Script
+
+Reference a workflow implemented in a different worker script using `scriptName`.
+
+```ts
+import { Workflow } from "alchemy/cloudflare";
+
+const workflow = await Workflow("shared-workflow", {
+  workflowName: "my-workflow",
+  className: "MyWorkflow",
+  scriptName: "shared-worker"
+});
+```
+
 ## Bind to a Worker
 
 Bind a workflow to a Worker to use its functionality.

--- a/alchemy/src/cloudflare/worker-metadata.ts
+++ b/alchemy/src/cloudflare/worker-metadata.ts
@@ -403,8 +403,7 @@ export async function prepareWorkerMetadata<B extends Bindings>(
         name: bindingName,
         workflow_name: binding.workflowName,
         class_name: binding.className,
-        // this should be set if the Workflow is in another script ...
-        // script_name: ??,
+        script_name: binding.scriptName,
       });
       // it's unclear whether this is needed, but it works both ways
       // configureClassMigration(binding, binding.id, binding.className);

--- a/alchemy/src/cloudflare/worker.ts
+++ b/alchemy/src/cloudflare/worker.ts
@@ -58,7 +58,7 @@ import {
 } from "./worker-metadata.ts";
 import type { SingleStepMigration } from "./worker-migration.ts";
 import { WorkerStub, isWorkerStub } from "./worker-stub.ts";
-import { type Workflow, upsertWorkflow } from "./workflow.ts";
+import { Workflow, isWorkflow, upsertWorkflow } from "./workflow.ts";
 
 /**
  * Configuration options for static assets
@@ -391,7 +391,6 @@ export type Worker<
  * const api = await Worker("api", {
  *   name: "api-worker",
  *   entrypoint: "./src/api.ts",
- *   routes: ["api.example.com/*"],
  *   url: true
  * });
  *
@@ -802,11 +801,16 @@ export const _Worker = Resource(
       await putWorker(api, workerName, scriptBundle, scriptMetadata);
 
       for (const workflow of workflowsBindings) {
-        await upsertWorkflow(api, {
-          workflowName: workflow.workflowName,
-          className: workflow.className,
-          scriptName: workflow.scriptName ?? workerName,
-        });
+        if (
+          workflow.scriptName === undefined ||
+          workflow.scriptName === workerName
+        ) {
+          await upsertWorkflow(api, {
+            workflowName: workflow.workflowName,
+            className: workflow.className,
+            scriptName: workflow.scriptName ?? workerName,
+          });
+        }
       }
 
       await Promise.all(
@@ -922,7 +926,13 @@ export const _Worker = Resource(
                   // re-export this binding mapping to the host worker (this worker)
                   scriptName: workerName,
                 })
-              : binding,
+              : isWorkflow(binding) && binding.scriptName === undefined
+                ? new Workflow(binding.id, {
+                    ...binding,
+                    // re-export this binding mapping to the host worker (this worker)
+                    scriptName: workerName,
+                  })
+                : binding,
           ],
         ),
       );

--- a/alchemy/src/cloudflare/worker.ts
+++ b/alchemy/src/cloudflare/worker.ts
@@ -805,7 +805,7 @@ export const _Worker = Resource(
         await upsertWorkflow(api, {
           workflowName: workflow.workflowName,
           className: workflow.className,
-          scriptName: workerName,
+          scriptName: workflow.scriptName ?? workerName,
         });
       }
 

--- a/alchemy/src/cloudflare/workflow.ts
+++ b/alchemy/src/cloudflare/workflow.ts
@@ -19,7 +19,6 @@ export interface WorkflowProps {
    * @default - workflowName if provided, otherwise id
    */
   className?: string;
-
   /**
    * Name of the script containing the workflow implementation
    *

--- a/alchemy/src/cloudflare/workflow.ts
+++ b/alchemy/src/cloudflare/workflow.ts
@@ -19,6 +19,13 @@ export interface WorkflowProps {
    * @default - workflowName if provided, otherwise id
    */
   className?: string;
+
+  /**
+   * Name of the script containing the workflow implementation
+   *
+   * @default - bound worker script
+   */
+  scriptName?: string;
 }
 
 export function isWorkflow(binding: Binding): binding is Workflow {
@@ -36,6 +43,7 @@ export class Workflow<PARAMS = unknown> {
 
   public readonly workflowName: string;
   public readonly className: string;
+  public readonly scriptName?: string;
 
   constructor(
     public readonly id: string,
@@ -43,6 +51,7 @@ export class Workflow<PARAMS = unknown> {
   ) {
     this.workflowName = props.workflowName ?? props.className ?? id;
     this.className = props.className ?? this.workflowName;
+    this.scriptName = props.scriptName;
   }
 }
 

--- a/alchemy/src/cloudflare/wrangler.json.ts
+++ b/alchemy/src/cloudflare/wrangler.json.ts
@@ -264,6 +264,7 @@ export interface WranglerJsonSpec {
     name: string;
     binding: string;
     class_name: string;
+    script_name?: string;
   }[];
 
   /**
@@ -369,7 +370,12 @@ function processBindings(
   const services: { binding: string; service: string; environment?: string }[] =
     [];
   const secrets: string[] = [];
-  const workflows: { name: string; binding: string; class_name: string }[] = [];
+  const workflows: {
+    name: string;
+    binding: string;
+    class_name: string;
+    script_name?: string;
+  }[] = [];
   const d1Databases: {
     binding: string;
     database_id: string;
@@ -484,6 +490,7 @@ function processBindings(
         name: binding.workflowName,
         binding: bindingName,
         class_name: binding.className,
+        script_name: binding.scriptName,
       });
     } else if (binding.type === "d1") {
       d1Databases.push({

--- a/alchemy/src/web/vitepress/process-front-matter-files.ts
+++ b/alchemy/src/web/vitepress/process-front-matter-files.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { parse as parseYaml } from "yaml";
 
 /**
  * Process markdown files with frontmatter to generate navigation items
@@ -56,14 +57,21 @@ export async function processFrontmatterFiles(
         let title;
 
         if (frontmatterMatch) {
-          const frontmatter = frontmatterMatch[1];
-          const orderMatch = frontmatter.match(/order:\s*(\d+)/);
-          if (orderMatch) {
-            order = Number.parseFloat(orderMatch[1]);
+          const frontmatter = parseYaml(frontmatterMatch[1]);
+
+          // Parse order as a number (supports both integers and floats)
+          if (frontmatter.order !== undefined) {
+            if (typeof frontmatter.order !== "number") {
+              throw new Error(
+                `Invalid order field in ${fullPath}: expected number, got ${typeof frontmatter.order}`,
+              );
+            }
+            order = frontmatter.order;
           }
-          const titleMatch = frontmatter.match(/title:\s*(.+)/);
-          if (titleMatch) {
-            title = titleMatch[1].trim();
+
+          // Get title from frontmatter
+          if (frontmatter.title) {
+            title = String(frontmatter.title).trim();
           }
         }
 

--- a/alchemy/test/cloudflare/d1-database.test.ts
+++ b/alchemy/test/cloudflare/d1-database.test.ts
@@ -2,8 +2,10 @@ import { describe, expect } from "bun:test";
 import { alchemy } from "../../src/alchemy.js";
 import { createCloudflareApi } from "../../src/cloudflare/api.js";
 import { D1Database, listDatabases } from "../../src/cloudflare/d1-database.js";
+import { Worker } from "../../src/cloudflare/worker.js";
 import { BRANCH_PREFIX } from "../util.js";
 
+import { destroy } from "../../src/destroy.js";
 import "../../src/test/bun.js";
 
 const test = alchemy.test(import.meta, {
@@ -357,6 +359,119 @@ describe("D1 Database Resource", async () => {
       await alchemy.destroy(scope);
     }
   });
+
+  test("create and test worker with D1 database binding", async (scope) => {
+    const workerName = `${BRANCH_PREFIX}-test-worker-d1`;
+
+    let worker: Worker<{ DATABASE: D1Database }> | undefined;
+    let db: D1Database | undefined;
+
+    try {
+      // Create a D1 database
+      db = await D1Database(`${BRANCH_PREFIX}-test-db`, {
+        name: `${BRANCH_PREFIX}-test-db`,
+        primaryLocationHint: "wnam", // West North America
+      });
+
+      expect(db.id).toBeTruthy();
+      expect(db.name).toEqual(`${BRANCH_PREFIX}-test-db`);
+
+      // Create a worker with the D1 database binding
+      worker = await Worker(workerName, {
+        name: workerName,
+        script: `
+          export default {
+            async fetch(request, env, ctx) {
+              const url = new URL(request.url);
+
+              // Initialize the database with a table and data
+              if (url.pathname === '/init-db') {
+                try {
+                  const db = env.DATABASE;
+
+                  // Create a test table
+                  await db.exec("CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY, name TEXT, email TEXT)");
+
+                  // Insert some test data
+                  await db.exec("INSERT INTO users (name, email) VALUES ('Test User', 'test@example.com')");
+
+                  return new Response('Database initialized successfully!', {
+                    status: 200,
+                    headers: { 'Content-Type': 'text/plain' }
+                  });
+                } catch (error) {
+                  return new Response('Error initializing database: ' + error.message, {
+                    status: 500,
+                    headers: { 'Content-Type': 'text/plain' }
+                  });
+                }
+              }
+
+              // Query data from the database
+              if (url.pathname === '/query-db') {
+                try {
+                  const db = env.DATABASE;
+
+                  // Query the database
+                  const { results } = await db.prepare("SELECT * FROM users").all();
+
+                  return new Response(JSON.stringify({ success: true, data: results }), {
+                    status: 200,
+                    headers: { 'Content-Type': 'application/json' }
+                  });
+                } catch (error) {
+                  return new Response(JSON.stringify({
+                    success: false,
+                    error: error.message
+                  }), {
+                    status: 500,
+                    headers: { 'Content-Type': 'application/json' }
+                  });
+                }
+              }
+
+              return new Response('D1 Database Worker is running!', {
+                status: 200,
+                headers: { 'Content-Type': 'text/plain' }
+              });
+            }
+          };
+        `,
+        format: "esm",
+        url: true, // Enable workers.dev URL to test the worker
+        bindings: {
+          DATABASE: db,
+        },
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+
+      expect(worker.id).toBeTruthy();
+      expect(worker.name).toEqual(workerName);
+      expect(worker.bindings).toBeDefined();
+      expect(worker.bindings!.DATABASE).toBeDefined();
+      expect(worker.bindings!.DATABASE.id).toEqual(db.id);
+      expect(worker.url).toBeTruthy();
+
+      // Initialize the database with a table and data
+      const initResponse = await fetch(`${worker.url}/init-db`);
+      expect(initResponse.status).toEqual(200);
+      const initText = await initResponse.text();
+      expect(initText).toEqual("Database initialized successfully!");
+
+      // Query data from the database
+      const queryResponse = await fetch(`${worker.url}/query-db`);
+      expect(queryResponse.status).toEqual(200);
+      const queryData: any = await queryResponse.json();
+      expect(queryData.success).toEqual(true);
+      expect(queryData.data).toBeArray();
+      expect(queryData.data.length).toBeGreaterThan(0);
+      expect(queryData.data[0].name).toEqual("Test User");
+      expect(queryData.data[0].email).toEqual("test@example.com");
+    } finally {
+      await destroy(scope);
+    }
+  }, 120000); // Increased timeout for D1 database operations
 });
 
 async function assertDatabaseDeleted(database: D1Database) {

--- a/alchemy/test/cloudflare/durable-object.test.ts
+++ b/alchemy/test/cloudflare/durable-object.test.ts
@@ -1,0 +1,778 @@
+import { describe, expect } from "bun:test";
+import { alchemy } from "../../src/alchemy.js";
+import { createCloudflareApi } from "../../src/cloudflare/api.js";
+import { DurableObjectNamespace } from "../../src/cloudflare/durable-object-namespace.js";
+import { Worker } from "../../src/cloudflare/worker.js";
+import { destroy } from "../../src/destroy.js";
+import { BRANCH_PREFIX } from "../util.js";
+
+import "../../src/test/bun.js";
+
+const test = alchemy.test(import.meta, {
+  prefix: BRANCH_PREFIX,
+});
+
+// Create a Cloudflare API client for verification
+const api = await createCloudflareApi();
+
+// Sample ESM worker script with a Durable Object
+const durableObjectWorkerScript = `
+export class Counter {
+  constructor(state, env) {
+    this.state = state;
+    this.env = env;
+    this.counter = 0;
+  }
+
+  async fetch(request) {
+    this.counter++;
+    return new Response('Counter: ' + this.counter, { status: 200 });
+  }
+}
+
+export default {
+  async fetch(request, env, ctx) {
+    // Use the DO binding if needed
+    if (request.url.includes('/counter')) {
+      const id = env.COUNTER.idFromName('default');
+      const stub = env.COUNTER.get(id);
+      return stub.fetch(request);
+    }
+
+    return new Response('Hello with Durable Object!', { status: 200 });
+  }
+};
+`;
+
+// Helper function to check if a worker exists
+async function assertWorkerDoesNotExist(workerName: string) {
+  try {
+    const response = await api.get(
+      `/accounts/${api.accountId}/workers/scripts/${workerName}`,
+    );
+    expect(response.status).toEqual(404);
+  } catch {
+    // 404 is expected, so we can ignore it
+    return;
+  }
+}
+
+describe("Durable Object Namespace", () => {
+  test("create and delete worker with Durable Object binding", async (scope) => {
+    const workerName = `${BRANCH_PREFIX}-test-worker-do-binding-do-1`;
+
+    let worker: Worker | undefined;
+    try {
+      // First create the worker without the DO binding
+      worker = await Worker(workerName, {
+        name: workerName,
+        script: durableObjectWorkerScript,
+        format: "esm",
+        // No bindings yet
+      });
+
+      expect(worker.id).toBeTruthy();
+      expect(worker.name).toEqual(workerName);
+      expect(worker.bindings).toBeEmpty();
+
+      // Create a Durable Object namespace
+      const counterNamespace = new DurableObjectNamespace(
+        "test-counter-namespace",
+        {
+          className: "Counter",
+          scriptName: workerName,
+        },
+      );
+
+      // Update the worker with the DO binding
+      worker = await Worker(workerName, {
+        name: workerName,
+        script: durableObjectWorkerScript,
+        format: "esm",
+        bindings: {
+          COUNTER: counterNamespace,
+        },
+      });
+
+      expect(worker.id).toBeTruthy();
+      expect(worker.name).toEqual(workerName);
+      expect(worker.bindings).toBeDefined();
+    } finally {
+      await destroy(scope);
+      await assertWorkerDoesNotExist(workerName);
+    }
+  });
+
+  test("add environment variables to worker with durable object", async (scope) => {
+    const workerName = `${BRANCH_PREFIX}-test-worker-do-with-env-doenv-1`;
+
+    let worker: Worker | undefined;
+    try {
+      // First create a worker with a Durable Object but no env vars
+      worker = await Worker(workerName, {
+        name: workerName,
+        script: durableObjectWorkerScript,
+        format: "esm",
+      });
+
+      expect(worker.id).toBeTruthy();
+      expect(worker.name).toEqual(workerName);
+
+      // Create a Durable Object namespace
+      const counterNamespace = new DurableObjectNamespace(
+        "test-counter-env-namespace",
+        {
+          className: "Counter",
+          scriptName: workerName,
+        },
+      );
+
+      // Update the worker with the DO binding
+      worker = await Worker(workerName, {
+        name: workerName,
+        script: durableObjectWorkerScript,
+        format: "esm",
+        bindings: {
+          COUNTER: counterNamespace,
+        },
+      });
+
+      // Apply the worker with binding
+      expect(worker.bindings).toBeDefined();
+      expect(worker.env).toBeUndefined();
+
+      // Now update the worker by adding environment variables
+      worker = await Worker(workerName, {
+        name: workerName,
+        script: durableObjectWorkerScript,
+        format: "esm",
+        bindings: {
+          COUNTER: counterNamespace,
+        },
+        env: {
+          API_SECRET: "test-secret-123",
+          DEBUG_MODE: "true",
+        },
+      });
+
+      expect(worker.bindings).toBeDefined();
+      expect(worker.env).toBeDefined();
+      expect(worker.env?.API_SECRET).toEqual("test-secret-123");
+      expect(worker.env?.DEBUG_MODE).toEqual("true");
+    } finally {
+      await destroy(scope);
+      await assertWorkerDoesNotExist(workerName);
+    }
+  });
+
+  test("create and test worker with cross-script durable object binding", async (scope) => {
+    // Create names for both workers
+    const doWorkerName = `${BRANCH_PREFIX}-do-provider-worker`;
+    const clientWorkerName = `${BRANCH_PREFIX}-do-client-worker`;
+
+    // Script for the worker that defines the durable object
+    const doProviderWorkerScript = `
+      export class SharedCounter {
+        constructor(state, env) {
+          this.state = state;
+          this.env = env;
+          this.counter = 0;
+        }
+
+        async fetch(request) {
+          const url = new URL(request.url);
+          
+          if (url.pathname === '/increment') {
+            this.counter++;
+            return new Response(JSON.stringify({
+              action: 'increment',
+              counter: this.counter,
+              worker: '${doWorkerName}'
+            }), {
+              headers: { 'Content-Type': 'application/json' }
+            });
+          }
+
+          if (url.pathname === '/get') {
+            return new Response(JSON.stringify({
+              action: 'get',
+              counter: this.counter,
+              worker: '${doWorkerName}'
+            }), {
+              headers: { 'Content-Type': 'application/json' }
+            });
+          }
+
+          return new Response('SharedCounter DO is running!', { status: 200 });
+        }
+      }
+
+      export default {
+        async fetch(request, env, ctx) {
+          return new Response('DO Provider Worker is running!', {
+            status: 200,
+            headers: { 'Content-Type': 'text/plain' }
+          });
+        }
+      };
+    `;
+
+    // Script for the worker that uses the cross-script durable object
+    const clientWorkerScript = `
+      export default {
+        async fetch(request, env, ctx) {
+          const url = new URL(request.url);
+          
+          if (url.pathname === '/increment') {
+            try {
+              // Get the durable object instance and increment
+              const id = env.SHARED_COUNTER.idFromName('test-counter');
+              const stub = env.SHARED_COUNTER.get(id);
+              const response = await stub.fetch(new Request('https://example.com/increment'));
+              const data = await response.json();
+              
+              return Response.json({
+                success: true,
+                clientWorker: '${clientWorkerName}',
+                result: data,
+                crossScriptWorking: true
+              });
+            } catch (error) {
+              return Response.json({
+                success: false,
+                error: error.message,
+                crossScriptWorking: false
+              }, { status: 500 });
+            }
+          }
+
+          if (url.pathname === '/get') {
+            try {
+              // Get the current counter value
+              const id = env.SHARED_COUNTER.idFromName('test-counter');
+              const stub = env.SHARED_COUNTER.get(id);
+              const response = await stub.fetch(new Request('https://example.com/get'));
+              const data = await response.json();
+              
+              return Response.json({
+                success: true,
+                clientWorker: '${clientWorkerName}',
+                result: data
+              });
+            } catch (error) {
+              return Response.json({
+                success: false,
+                error: error.message
+              }, { status: 500 });
+            }
+          }
+
+          return new Response('DO Client Worker is running!', {
+            status: 200,
+            headers: { 'Content-Type': 'text/plain' }
+          });
+        }
+      };
+    `;
+
+    let doProviderWorker;
+    let clientWorker;
+
+    try {
+      // First create the worker that defines the durable object with its own binding
+      doProviderWorker = await Worker(doWorkerName, {
+        name: doWorkerName,
+        script: doProviderWorkerScript,
+        format: "esm",
+        url: true, // Enable workers.dev URL
+        bindings: {
+          // Create a durable object namespace for the provider worker
+          SHARED_COUNTER: new DurableObjectNamespace(
+            "provider-counter-namespace",
+            {
+              className: "SharedCounter",
+              // No scriptName means it binds to its own script
+            },
+          ), // Bind to its own durable object
+        },
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+
+      expect(doProviderWorker.id).toBeTruthy();
+      expect(doProviderWorker.name).toEqual(doWorkerName);
+      expect(doProviderWorker.url).toBeTruthy();
+
+      // Create the client worker with the cross-script durable object binding
+      clientWorker = await Worker(clientWorkerName, {
+        name: clientWorkerName,
+        script: clientWorkerScript,
+        format: "esm",
+        url: true, // Enable workers.dev URL
+        bindings: {
+          // Create a cross-script durable object namespace that references the first worker
+          SHARED_COUNTER: new DurableObjectNamespace(
+            "cross-script-counter-namespace",
+            {
+              className: "SharedCounter",
+              scriptName: doWorkerName, // This makes it cross-script
+            },
+          ), // Cross-script binding
+        },
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+
+      expect(clientWorker.id).toBeTruthy();
+      expect(clientWorker.name).toEqual(clientWorkerName);
+      expect(clientWorker.url).toBeTruthy();
+      expect(clientWorker.bindings?.SHARED_COUNTER).toBeDefined();
+
+      // Verify the binding configuration
+      const binding = clientWorker.bindings.SHARED_COUNTER;
+      expect(binding.className).toEqual("SharedCounter");
+      expect(binding.scriptName).toEqual(doWorkerName);
+
+      // Test that both workers respond to basic requests
+      const doProviderResponse = await fetch(doProviderWorker.url!);
+      expect(doProviderResponse.status).toEqual(200);
+      const doProviderText = await doProviderResponse.text();
+      expect(doProviderText).toEqual("DO Provider Worker is running!");
+
+      const clientResponse = await fetch(clientWorker.url!);
+      expect(clientResponse.status).toEqual(200);
+      const clientText = await clientResponse.text();
+      expect(clientText).toEqual("DO Client Worker is running!");
+
+      // Test cross-script durable object functionality by calling increment
+      const incrementResponse = await fetch(`${clientWorker.url}/increment`);
+      expect(incrementResponse.status).toEqual(200);
+      const incrementData: any = await incrementResponse.json();
+
+      expect(incrementData).toMatchObject({
+        success: true,
+        clientWorker: clientWorkerName,
+        crossScriptWorking: true,
+        result: {
+          action: "increment",
+          worker: doWorkerName,
+        },
+      });
+
+      // Test getting the counter value
+      const getResponse = await fetch(`${clientWorker.url}/get`);
+      expect(getResponse.status).toEqual(200);
+      const getData: any = await getResponse.json();
+
+      expect(getData).toMatchObject({
+        success: true,
+        clientWorker: clientWorkerName,
+        result: {
+          action: "get",
+          worker: doWorkerName,
+        },
+      });
+
+      // Test state persistence by making multiple increment calls
+      const firstIncrement = await fetch(`${clientWorker.url}/increment`);
+      const firstData: any = await firstIncrement.json();
+
+      const secondIncrement = await fetch(`${clientWorker.url}/increment`);
+      const secondData: any = await secondIncrement.json();
+
+      const thirdIncrement = await fetch(`${clientWorker.url}/increment`);
+      const thirdData: any = await thirdIncrement.json();
+
+      // Verify that the counter is incrementing properly across calls
+      expect(firstData.result.counter).toBeLessThan(secondData.result.counter);
+      expect(secondData.result.counter).toBeLessThan(thirdData.result.counter);
+    } finally {
+      await destroy(scope);
+      // Verify both workers were deleted
+      await assertWorkerDoesNotExist(doWorkerName);
+      await assertWorkerDoesNotExist(clientWorkerName);
+    }
+  }, 120000); // Increased timeout for cross-script DO operations
+
+  test("migrate durable object by renaming class", async (scope) => {
+    const workerName = `${BRANCH_PREFIX}-test-worker-do-migration-migrate-1`;
+
+    // Sample ESM worker script with renamed CounterV2 class
+    const doMigrationWorkerScriptV2 = `
+export class CounterV2 {
+  constructor(state, env) {
+    this.state = state;
+    this.env = env;
+    this.counter = 0;
+  }
+
+  async fetch(request) {
+    this.counter++;
+    return new Response('Counter V2: ' + this.counter, { status: 200 });
+  }
+}
+
+export default {
+  async fetch(request, env, ctx) {
+    if (request.url.includes('/counter')) {
+      const id = env.COUNTER.idFromName('default');
+      const stub = env.COUNTER.get(id);
+      return stub.fetch(request);
+    }
+    return new Response('Hello with Counter V2!', { status: 200 });
+  }
+};
+`;
+
+    // Sample ESM worker script with original Counter class
+    const doMigrationWorkerScriptV1 = `
+export class Counter {
+  constructor(state, env) {
+    this.state = state;
+    this.env = env;
+    this.counter = 0;
+  }
+
+  async fetch(request) {
+    this.counter++;
+    return new Response('Counter V1: ' + this.counter, { status: 200 });
+  }
+}
+
+export default {
+  async fetch(request, env, ctx) {
+    if (request.url.includes('/counter')) {
+      const id = env.COUNTER.idFromName('default');
+      const stub = env.COUNTER.get(id);
+      return stub.fetch(request);
+    }
+    return new Response('Hello with Counter V1!', { status: 200 });
+  }
+};
+`;
+
+    let worker: Worker | undefined;
+    try {
+      // First create the worker with the original Counter class
+      worker = await Worker(workerName, {
+        name: workerName,
+        script: doMigrationWorkerScriptV1,
+        format: "esm",
+        adopt: true,
+      });
+
+      // Apply to create the worker first
+      expect(worker.id).toBeTruthy();
+      expect(worker.name).toEqual(workerName);
+
+      // Create a stable DO namespace with the original Counter class
+      const counterNamespace = new DurableObjectNamespace(
+        "test-counter-namespace",
+        {
+          className: "Counter",
+          scriptName: workerName,
+        },
+      );
+
+      // Update worker with the original Counter binding
+      worker = await Worker(workerName, {
+        name: workerName,
+        script: doMigrationWorkerScriptV1,
+        format: "esm",
+        bindings: {
+          COUNTER: counterNamespace,
+        },
+      });
+
+      expect(worker.bindings).toBeDefined();
+
+      // Now update the namespace to use CounterV2 class
+      const updatedNamespace = new DurableObjectNamespace(
+        "test-counter-namespace",
+        {
+          className: "CounterV2",
+          scriptName: workerName,
+        },
+      );
+
+      // Update worker with the migrated binding
+      worker = await Worker(workerName, {
+        name: workerName,
+        script: doMigrationWorkerScriptV2,
+        format: "esm",
+        bindings: {
+          COUNTER: updatedNamespace,
+        },
+      });
+
+      expect(worker.bindings).toBeDefined();
+    } finally {
+      await destroy(scope);
+      await assertWorkerDoesNotExist(workerName);
+    }
+  });
+
+  test("create and test worker with cross-script durable object binding using re-exported syntax", async (scope) => {
+    // Create names for both workers
+    const doWorkerName = `${BRANCH_PREFIX}-do-provider-worker-re-exported`;
+    const clientWorkerName = `${BRANCH_PREFIX}-do-client-worker-re-exported`;
+
+    // Script for the worker that defines the durable object
+    const doProviderWorkerScript = `
+      export class SharedCounter {
+        constructor(state, env) {
+          this.state = state;
+          this.env = env;
+          this.counter = 0;
+        }
+
+        async fetch(request) {
+          const url = new URL(request.url);
+          
+          if (url.pathname === '/increment') {
+            this.counter++;
+            return new Response(JSON.stringify({
+              action: 'increment',
+              counter: this.counter,
+              worker: '${doWorkerName}'
+            }), {
+              headers: { 'Content-Type': 'application/json' }
+            });
+          }
+
+          if (url.pathname === '/get') {
+            return new Response(JSON.stringify({
+              action: 'get',
+              counter: this.counter,
+              worker: '${doWorkerName}'
+            }), {
+              headers: { 'Content-Type': 'application/json' }
+            });
+          }
+
+          return new Response('SharedCounter DO is running!', { status: 200 });
+        }
+      }
+
+      export default {
+        async fetch(request, env, ctx) {
+          return new Response('DO Provider Worker is running!', {
+            status: 200,
+            headers: { 'Content-Type': 'text/plain' }
+          });
+        }
+      };
+    `;
+
+    // Script for the worker that uses the cross-script durable object
+    const clientWorkerScript = `
+      export default {
+        async fetch(request, env, ctx) {
+          const url = new URL(request.url);
+          
+          if (url.pathname === '/increment') {
+            try {
+              // Get the durable object instance and increment
+              const id = env.SHARED_COUNTER.idFromName('test-counter');
+              const stub = env.SHARED_COUNTER.get(id);
+              const response = await stub.fetch(new Request('https://example.com/increment'));
+              const data = await response.json();
+              
+              return Response.json({
+                success: true,
+                clientWorker: '${clientWorkerName}',
+                result: data,
+                crossScriptWorking: true
+              });
+            } catch (error) {
+              return Response.json({
+                success: false,
+                error: error.message,
+                crossScriptWorking: false
+              }, { status: 500 });
+            }
+          }
+
+          if (url.pathname === '/get') {
+            try {
+              // Get the current counter value
+              const id = env.SHARED_COUNTER.idFromName('test-counter');
+              const stub = env.SHARED_COUNTER.get(id);
+              const response = await stub.fetch(new Request('https://example.com/get'));
+              const data = await response.json();
+              
+              return Response.json({
+                success: true,
+                clientWorker: '${clientWorkerName}',
+                result: data
+              });
+            } catch (error) {
+              return Response.json({
+                success: false,
+                error: error.message
+              }, { status: 500 });
+            }
+          }
+
+          return new Response('DO Client Worker is running!', {
+            status: 200,
+            headers: { 'Content-Type': 'text/plain' }
+          });
+        }
+      };
+    `;
+
+    let doProviderWorker;
+    let clientWorker;
+
+    try {
+      // First create the worker that defines the durable object with its own binding
+      doProviderWorker = await Worker(doWorkerName, {
+        name: doWorkerName,
+        script: doProviderWorkerScript,
+        format: "esm",
+        url: true, // Enable workers.dev URL
+        bindings: {
+          // Create a durable object namespace for the provider worker
+          SHARED_COUNTER: new DurableObjectNamespace(
+            "provider-counter-namespace",
+            {
+              className: "SharedCounter",
+              // No scriptName means it binds to its own script
+            },
+          ), // Bind to its own durable object
+        },
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+
+      expect(doProviderWorker.id).toBeTruthy();
+      expect(doProviderWorker.name).toEqual(doWorkerName);
+      expect(doProviderWorker.url).toBeTruthy();
+
+      expect(doProviderWorker.bindings.SHARED_COUNTER.scriptName).toEqual(
+        doWorkerName,
+      );
+
+      // Create the client worker with the cross-script durable object binding
+      clientWorker = await Worker(clientWorkerName, {
+        name: clientWorkerName,
+        script: clientWorkerScript,
+        format: "esm",
+        url: true, // Enable workers.dev URL
+        bindings: {
+          // Create a cross-script durable object namespace that references the first worker
+          SHARED_COUNTER: doProviderWorker.bindings.SHARED_COUNTER,
+        },
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+
+      expect(clientWorker.id).toBeTruthy();
+      expect(clientWorker.name).toEqual(clientWorkerName);
+      expect(clientWorker.url).toBeTruthy();
+      expect(clientWorker.bindings?.SHARED_COUNTER).toBeDefined();
+
+      // Verify the binding configuration
+      const binding = clientWorker.bindings.SHARED_COUNTER;
+      expect(binding.className).toEqual("SharedCounter");
+      expect(binding.scriptName).toEqual(doWorkerName);
+
+      // Test that both workers respond to basic requests
+      const doProviderResponse = await fetch(doProviderWorker.url!);
+      expect(doProviderResponse.status).toEqual(200);
+      const doProviderText = await doProviderResponse.text();
+      expect(doProviderText).toEqual("DO Provider Worker is running!");
+
+      const clientResponse = await fetch(clientWorker.url!);
+      expect(clientResponse.status).toEqual(200);
+      const clientText = await clientResponse.text();
+      expect(clientText).toEqual("DO Client Worker is running!");
+
+      // Test cross-script durable object functionality by calling increment
+      const incrementResponse = await fetch(`${clientWorker.url}/increment`);
+      expect(incrementResponse.status).toEqual(200);
+      const incrementData: any = await incrementResponse.json();
+
+      expect(incrementData).toMatchObject({
+        success: true,
+        clientWorker: clientWorkerName,
+        crossScriptWorking: true,
+        result: {
+          action: "increment",
+          worker: doWorkerName,
+        },
+      });
+
+      // Test getting the counter value
+      const getResponse = await fetch(`${clientWorker.url}/get`);
+      expect(getResponse.status).toEqual(200);
+      const getData: any = await getResponse.json();
+
+      expect(getData).toMatchObject({
+        success: true,
+        clientWorker: clientWorkerName,
+        result: {
+          action: "get",
+          worker: doWorkerName,
+        },
+      });
+
+      // Test state persistence by making multiple increment calls
+      const firstIncrement = await fetch(`${clientWorker.url}/increment`);
+      const firstData: any = await firstIncrement.json();
+
+      const secondIncrement = await fetch(`${clientWorker.url}/increment`);
+      const secondData: any = await secondIncrement.json();
+
+      const thirdIncrement = await fetch(`${clientWorker.url}/increment`);
+      const thirdData: any = await thirdIncrement.json();
+
+      // Verify that the counter is incrementing properly across calls
+      expect(firstData.result.counter).toBeLessThan(secondData.result.counter);
+      expect(secondData.result.counter).toBeLessThan(thirdData.result.counter);
+    } finally {
+      await destroy(scope);
+      // Verify both workers were deleted
+      await assertWorkerDoesNotExist(doWorkerName);
+      await assertWorkerDoesNotExist(clientWorkerName);
+    }
+  }, 120000); // Increased timeout for cross-script DO operations
+
+  test("adopting a Worker should use server-side state to migrate classes", async (scope) => {
+    try {
+      const workerName = `${BRANCH_PREFIX}-test-worker-adoption-migrate`;
+      await Worker("worker-1", {
+        name: workerName,
+        script: `
+          export class Counter {}
+          export default { fetch() {} }
+        `,
+        bindings: {
+          DO: new DurableObjectNamespace("DO", {
+            className: "Counter",
+          }),
+        },
+      });
+
+      await Worker("worker-2", {
+        name: workerName,
+        // adopt the worker since it already exists
+        adopt: true,
+        script: `
+          export class Counter2 {}
+          export default { fetch() {} }
+        `,
+        bindings: {
+          // mapped by stable ID "DO"
+          DO_1: new DurableObjectNamespace("DO", {
+            // should migrate to Counter 2
+            className: "Counter2",
+          }),
+        },
+      });
+    } finally {
+      await destroy(scope);
+    }
+  });
+});

--- a/alchemy/test/cloudflare/kv-namespace.test.ts
+++ b/alchemy/test/cloudflare/kv-namespace.test.ts
@@ -2,8 +2,10 @@ import { describe, expect } from "bun:test";
 import { alchemy } from "../../src/alchemy.js";
 import { createCloudflareApi } from "../../src/cloudflare/api.js";
 import { KVNamespace } from "../../src/cloudflare/kv-namespace.js";
+import { Worker } from "../../src/cloudflare/worker.js";
 import { BRANCH_PREFIX } from "../util.js";
 
+import { destroy } from "../../src/destroy.js";
 import "../../src/test/bun.js";
 
 const test = alchemy.test(import.meta, {
@@ -123,6 +125,51 @@ describe("KV Namespace Resource", () => {
     } finally {
       await alchemy.destroy(scope);
       await assertKvNamespaceNotExists(kvNamespace!.namespaceId);
+    }
+  });
+
+  test("create and delete worker with KV Namespace binding", async (scope) => {
+    const workerName = `${BRANCH_PREFIX}-test-worker-kv-binding-kv-1`;
+
+    let worker: Worker | undefined;
+    let testKv: KVNamespace | undefined;
+    try {
+      // Create a KV namespace with initial values
+      testKv = await KVNamespace("test-kv-namespace", {
+        title: `${BRANCH_PREFIX} Test KV Namespace 2`,
+        values: [
+          {
+            key: "testKey",
+            value: "initial-value",
+          },
+        ],
+      });
+      // Create a worker with the KV Namespace binding
+      worker = await Worker(workerName, {
+        name: workerName,
+        script: `
+          export default {
+            async fetch(request, env, ctx) {
+              // Use the KV binding
+              if (request.url.includes('/kv')) {
+                const value = await env.TEST_KV.get('testKey');
+                return new Response('KV Value: ' + (value || 'not found'), { status: 200 });
+              }
+
+              return new Response('Hello with KV Namespace!', { status: 200 });
+            }
+          };
+        `,
+        format: "esm",
+        bindings: {
+          TEST_KV: testKv,
+        },
+      });
+      expect(worker.id).toBeTruthy();
+      expect(worker.name).toEqual(workerName);
+      expect(worker.bindings).toBeDefined();
+    } finally {
+      await destroy(scope);
     }
   });
 

--- a/alchemy/test/cloudflare/worker.test.ts
+++ b/alchemy/test/cloudflare/worker.test.ts
@@ -6,13 +6,9 @@ import { AnalyticsEngineDataset } from "../../src/cloudflare/analytics-engine.js
 import { createCloudflareApi } from "../../src/cloudflare/api.js";
 import { Assets } from "../../src/cloudflare/assets.js";
 import { Self } from "../../src/cloudflare/bindings.js";
-import { R2Bucket } from "../../src/cloudflare/bucket.js";
-import { D1Database } from "../../src/cloudflare/d1-database.js";
 import { DurableObjectNamespace } from "../../src/cloudflare/durable-object-namespace.js";
 import { KVNamespace } from "../../src/cloudflare/kv-namespace.js";
-import { Queue } from "../../src/cloudflare/queue.js";
 import { Worker } from "../../src/cloudflare/worker.js";
-import { Workflow } from "../../src/cloudflare/workflow.js";
 import { destroy } from "../../src/destroy.js";
 import { BRANCH_PREFIX } from "../util.js";
 
@@ -39,229 +35,6 @@ async function assertWorkerDoesNotExist(workerName: string) {
 }
 
 describe("Worker Resource", () => {
-  // Sample worker script (CJS style)
-  const workerScript = `
-    addEventListener('fetch', event => {
-      event.respondWith(new Response('Hello world!', { status: 200 }));
-    });
-  `;
-
-  // Sample ESM worker script
-  const esmWorkerScript = `
-    export default {
-      async fetch(request, env, ctx) {
-        return new Response('Hello ESM world!', { status: 200 });
-      }
-    };
-  `;
-
-  // Sample ESM worker script with a Durable Object
-  const durableObjectWorkerScript = `
-    export class Counter {
-      constructor(state, env) {
-        this.state = state;
-        this.env = env;
-        this.counter = 0;
-      }
-
-      async fetch(request) {
-        this.counter++;
-        return new Response('Counter: ' + this.counter, { status: 200 });
-      }
-    }
-
-    export default {
-      async fetch(request, env, ctx) {
-        // Use the DO binding if needed
-        if (request.url.includes('/counter')) {
-          const id = env.COUNTER.idFromName('default');
-          const stub = env.COUNTER.get(id);
-          return stub.fetch(request);
-        }
-
-        return new Response('Hello with Durable Object!', { status: 200 });
-      }
-    };
-  `;
-
-  // Sample ESM worker script with KV Namespace
-  const kvWorkerScript = `
-    export default {
-      async fetch(request, env, ctx) {
-        // Use the KV binding
-        if (request.url.includes('/kv')) {
-          const value = await env.TEST_KV.get('testKey');
-          return new Response('KV Value: ' + (value || 'not found'), { status: 200 });
-        }
-
-        return new Response('Hello with KV Namespace!', { status: 200 });
-      }
-    };
-  `;
-
-  // Sample ESM worker script with R2 bucket
-  const r2WorkerScript = `
-    export default {
-      async fetch(request, env, ctx) {
-        // Use the R2 binding
-        if (request.url.includes('/r2-info')) {
-          // Just confirm we have access to the binding
-          return new Response(JSON.stringify({
-            hasR2: !!env.STORAGE,
-            bucketName: env.STORAGE.name || 'unknown'
-          }), {
-            status: 200,
-            headers: { 'Content-Type': 'application/json' }
-          });
-        }
-
-        return new Response('Hello with R2 Bucket!', { status: 200 });
-      }
-    };
-  `;
-
-  // Sample ESM worker script with multiple bindings
-  const multiBindingsWorkerScript = `
-    export class Counter {
-      constructor(state, env) {
-        this.state = state;
-        this.env = env;
-        this.counter = 0;
-      }
-
-      async fetch(request) {
-        this.counter++;
-        return new Response('Counter: ' + this.counter, { status: 200 });
-      }
-    }
-
-    export default {
-      async fetch(request, env, ctx) {
-        // Path-based routing to demonstrate different bindings
-        const url = new URL(request.url);
-
-        if (url.pathname.includes('/counter')) {
-          const id = env.COUNTER.idFromName('default');
-          const stub = env.COUNTER.get(id);
-          return stub.fetch(request);
-        }
-
-        if (url.pathname.includes('/kv')) {
-          const value = await env.TEST_KV.get('testKey');
-          return new Response('KV Value: ' + (value || 'not found'), { status: 200 });
-        }
-
-        if (url.pathname.includes('/secret')) {
-          return new Response('Secret: ' + env.API_KEY, { status: 200 });
-        }
-
-        return new Response('Hello worker with multiple bindings!', { status: 200 });
-      }
-    };
-  `;
-
-  // Sample ESM worker script with environment variables
-  const envVarsWorkerScript = `
-    export default {
-      async fetch(request, env, ctx) {
-        const url = new URL(request.url);
-
-        // Return the value of the requested environment variable
-        if (url.pathname.startsWith('/env/')) {
-          const varName = url.pathname.split('/env/')[1];
-          const value = env[varName];
-          return new Response(value || 'undefined', {
-            status: 200,
-            headers: { 'Content-Type': 'text/plain' }
-          });
-        }
-
-        // Return all environment variables
-        if (url.pathname === '/env') {
-          const envVars = Object.entries(env)
-            .filter(([key]) => key !== 'COUNTER' && !key.includes('Durable')) // Filter out bindings
-            .map(([key, value]) => \`\${key}: \${value}\`)
-            .join('\\n');
-
-          return new Response(envVars, {
-            status: 200,
-            headers: { 'Content-Type': 'text/plain' }
-          });
-        }
-
-        return new Response('Hello with environment variables!', { status: 200 });
-      }
-    };
-  `;
-
-  // Sample ESM worker script with original Counter class
-  const doMigrationWorkerScriptV1 = `
-    export class Counter {
-      constructor(state, env) {
-        this.state = state;
-        this.env = env;
-        this.counter = 0;
-      }
-
-      async fetch(request) {
-        this.counter++;
-        return new Response('Counter V1: ' + this.counter, { status: 200 });
-      }
-    }
-
-    export default {
-      async fetch(request, env, ctx) {
-        if (request.url.includes('/counter')) {
-          const id = env.COUNTER.idFromName('default');
-          const stub = env.COUNTER.get(id);
-          return stub.fetch(request);
-        }
-        return new Response('Hello with Counter V1!', { status: 200 });
-      }
-    };
-  `;
-
-  // Sample ESM worker script with renamed CounterV2 class
-  const doMigrationWorkerScriptV2 = `
-    export class CounterV2 {
-      constructor(state, env) {
-        this.state = state;
-        this.env = env;
-        this.counter = 0;
-      }
-
-      async fetch(request) {
-        this.counter++;
-        return new Response('Counter V2: ' + this.counter, { status: 200 });
-      }
-    }
-
-    export default {
-      async fetch(request, env, ctx) {
-        if (request.url.includes('/counter')) {
-          const id = env.COUNTER.idFromName('default');
-          const stub = env.COUNTER.get(id);
-          return stub.fetch(request);
-        }
-        return new Response('Hello with Counter V2!', { status: 200 });
-      }
-    };
-  `;
-
-  // Sample worker script with a scheduled handler
-  const cronWorkerScript = `
-    export default {
-      async fetch(request, env, ctx) {
-        return new Response('Worker with cron is running!', { status: 200 });
-      },
-      async scheduled(event, env, ctx) {
-        // Log the scheduled event details
-        console.log('Scheduled event received:', event.scheduledTime, event.cron);
-        // In a real worker, you would perform tasks here
-      },
-    };
-  `;
-
   test("create, update, and delete worker (CJS format)", async (scope) => {
     const workerName = `${BRANCH_PREFIX}-test-worker-cjs-1`;
 
@@ -270,7 +43,11 @@ describe("Worker Resource", () => {
       // Create a worker with an explicit name
       worker = await Worker(workerName, {
         name: workerName,
-        script: workerScript,
+        script: `
+          addEventListener('fetch', event => {
+            event.respondWith(new Response('Hello world!', { status: 200 }));
+          });
+        `,
         format: "cjs",
       });
 
@@ -307,7 +84,13 @@ describe("Worker Resource", () => {
       // Create a worker with ESM format
       worker = await Worker(workerName, {
         name: workerName,
-        script: esmWorkerScript,
+        script: `
+          export default {
+            async fetch(request, env, ctx) {
+              return new Response('Hello ESM world!', { status: 200 });
+            }
+          };
+        `,
         format: "esm", // Explicitly using ESM
       });
 
@@ -346,7 +129,13 @@ describe("Worker Resource", () => {
       // First create with ESM format
       worker = await Worker(workerName, {
         name: workerName,
-        script: esmWorkerScript,
+        script: `
+          export default {
+            async fetch(request, env, ctx) {
+              return new Response('Hello ESM world!', { status: 200 });
+            }
+          };
+        `,
         format: "esm",
       });
 
@@ -355,7 +144,11 @@ describe("Worker Resource", () => {
       // Update to CJS format
       worker = await Worker(workerName, {
         name: workerName,
-        script: workerScript,
+        script: `
+          addEventListener('fetch', event => {
+            event.respondWith(new Response('Hello world!', { status: 200 }));
+          });
+        `,
         format: "cjs",
       });
       expect(worker.format).toEqual("cjs");
@@ -363,7 +156,13 @@ describe("Worker Resource", () => {
       // Update back to ESM format
       worker = await Worker(workerName, {
         name: workerName,
-        script: esmWorkerScript,
+        script: `
+          export default {
+            async fetch(request, env, ctx) {
+              return new Response('Hello ESM world!', { status: 200 });
+            }
+          };
+        `,
         format: "esm",
       });
 
@@ -381,14 +180,22 @@ describe("Worker Resource", () => {
       // First, create a worker successfully
       await Worker(workerName, {
         name: workerName,
-        script: workerScript,
+        script: `
+          addEventListener('fetch', event => {
+            event.respondWith(new Response('Hello world!', { status: 200 }));
+          });
+        `,
         format: "cjs",
       });
 
       // Try to create another worker with the same name, which should fail
       const duplicateWorker = Worker(`${workerName}-dup`, {
         name: workerName, // Same name as firstWorker
-        script: workerScript,
+        script: `
+          addEventListener('fetch', event => {
+            event.respondWith(new Response('Hello world!', { status: 200 }));
+          });
+        `,
         format: "cjs",
       });
       await expect(duplicateWorker).rejects.toThrow(
@@ -399,88 +206,48 @@ describe("Worker Resource", () => {
     }
   });
 
-  test("create and delete worker with Durable Object binding", async (scope) => {
-    const workerName = `${BRANCH_PREFIX}-test-worker-do-binding-do-1`;
-
-    let worker: Worker | undefined;
-    try {
-      // First create the worker without the DO binding
-      worker = await Worker(workerName, {
-        name: workerName,
-        script: durableObjectWorkerScript,
-        format: "esm",
-        // No bindings yet
-      });
-
-      expect(worker.id).toBeTruthy();
-      expect(worker.name).toEqual(workerName);
-      expect(worker.bindings).toBeEmpty();
-
-      // Create a Durable Object namespace
-      const counterNamespace = new DurableObjectNamespace(
-        "test-counter-namespace",
-        {
-          className: "Counter",
-          scriptName: workerName,
-        },
-      );
-
-      // Update the worker with the DO binding
-      worker = await Worker(workerName, {
-        name: workerName,
-        script: durableObjectWorkerScript,
-        format: "esm",
-        bindings: {
-          COUNTER: counterNamespace,
-        },
-      });
-
-      expect(worker.id).toBeTruthy();
-      expect(worker.name).toEqual(workerName);
-      expect(worker.bindings).toBeDefined();
-    } finally {
-      await destroy(scope);
-      await assertWorkerDoesNotExist(workerName);
-    }
-  });
-
-  test("create and delete worker with KV Namespace binding", async (scope) => {
-    const workerName = `${BRANCH_PREFIX}-test-worker-kv-binding-kv-1`;
-
-    let worker: Worker | undefined;
-    let testKv: KVNamespace | undefined;
-    try {
-      // Create a KV namespace with initial values
-      testKv = await KVNamespace("test-kv-namespace", {
-        title: `${BRANCH_PREFIX} Test KV Namespace 2`,
-        values: [
-          {
-            key: "testKey",
-            value: "initial-value",
-          },
-        ],
-      });
-
-      // Create a worker with the KV Namespace binding
-      worker = await Worker(workerName, {
-        name: workerName,
-        script: kvWorkerScript,
-        format: "esm",
-        bindings: {
-          TEST_KV: testKv,
-        },
-      });
-      expect(worker.id).toBeTruthy();
-      expect(worker.name).toEqual(workerName);
-      expect(worker.bindings).toBeDefined();
-    } finally {
-      await destroy(scope);
-      await assertWorkerDoesNotExist(workerName);
-    }
-  });
-
   test("create and delete worker with multiple bindings", async (scope) => {
     const workerName = `${BRANCH_PREFIX}-test-worker-multi-bindings-multi-1`;
+
+    // Sample ESM worker script with multiple bindings
+    const multiBindingsWorkerScript = `
+  export class Counter {
+    constructor(state, env) {
+      this.state = state;
+      this.env = env;
+      this.counter = 0;
+    }
+
+    async fetch(request) {
+      this.counter++;
+      return new Response('Counter: ' + this.counter, { status: 200 });
+    }
+  }
+
+  export default {
+    async fetch(request, env, ctx) {
+      // Path-based routing to demonstrate different bindings
+      const url = new URL(request.url);
+
+      if (url.pathname.includes('/counter')) {
+        const id = env.COUNTER.idFromName('default');
+        const stub = env.COUNTER.get(id);
+        return stub.fetch(request);
+      }
+
+      if (url.pathname.includes('/kv')) {
+        const value = await env.TEST_KV.get('testKey');
+        return new Response('KV Value: ' + (value || 'not found'), { status: 200 });
+      }
+
+      if (url.pathname.includes('/secret')) {
+        return new Response('Secret: ' + env.API_KEY, { status: 200 });
+      }
+
+      return new Response('Hello worker with multiple bindings!', { status: 200 });
+    }
+  };
+`;
 
     // Create a Durable Object namespace
     const counterNamespace = new DurableObjectNamespace(
@@ -539,6 +306,39 @@ describe("Worker Resource", () => {
   // Add a new test for environment variables
   test("create and test worker with environment variables", async (scope) => {
     const workerName = `${BRANCH_PREFIX}-test-worker-env-vars-env-1`;
+    // Sample ESM worker script with environment variables
+    const envVarsWorkerScript = `
+      export default {
+        async fetch(request, env, ctx) {
+          const url = new URL(request.url);
+
+          // Return the value of the requested environment variable
+          if (url.pathname.startsWith('/env/')) {
+            const varName = url.pathname.split('/env/')[1];
+            const value = env[varName];
+            return new Response(value || 'undefined', {
+              status: 200,
+              headers: { 'Content-Type': 'text/plain' }
+            });
+          }
+
+          // Return all environment variables
+          if (url.pathname === '/env') {
+            const envVars = Object.entries(env)
+              .filter(([key]) => key !== 'COUNTER' && !key.includes('Durable')) // Filter out bindings
+              .map(([key, value]) => \`\${key}: \${value}\`)
+              .join('\\n');
+
+            return new Response(envVars, {
+              status: 200,
+              headers: { 'Content-Type': 'text/plain' }
+            });
+          }
+
+          return new Response('Hello with environment variables!', { status: 200 });
+        }
+      };
+    `;
     let worker: Worker | undefined;
     try {
       // Create a worker with environment variables
@@ -617,177 +417,6 @@ describe("Worker Resource", () => {
     } finally {
       await destroy(scope);
       // Verify the worker was deleted
-      await assertWorkerDoesNotExist(workerName);
-    }
-  });
-
-  test("migrate durable object by renaming class", async (scope) => {
-    const workerName = `${BRANCH_PREFIX}-test-worker-do-migration-migrate-1`;
-    let worker: Worker | undefined;
-    try {
-      // First create the worker with the original Counter class
-      worker = await Worker(workerName, {
-        name: workerName,
-        script: doMigrationWorkerScriptV1,
-        format: "esm",
-        adopt: true,
-      });
-
-      // Apply to create the worker first
-      expect(worker.id).toBeTruthy();
-      expect(worker.name).toEqual(workerName);
-
-      // Create a stable DO namespace with the original Counter class
-      const counterNamespace = new DurableObjectNamespace(
-        "test-counter-namespace",
-        {
-          className: "Counter",
-          scriptName: workerName,
-        },
-      );
-
-      // Update worker with the original Counter binding
-      worker = await Worker(workerName, {
-        name: workerName,
-        script: doMigrationWorkerScriptV1,
-        format: "esm",
-        bindings: {
-          COUNTER: counterNamespace,
-        },
-      });
-
-      expect(worker.bindings).toBeDefined();
-
-      // Now update the namespace to use CounterV2 class
-      const updatedNamespace = new DurableObjectNamespace(
-        "test-counter-namespace",
-        {
-          className: "CounterV2",
-          scriptName: workerName,
-        },
-      );
-
-      // Update worker with the migrated binding
-      worker = await Worker(workerName, {
-        name: workerName,
-        script: doMigrationWorkerScriptV2,
-        format: "esm",
-        bindings: {
-          COUNTER: updatedNamespace,
-        },
-      });
-
-      expect(worker.bindings).toBeDefined();
-    } finally {
-      await destroy(scope);
-      await assertWorkerDoesNotExist(workerName);
-    }
-  });
-
-  test("add environment variables to worker with durable object", async (scope) => {
-    const workerName = `${BRANCH_PREFIX}-test-worker-do-with-env-doenv-1`;
-
-    let worker: Worker | undefined;
-    try {
-      // First create a worker with a Durable Object but no env vars
-      worker = await Worker(workerName, {
-        name: workerName,
-        script: durableObjectWorkerScript,
-        format: "esm",
-      });
-
-      expect(worker.id).toBeTruthy();
-      expect(worker.name).toEqual(workerName);
-
-      // Create a Durable Object namespace
-      const counterNamespace = new DurableObjectNamespace(
-        "test-counter-env-namespace",
-        {
-          className: "Counter",
-          scriptName: workerName,
-        },
-      );
-
-      // Update the worker with the DO binding
-      worker = await Worker(workerName, {
-        name: workerName,
-        script: durableObjectWorkerScript,
-        format: "esm",
-        bindings: {
-          COUNTER: counterNamespace,
-        },
-      });
-
-      // Apply the worker with binding
-      expect(worker.bindings).toBeDefined();
-      expect(worker.env).toBeUndefined();
-
-      // Now update the worker by adding environment variables
-      worker = await Worker(workerName, {
-        name: workerName,
-        script: durableObjectWorkerScript,
-        format: "esm",
-        bindings: {
-          COUNTER: counterNamespace,
-        },
-        env: {
-          API_SECRET: "test-secret-123",
-          DEBUG_MODE: "true",
-        },
-      });
-
-      expect(worker.bindings).toBeDefined();
-      expect(worker.env).toBeDefined();
-      expect(worker.env?.API_SECRET).toEqual("test-secret-123");
-      expect(worker.env?.DEBUG_MODE).toEqual("true");
-    } finally {
-      await destroy(scope);
-      await assertWorkerDoesNotExist(workerName);
-    }
-  });
-
-  test("create and delete worker with R2 bucket binding", async (scope) => {
-    const workerName = `${BRANCH_PREFIX}-test-worker-r2-binding-r2-1`;
-
-    // Create a test R2 bucket
-    let testBucket: R2Bucket | undefined;
-
-    let worker: Worker<{ STORAGE: R2Bucket }> | undefined;
-
-    try {
-      testBucket = await R2Bucket("test-bucket", {
-        name: `${BRANCH_PREFIX.toLowerCase()}-test-r2-bucket`,
-        allowPublicAccess: false,
-      });
-
-      // Create a worker with the R2 bucket binding
-      worker = await Worker(workerName, {
-        name: workerName,
-        script: r2WorkerScript,
-        format: "esm",
-        url: true, // Enable workers.dev URL to test the worker
-        bindings: {
-          STORAGE: testBucket,
-        },
-      });
-
-      await new Promise((resolve) => setTimeout(resolve, 1000));
-
-      expect(worker.id).toBeTruthy();
-      expect(worker.name).toEqual(workerName);
-      expect(worker.bindings).toBeDefined();
-      expect(worker.bindings!.STORAGE).toBeDefined();
-
-      // Test that the R2 binding is accessible in the worker
-      const response = await fetch(`${worker.url}/r2-info`);
-      expect(response.status).toEqual(200);
-      const data = (await response.json()) as {
-        hasR2: boolean;
-        bucketName: string;
-      };
-      expect(data.hasR2).toEqual(true);
-    } finally {
-      await destroy(scope);
       await assertWorkerDoesNotExist(workerName);
     }
   });
@@ -1102,446 +731,6 @@ describe("Worker Resource", () => {
     }
   });
 
-  // Test for binding a workflow to a worker
-  test("create and delete worker with workflow binding", async (scope) => {
-    const workerName = `${BRANCH_PREFIX}-test-worker-workflow`;
-
-    // Sample worker script with workflow handler - updated to match Cloudflare Workflows pattern
-    const workflowWorkerScript = `
-      // Workflow definition for email notifications
-      export class EmailNotifier {
-        constructor(state, env) {
-          this.state = state;
-          this.env = env;
-        }
-
-        async run(event, step) {
-          // Process order data from event payload
-          const orderDetails = await step.do('process-order', async () => {
-            console.log("Processing order", event.payload);
-            return {
-              success: true,
-              orderId: event.payload.orderId,
-              message: "Order processed successfully"
-            };
-          });
-
-          return orderDetails;
-        }
-      }
-
-      // Workflow definition for order processing
-      export class OrderProcessor {
-        constructor(state, env) {
-          this.state = state;
-          this.env = env;
-        }
-
-        async run(event, step) {
-          // Process shipping data
-          const shippingDetails = await step.do('process-shipping', async () => {
-            console.log("Processing shipping", event.payload);
-            return {
-              success: true,
-              shipmentId: event.payload.shipmentId,
-              message: "Shipment scheduled successfully"
-            };
-          });
-
-          return shippingDetails;
-        }
-      }
-
-      export default {
-        async fetch(request, env, ctx) {
-          const url = new URL(request.url);
-
-          // Add endpoints to trigger workflows for testing
-          if (url.pathname === '/trigger-email-workflow') {
-            try {
-              // Get workflow binding
-              const workflow = env.EMAIL_WORKFLOW;
-
-              if (!workflow) {
-                return new Response(JSON.stringify({ error: "No email workflow binding found" }), {
-                  status: 500,
-                  headers: { 'Content-Type': 'application/json' }
-                });
-              }
-
-              // Create a workflow instance with parameters
-              const params = { orderId: "test-123", amount: 99.99 };
-              const instance = await workflow.create(params);
-
-              return Response.json({
-                id: instance.id,
-                details: await instance.status(),
-                success: true,
-                orderId: params.orderId,
-                message: "Order processed successfully"
-              });
-            } catch (error) {
-              console.error("Error triggering email workflow:", error);
-              return new Response(JSON.stringify({ error: error.message || "Unknown error" }), {
-                status: 500,
-                headers: { 'Content-Type': 'application/json' }
-              });
-            }
-          }
-
-          // Endpoint for the order workflow
-          if (url.pathname === '/trigger-order-workflow') {
-            try {
-              // Get workflow binding
-              const workflow = env.ORDER_WORKFLOW;
-
-              if (!workflow) {
-                return new Response(JSON.stringify({ error: "No order workflow binding found" }), {
-                  status: 500,
-                  headers: { 'Content-Type': 'application/json' }
-                });
-              }
-
-              // Create a workflow instance with parameters
-              const params = { shipmentId: "ship-456", carrier: "FastShip" };
-              const instance = await workflow.create(params);
-
-              return Response.json({
-                id: instance.id,
-                details: await instance.status(),
-                success: true,
-                shipmentId: params.shipmentId,
-                message: "Shipment scheduled successfully"
-              });
-            } catch (error) {
-              console.error("Error triggering order workflow:", error);
-              return new Response(JSON.stringify({ error: error.message || "Unknown error" }), {
-                status: 500,
-                headers: { 'Content-Type': 'application/json' }
-              });
-            }
-          }
-
-          return new Response('Worker with workflow bindings!', { status: 200 });
-        }
-      };
-    `;
-
-    let worker: Worker | undefined;
-    try {
-      // Create a workflow instance
-      const emailWorkflow = new Workflow("email-notifier", {
-        className: "EmailNotifier",
-        workflowName: "email-notification-workflow",
-      });
-
-      // Create a worker with the workflow binding
-      worker = await Worker(workerName, {
-        name: workerName,
-        script: workflowWorkerScript,
-        format: "esm",
-        bindings: {
-          EMAIL_WORKFLOW: emailWorkflow,
-        },
-        url: true, // Enable workers.dev URL to test the workflow
-      });
-
-      await new Promise((resolve) => setTimeout(resolve, 1000));
-
-      expect(worker.id).toBeTruthy();
-      expect(worker.name).toEqual(workerName);
-      expect(worker.bindings).toBeDefined();
-      expect(worker.url).toBeTruthy();
-
-      // Test triggering the first workflow
-      const response = await fetch(`${worker.url!}/trigger-email-workflow`);
-      const result: any = await response.json();
-      console.log("Email workflow response:", result);
-
-      expect(response.status).toEqual(200);
-      expect(result.success).toEqual(true);
-      expect(result.orderId).toEqual("test-123");
-      expect(result.message).toEqual("Order processed successfully");
-      // Verify the instance ID is not empty
-      expect(result.id).toBeTruthy();
-      expect(typeof result.id).toBe("string");
-      expect(result.id.length).toBeGreaterThan(0);
-      // Verify the details contain valid status
-      expect(result.details).toBeDefined();
-      expect(result.details.status).toBeTruthy();
-
-      // Create a new workflow binding and update the worker
-      const orderWorkflow = new Workflow("order-processor", {
-        className: "OrderProcessor",
-        workflowName: "order-processing-workflow",
-      });
-
-      // Update the worker with multiple workflow bindings
-      worker = await Worker(workerName, {
-        name: workerName,
-        script: workflowWorkerScript,
-        format: "esm",
-        bindings: {
-          EMAIL_WORKFLOW: emailWorkflow,
-          ORDER_WORKFLOW: orderWorkflow,
-        },
-        url: true,
-      });
-
-      await new Promise((resolve) => setTimeout(resolve, 1000));
-
-      expect(worker.bindings).toBeDefined();
-      expect(Object.keys(worker.bindings || {})).toHaveLength(2);
-
-      // Test triggering the second workflow
-      const orderResponse = await fetch(
-        `${worker.url!}/trigger-order-workflow`,
-      );
-      const orderResult: any = await orderResponse.json();
-      console.log("Order workflow response:", orderResult);
-
-      expect(orderResponse.status).toEqual(200);
-      expect(orderResult.success).toEqual(true);
-      expect(orderResult.shipmentId).toEqual("ship-456");
-      expect(orderResult.message).toEqual("Shipment scheduled successfully");
-      // Verify the instance ID is not empty
-      expect(orderResult.id).toBeTruthy();
-      expect(typeof orderResult.id).toBe("string");
-      expect(orderResult.id.length).toBeGreaterThan(0);
-      // Verify the details contain valid status
-      expect(orderResult.details).toBeDefined();
-      expect(orderResult.details.status).toBeTruthy();
-    } finally {
-      // Explicitly destroy resources since destroy: false is set
-      await destroy(scope);
-      // Verify the worker was deleted
-      await assertWorkerDoesNotExist(workerName);
-    }
-  });
-
-  test("create and test worker with D1 database binding", async (scope) => {
-    // Sample ESM worker script with D1 database functionality
-    const d1WorkerScript = `
-      export default {
-        async fetch(request, env, ctx) {
-          const url = new URL(request.url);
-
-          // Initialize the database with a table and data
-          if (url.pathname === '/init-db') {
-            try {
-              const db = env.DATABASE;
-
-              // Create a test table
-              await db.exec("CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY, name TEXT, email TEXT)");
-
-              // Insert some test data
-              await db.exec("INSERT INTO users (name, email) VALUES ('Test User', 'test@example.com')");
-
-              return new Response('Database initialized successfully!', {
-                status: 200,
-                headers: { 'Content-Type': 'text/plain' }
-              });
-            } catch (error) {
-              return new Response('Error initializing database: ' + error.message, {
-                status: 500,
-                headers: { 'Content-Type': 'text/plain' }
-              });
-            }
-          }
-
-          // Query data from the database
-          if (url.pathname === '/query-db') {
-            try {
-              const db = env.DATABASE;
-
-              // Query the database
-              const { results } = await db.prepare("SELECT * FROM users").all();
-
-              return new Response(JSON.stringify({ success: true, data: results }), {
-                status: 200,
-                headers: { 'Content-Type': 'application/json' }
-              });
-            } catch (error) {
-              return new Response(JSON.stringify({
-                success: false,
-                error: error.message
-              }), {
-                status: 500,
-                headers: { 'Content-Type': 'application/json' }
-              });
-            }
-          }
-
-          return new Response('D1 Database Worker is running!', {
-            status: 200,
-            headers: { 'Content-Type': 'text/plain' }
-          });
-        }
-      };
-    `;
-
-    const workerName = `${BRANCH_PREFIX}-test-worker-d1`;
-
-    let worker: Worker<{ DATABASE: D1Database }> | undefined;
-    let db: D1Database | undefined;
-
-    try {
-      // Create a D1 database
-      db = await D1Database(`${BRANCH_PREFIX}-test-db`, {
-        name: `${BRANCH_PREFIX}-test-db`,
-        primaryLocationHint: "wnam", // West North America
-      });
-
-      expect(db.id).toBeTruthy();
-      expect(db.name).toEqual(`${BRANCH_PREFIX}-test-db`);
-
-      // Create a worker with the D1 database binding
-      worker = await Worker(workerName, {
-        name: workerName,
-        script: d1WorkerScript,
-        format: "esm",
-        url: true, // Enable workers.dev URL to test the worker
-        bindings: {
-          DATABASE: db,
-        },
-      });
-
-      await new Promise((resolve) => setTimeout(resolve, 1000));
-
-      expect(worker.id).toBeTruthy();
-      expect(worker.name).toEqual(workerName);
-      expect(worker.bindings).toBeDefined();
-      expect(worker.bindings!.DATABASE).toBeDefined();
-      expect(worker.bindings!.DATABASE.id).toEqual(db.id);
-      expect(worker.url).toBeTruthy();
-
-      // Initialize the database with a table and data
-      const initResponse = await fetch(`${worker.url}/init-db`);
-      expect(initResponse.status).toEqual(200);
-      const initText = await initResponse.text();
-      expect(initText).toEqual("Database initialized successfully!");
-
-      // Query data from the database
-      const queryResponse = await fetch(`${worker.url}/query-db`);
-      expect(queryResponse.status).toEqual(200);
-      const queryData: any = await queryResponse.json();
-      expect(queryData.success).toEqual(true);
-      expect(queryData.data).toBeArray();
-      expect(queryData.data.length).toBeGreaterThan(0);
-      expect(queryData.data[0].name).toEqual("Test User");
-      expect(queryData.data[0].email).toEqual("test@example.com");
-    } finally {
-      await destroy(scope);
-      await assertWorkerDoesNotExist(workerName);
-    }
-  }, 120000); // Increased timeout for D1 database operations
-
-  test("create and test worker with Queue binding", async (scope) => {
-    // Sample ESM worker script with Queue functionality
-    const queueWorkerScript = `
-      export default {
-        async fetch(request, env, ctx) {
-          const url = new URL(request.url);
-
-          // Send a message to the queue
-          if (url.pathname === '/send-message') {
-            try {
-              const body = await request.json();
-              const messageId = await env.MESSAGE_QUEUE.send(body);
-
-              return new Response(JSON.stringify({
-                success: true,
-                messageId,
-                message: 'Message sent successfully'
-              }), {
-                status: 200,
-                headers: { 'Content-Type': 'application/json' }
-              });
-            } catch (error) {
-              return new Response(JSON.stringify({
-                success: false,
-                error: error.message
-              }), {
-                status: 500,
-                headers: { 'Content-Type': 'application/json' }
-              });
-            }
-          }
-
-          return new Response('Queue Worker is running!', {
-            status: 200,
-            headers: { 'Content-Type': 'text/plain' }
-          });
-        }
-      };
-    `;
-
-    const workerName = `${BRANCH_PREFIX}-test-worker-queue`;
-    const queueName = `${BRANCH_PREFIX}-test-queue`;
-
-    let worker: Worker<{ MESSAGE_QUEUE: Queue }> | undefined;
-    let queue: Queue | undefined;
-
-    try {
-      // Create a Queue
-      queue = await Queue(queueName, {
-        name: queueName,
-        settings: {
-          deliveryDelay: 0, // No delay for testing
-          deliveryPaused: false,
-        },
-      });
-
-      expect(queue.id).toBeTruthy();
-      expect(queue.name).toEqual(queueName);
-      expect(queue.type).toEqual("queue");
-
-      // Create a worker with the Queue binding
-      worker = await Worker(workerName, {
-        name: workerName,
-        script: queueWorkerScript,
-        format: "esm",
-        url: true, // Enable workers.dev URL to test the worker
-        bindings: {
-          MESSAGE_QUEUE: queue,
-        },
-      });
-
-      await new Promise((resolve) => setTimeout(resolve, 1000));
-
-      expect(worker.id).toBeTruthy();
-      expect(worker.name).toEqual(workerName);
-      expect(worker.bindings).toBeDefined();
-      expect(worker.bindings!.MESSAGE_QUEUE).toBeDefined();
-      expect(worker.url).toBeTruthy();
-
-      if (worker.url) {
-        // Send a message to the queue
-        const testMessage = {
-          id: "msg-123",
-          content: "Test message content",
-          timestamp: Date.now(),
-        };
-
-        const sendResponse = await fetch(`${worker.url}/send-message`, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify(testMessage),
-        });
-
-        expect(sendResponse.status).toEqual(200);
-        const responseData: any = await sendResponse.json();
-        expect(responseData.success).toEqual(true);
-        expect(responseData.message).toEqual("Message sent successfully");
-      }
-    } finally {
-      await destroy(scope);
-      await assertWorkerDoesNotExist(workerName);
-    }
-  }, 120000); // Increased timeout for Queue operations
-
   test("create and test worker with Self binding", async (scope) => {
     // Sample ESM worker script with Self binding functionality
 
@@ -1758,6 +947,20 @@ describe("Worker Resource", () => {
 
   test("create and test worker with cron triggers", async (scope) => {
     const workerName = `${BRANCH_PREFIX}-test-worker-cron`;
+
+    // Sample worker script with a scheduled handler
+    const cronWorkerScript = `
+      export default {
+        async fetch(request, env, ctx) {
+          return new Response('Worker with cron is running!', { status: 200 });
+        },
+        async scheduled(event, env, ctx) {
+          // Log the scheduled event details
+          console.log('Scheduled event received:', event.scheduledTime, event.cron);
+          // In a real worker, you would perform tasks here
+        },
+      };
+    `;
 
     let worker: Worker | undefined;
     try {
@@ -2002,53 +1205,6 @@ describe("Worker Resource", () => {
   test("create and delete worker with Analytics Engine binding", async (scope) => {
     const workerName = `${BRANCH_PREFIX}-test-worker-analytics-engine`;
 
-    // Sample worker script that uses Analytics Engine
-    const analyticsWorkerScript = `
-      export default {
-        async fetch(request, env, ctx) {
-          const url = new URL(request.url);
-          
-          // Log an event to the analytics engine
-          if (url.pathname === '/log-event') {
-            try {
-              const body = await request.json();
-              
-              // Write an event to the analytics dataset
-              env.ANALYTICS.writeDataPoint({
-                blobs: [body.action, body.category, body.details || ""],
-                doubles: [body.value || 1.0],
-                indexes: [body.userId || "anonymous"]
-              });
-              
-              return Response.json({
-                success: true,
-                message: "Event logged successfully"
-              });
-            } catch (error) {
-              return Response.json({
-                success: false,
-                error: error.message || "Unknown error"
-              }, { status: 500 });
-            }
-          }
-          
-          // Confirm binding exists
-          if (url.pathname === '/check-binding') {
-            return Response.json({
-              hasBinding: !!env.ANALYTICS,
-              bindingType: typeof env.ANALYTICS,
-              success: true
-            });
-          }
-          
-          return new Response('Analytics Engine Worker is running!', {
-            status: 200,
-            headers: { 'Content-Type': 'text/plain' }
-          });
-        }
-      };
-    `;
-
     let worker: Worker | undefined;
     let dataset: AnalyticsEngineDataset | undefined;
 
@@ -2066,7 +1222,51 @@ describe("Worker Resource", () => {
       // Create a worker with the analytics engine binding
       worker = await Worker(workerName, {
         name: workerName,
-        script: analyticsWorkerScript,
+        script: `
+          export default {
+            async fetch(request, env, ctx) {
+              const url = new URL(request.url);
+              
+              // Log an event to the analytics engine
+              if (url.pathname === '/log-event') {
+                try {
+                  const body = await request.json();
+                  
+                  // Write an event to the analytics dataset
+                  env.ANALYTICS.writeDataPoint({
+                    blobs: [body.action, body.category, body.details || ""],
+                    doubles: [body.value || 1.0],
+                    indexes: [body.userId || "anonymous"]
+                  });
+                  
+                  return Response.json({
+                    success: true,
+                    message: "Event logged successfully"
+                  });
+                } catch (error) {
+                  return Response.json({
+                    success: false,
+                    error: error.message || "Unknown error"
+                  }, { status: 500 });
+                }
+              }
+              
+              // Confirm binding exists
+              if (url.pathname === '/check-binding') {
+                return Response.json({
+                  hasBinding: !!env.ANALYTICS,
+                  bindingType: typeof env.ANALYTICS,
+                  success: true
+                });
+              }
+              
+              return new Response('Analytics Engine Worker is running!', {
+                status: 200,
+                headers: { 'Content-Type': 'text/plain' }
+              });
+            }
+          };
+        `,
         format: "esm",
         url: true, // Enable workers.dev URL to test the worker
         bindings: {
@@ -2113,497 +1313,4 @@ describe("Worker Resource", () => {
       await assertWorkerDoesNotExist(workerName);
     }
   }, 60000); // Increase timeout for Worker operations
-
-  test("create and test worker with cross-script durable object binding", async (scope) => {
-    // Create names for both workers
-    const doWorkerName = `${BRANCH_PREFIX}-do-provider-worker`;
-    const clientWorkerName = `${BRANCH_PREFIX}-do-client-worker`;
-
-    // Script for the worker that defines the durable object
-    const doProviderWorkerScript = `
-      export class SharedCounter {
-        constructor(state, env) {
-          this.state = state;
-          this.env = env;
-          this.counter = 0;
-        }
-
-        async fetch(request) {
-          const url = new URL(request.url);
-          
-          if (url.pathname === '/increment') {
-            this.counter++;
-            return new Response(JSON.stringify({
-              action: 'increment',
-              counter: this.counter,
-              worker: '${doWorkerName}'
-            }), {
-              headers: { 'Content-Type': 'application/json' }
-            });
-          }
-
-          if (url.pathname === '/get') {
-            return new Response(JSON.stringify({
-              action: 'get',
-              counter: this.counter,
-              worker: '${doWorkerName}'
-            }), {
-              headers: { 'Content-Type': 'application/json' }
-            });
-          }
-
-          return new Response('SharedCounter DO is running!', { status: 200 });
-        }
-      }
-
-      export default {
-        async fetch(request, env, ctx) {
-          return new Response('DO Provider Worker is running!', {
-            status: 200,
-            headers: { 'Content-Type': 'text/plain' }
-          });
-        }
-      };
-    `;
-
-    // Script for the worker that uses the cross-script durable object
-    const clientWorkerScript = `
-      export default {
-        async fetch(request, env, ctx) {
-          const url = new URL(request.url);
-          
-          if (url.pathname === '/increment') {
-            try {
-              // Get the durable object instance and increment
-              const id = env.SHARED_COUNTER.idFromName('test-counter');
-              const stub = env.SHARED_COUNTER.get(id);
-              const response = await stub.fetch(new Request('https://example.com/increment'));
-              const data = await response.json();
-              
-              return Response.json({
-                success: true,
-                clientWorker: '${clientWorkerName}',
-                result: data,
-                crossScriptWorking: true
-              });
-            } catch (error) {
-              return Response.json({
-                success: false,
-                error: error.message,
-                crossScriptWorking: false
-              }, { status: 500 });
-            }
-          }
-
-          if (url.pathname === '/get') {
-            try {
-              // Get the current counter value
-              const id = env.SHARED_COUNTER.idFromName('test-counter');
-              const stub = env.SHARED_COUNTER.get(id);
-              const response = await stub.fetch(new Request('https://example.com/get'));
-              const data = await response.json();
-              
-              return Response.json({
-                success: true,
-                clientWorker: '${clientWorkerName}',
-                result: data
-              });
-            } catch (error) {
-              return Response.json({
-                success: false,
-                error: error.message
-              }, { status: 500 });
-            }
-          }
-
-          return new Response('DO Client Worker is running!', {
-            status: 200,
-            headers: { 'Content-Type': 'text/plain' }
-          });
-        }
-      };
-    `;
-
-    let doProviderWorker;
-    let clientWorker;
-
-    try {
-      // First create the worker that defines the durable object with its own binding
-      doProviderWorker = await Worker(doWorkerName, {
-        name: doWorkerName,
-        script: doProviderWorkerScript,
-        format: "esm",
-        url: true, // Enable workers.dev URL
-        bindings: {
-          // Create a durable object namespace for the provider worker
-          SHARED_COUNTER: new DurableObjectNamespace(
-            "provider-counter-namespace",
-            {
-              className: "SharedCounter",
-              // No scriptName means it binds to its own script
-            },
-          ), // Bind to its own durable object
-        },
-      });
-
-      await new Promise((resolve) => setTimeout(resolve, 1000));
-
-      expect(doProviderWorker.id).toBeTruthy();
-      expect(doProviderWorker.name).toEqual(doWorkerName);
-      expect(doProviderWorker.url).toBeTruthy();
-
-      // Create the client worker with the cross-script durable object binding
-      clientWorker = await Worker(clientWorkerName, {
-        name: clientWorkerName,
-        script: clientWorkerScript,
-        format: "esm",
-        url: true, // Enable workers.dev URL
-        bindings: {
-          // Create a cross-script durable object namespace that references the first worker
-          SHARED_COUNTER: new DurableObjectNamespace(
-            "cross-script-counter-namespace",
-            {
-              className: "SharedCounter",
-              scriptName: doWorkerName, // This makes it cross-script
-            },
-          ), // Cross-script binding
-        },
-      });
-
-      await new Promise((resolve) => setTimeout(resolve, 1000));
-
-      expect(clientWorker.id).toBeTruthy();
-      expect(clientWorker.name).toEqual(clientWorkerName);
-      expect(clientWorker.url).toBeTruthy();
-      expect(clientWorker.bindings?.SHARED_COUNTER).toBeDefined();
-
-      // Verify the binding configuration
-      const binding = clientWorker.bindings.SHARED_COUNTER;
-      expect(binding.className).toEqual("SharedCounter");
-      expect(binding.scriptName).toEqual(doWorkerName);
-
-      // Test that both workers respond to basic requests
-      const doProviderResponse = await fetch(doProviderWorker.url!);
-      expect(doProviderResponse.status).toEqual(200);
-      const doProviderText = await doProviderResponse.text();
-      expect(doProviderText).toEqual("DO Provider Worker is running!");
-
-      const clientResponse = await fetch(clientWorker.url!);
-      expect(clientResponse.status).toEqual(200);
-      const clientText = await clientResponse.text();
-      expect(clientText).toEqual("DO Client Worker is running!");
-
-      // Test cross-script durable object functionality by calling increment
-      const incrementResponse = await fetch(`${clientWorker.url}/increment`);
-      expect(incrementResponse.status).toEqual(200);
-      const incrementData: any = await incrementResponse.json();
-
-      expect(incrementData).toMatchObject({
-        success: true,
-        clientWorker: clientWorkerName,
-        crossScriptWorking: true,
-        result: {
-          action: "increment",
-          worker: doWorkerName,
-        },
-      });
-
-      // Test getting the counter value
-      const getResponse = await fetch(`${clientWorker.url}/get`);
-      expect(getResponse.status).toEqual(200);
-      const getData: any = await getResponse.json();
-
-      expect(getData).toMatchObject({
-        success: true,
-        clientWorker: clientWorkerName,
-        result: {
-          action: "get",
-          worker: doWorkerName,
-        },
-      });
-
-      // Test state persistence by making multiple increment calls
-      const firstIncrement = await fetch(`${clientWorker.url}/increment`);
-      const firstData: any = await firstIncrement.json();
-
-      const secondIncrement = await fetch(`${clientWorker.url}/increment`);
-      const secondData: any = await secondIncrement.json();
-
-      const thirdIncrement = await fetch(`${clientWorker.url}/increment`);
-      const thirdData: any = await thirdIncrement.json();
-
-      // Verify that the counter is incrementing properly across calls
-      expect(firstData.result.counter).toBeLessThan(secondData.result.counter);
-      expect(secondData.result.counter).toBeLessThan(thirdData.result.counter);
-    } finally {
-      await destroy(scope);
-      // Verify both workers were deleted
-      await assertWorkerDoesNotExist(doWorkerName);
-      await assertWorkerDoesNotExist(clientWorkerName);
-    }
-  }, 120000); // Increased timeout for cross-script DO operations
-
-  test("create and test worker with cross-script durable object binding using re-exported syntax", async (scope) => {
-    // Create names for both workers
-    const doWorkerName = `${BRANCH_PREFIX}-do-provider-worker-re-exported`;
-    const clientWorkerName = `${BRANCH_PREFIX}-do-client-worker-re-exported`;
-
-    // Script for the worker that defines the durable object
-    const doProviderWorkerScript = `
-      export class SharedCounter {
-        constructor(state, env) {
-          this.state = state;
-          this.env = env;
-          this.counter = 0;
-        }
-
-        async fetch(request) {
-          const url = new URL(request.url);
-          
-          if (url.pathname === '/increment') {
-            this.counter++;
-            return new Response(JSON.stringify({
-              action: 'increment',
-              counter: this.counter,
-              worker: '${doWorkerName}'
-            }), {
-              headers: { 'Content-Type': 'application/json' }
-            });
-          }
-
-          if (url.pathname === '/get') {
-            return new Response(JSON.stringify({
-              action: 'get',
-              counter: this.counter,
-              worker: '${doWorkerName}'
-            }), {
-              headers: { 'Content-Type': 'application/json' }
-            });
-          }
-
-          return new Response('SharedCounter DO is running!', { status: 200 });
-        }
-      }
-
-      export default {
-        async fetch(request, env, ctx) {
-          return new Response('DO Provider Worker is running!', {
-            status: 200,
-            headers: { 'Content-Type': 'text/plain' }
-          });
-        }
-      };
-    `;
-
-    // Script for the worker that uses the cross-script durable object
-    const clientWorkerScript = `
-      export default {
-        async fetch(request, env, ctx) {
-          const url = new URL(request.url);
-          
-          if (url.pathname === '/increment') {
-            try {
-              // Get the durable object instance and increment
-              const id = env.SHARED_COUNTER.idFromName('test-counter');
-              const stub = env.SHARED_COUNTER.get(id);
-              const response = await stub.fetch(new Request('https://example.com/increment'));
-              const data = await response.json();
-              
-              return Response.json({
-                success: true,
-                clientWorker: '${clientWorkerName}',
-                result: data,
-                crossScriptWorking: true
-              });
-            } catch (error) {
-              return Response.json({
-                success: false,
-                error: error.message,
-                crossScriptWorking: false
-              }, { status: 500 });
-            }
-          }
-
-          if (url.pathname === '/get') {
-            try {
-              // Get the current counter value
-              const id = env.SHARED_COUNTER.idFromName('test-counter');
-              const stub = env.SHARED_COUNTER.get(id);
-              const response = await stub.fetch(new Request('https://example.com/get'));
-              const data = await response.json();
-              
-              return Response.json({
-                success: true,
-                clientWorker: '${clientWorkerName}',
-                result: data
-              });
-            } catch (error) {
-              return Response.json({
-                success: false,
-                error: error.message
-              }, { status: 500 });
-            }
-          }
-
-          return new Response('DO Client Worker is running!', {
-            status: 200,
-            headers: { 'Content-Type': 'text/plain' }
-          });
-        }
-      };
-    `;
-
-    let doProviderWorker;
-    let clientWorker;
-
-    try {
-      // First create the worker that defines the durable object with its own binding
-      doProviderWorker = await Worker(doWorkerName, {
-        name: doWorkerName,
-        script: doProviderWorkerScript,
-        format: "esm",
-        url: true, // Enable workers.dev URL
-        bindings: {
-          // Create a durable object namespace for the provider worker
-          SHARED_COUNTER: new DurableObjectNamespace(
-            "provider-counter-namespace",
-            {
-              className: "SharedCounter",
-              // No scriptName means it binds to its own script
-            },
-          ), // Bind to its own durable object
-        },
-      });
-
-      await new Promise((resolve) => setTimeout(resolve, 1000));
-
-      expect(doProviderWorker.id).toBeTruthy();
-      expect(doProviderWorker.name).toEqual(doWorkerName);
-      expect(doProviderWorker.url).toBeTruthy();
-
-      expect(doProviderWorker.bindings.SHARED_COUNTER.scriptName).toEqual(
-        doWorkerName,
-      );
-
-      // Create the client worker with the cross-script durable object binding
-      clientWorker = await Worker(clientWorkerName, {
-        name: clientWorkerName,
-        script: clientWorkerScript,
-        format: "esm",
-        url: true, // Enable workers.dev URL
-        bindings: {
-          // Create a cross-script durable object namespace that references the first worker
-          SHARED_COUNTER: doProviderWorker.bindings.SHARED_COUNTER,
-        },
-      });
-
-      await new Promise((resolve) => setTimeout(resolve, 1000));
-
-      expect(clientWorker.id).toBeTruthy();
-      expect(clientWorker.name).toEqual(clientWorkerName);
-      expect(clientWorker.url).toBeTruthy();
-      expect(clientWorker.bindings?.SHARED_COUNTER).toBeDefined();
-
-      // Verify the binding configuration
-      const binding = clientWorker.bindings.SHARED_COUNTER;
-      expect(binding.className).toEqual("SharedCounter");
-      expect(binding.scriptName).toEqual(doWorkerName);
-
-      // Test that both workers respond to basic requests
-      const doProviderResponse = await fetch(doProviderWorker.url!);
-      expect(doProviderResponse.status).toEqual(200);
-      const doProviderText = await doProviderResponse.text();
-      expect(doProviderText).toEqual("DO Provider Worker is running!");
-
-      const clientResponse = await fetch(clientWorker.url!);
-      expect(clientResponse.status).toEqual(200);
-      const clientText = await clientResponse.text();
-      expect(clientText).toEqual("DO Client Worker is running!");
-
-      // Test cross-script durable object functionality by calling increment
-      const incrementResponse = await fetch(`${clientWorker.url}/increment`);
-      expect(incrementResponse.status).toEqual(200);
-      const incrementData: any = await incrementResponse.json();
-
-      expect(incrementData).toMatchObject({
-        success: true,
-        clientWorker: clientWorkerName,
-        crossScriptWorking: true,
-        result: {
-          action: "increment",
-          worker: doWorkerName,
-        },
-      });
-
-      // Test getting the counter value
-      const getResponse = await fetch(`${clientWorker.url}/get`);
-      expect(getResponse.status).toEqual(200);
-      const getData: any = await getResponse.json();
-
-      expect(getData).toMatchObject({
-        success: true,
-        clientWorker: clientWorkerName,
-        result: {
-          action: "get",
-          worker: doWorkerName,
-        },
-      });
-
-      // Test state persistence by making multiple increment calls
-      const firstIncrement = await fetch(`${clientWorker.url}/increment`);
-      const firstData: any = await firstIncrement.json();
-
-      const secondIncrement = await fetch(`${clientWorker.url}/increment`);
-      const secondData: any = await secondIncrement.json();
-
-      const thirdIncrement = await fetch(`${clientWorker.url}/increment`);
-      const thirdData: any = await thirdIncrement.json();
-
-      // Verify that the counter is incrementing properly across calls
-      expect(firstData.result.counter).toBeLessThan(secondData.result.counter);
-      expect(secondData.result.counter).toBeLessThan(thirdData.result.counter);
-    } finally {
-      await destroy(scope);
-      // Verify both workers were deleted
-      await assertWorkerDoesNotExist(doWorkerName);
-      await assertWorkerDoesNotExist(clientWorkerName);
-    }
-  }, 120000); // Increased timeout for cross-script DO operations
-
-  test("adopting a Worker should use server-side state to migrate classes", async (scope) => {
-    try {
-      const workerName = `${BRANCH_PREFIX}-test-worker-adoption-migrate`;
-      await Worker("worker-1", {
-        name: workerName,
-        script: `
-          export class Counter {}
-          export default { fetch() {} }
-        `,
-        bindings: {
-          DO: new DurableObjectNamespace("DO", {
-            className: "Counter",
-          }),
-        },
-      });
-
-      await Worker("worker-2", {
-        name: workerName,
-        // adopt the worker since it already exists
-        adopt: true,
-        script: `
-          export class Counter2 {}
-          export default { fetch() {} }
-        `,
-        bindings: {
-          // mapped by stable ID "DO"
-          DO_1: new DurableObjectNamespace("DO", {
-            // should migrate to Counter 2
-            className: "Counter2",
-          }),
-        },
-      });
-    } finally {
-      await destroy(scope);
-    }
-  });
 });

--- a/alchemy/test/cloudflare/workflow.test.ts
+++ b/alchemy/test/cloudflare/workflow.test.ts
@@ -1,0 +1,575 @@
+import { describe, expect } from "bun:test";
+import { alchemy } from "../../src/alchemy.js";
+import { Worker } from "../../src/cloudflare/worker.js";
+import { Workflow } from "../../src/cloudflare/workflow.js";
+import { destroy } from "../../src/destroy.js";
+import { BRANCH_PREFIX } from "../util.js";
+
+import "../../src/test/bun.js";
+
+const test = alchemy.test(import.meta, {
+  prefix: BRANCH_PREFIX,
+});
+
+// Helper function to create client worker scripts
+function createClientWorkerScript(
+  clientWorkerName: string,
+  endpointPath: string,
+  workflowBindingName: string,
+  errorMessage: string,
+  params: Record<string, any>,
+) {
+  return `
+    export default {
+      async fetch(request, env, ctx) {
+        const url = new URL(request.url);
+        
+        if (url.pathname === '/${endpointPath}') {
+          try {
+            // Get the shared workflow binding
+            const workflow = env.${workflowBindingName};
+
+            if (!workflow) {
+              return new Response(JSON.stringify({ error: "${errorMessage}" }), {
+                status: 500,
+                headers: { 'Content-Type': 'application/json' }
+              });
+            }
+
+            // Create a workflow instance with parameters
+            const params = ${JSON.stringify(params)};
+            const instance = await workflow.create(params);
+
+            return Response.json({
+              id: instance.id,
+              details: await instance.status(),
+              success: true,
+              clientWorker: '${clientWorkerName}',
+              crossScriptWorking: true,
+              params: params
+            });
+          } catch (error) {
+            console.error("Error triggering shared workflow:", error);
+            return new Response(JSON.stringify({ 
+              error: error.message || "Unknown error",
+              crossScriptWorking: false
+            }), {
+              status: 500,
+              headers: { 'Content-Type': 'application/json' }
+            });
+          }
+        }
+
+        return new Response('Workflow Client Worker is running!', {
+          status: 200,
+          headers: { 'Content-Type': 'text/plain' }
+        });
+      }
+    };
+  `;
+}
+
+describe("Workflow", () => {
+  // Test for binding a workflow to a worker
+  test("create and delete worker with workflow binding", async (scope) => {
+    const workerName = `${BRANCH_PREFIX}-test-worker-workflow`;
+
+    // Sample worker script with workflow handler - updated to match Cloudflare Workflows pattern
+    const workflowWorkerScript = `
+      // Workflow definition for email notifications
+      export class EmailNotifier {
+        constructor(state, env) {
+          this.state = state;
+          this.env = env;
+        }
+
+        async run(event, step) {
+          // Process order data from event payload
+          const orderDetails = await step.do('process-order', async () => {
+            console.log("Processing order", event.payload);
+            return {
+              success: true,
+              orderId: event.payload.orderId,
+              message: "Order processed successfully"
+            };
+          });
+
+          return orderDetails;
+        }
+      }
+
+      // Workflow definition for order processing
+      export class OrderProcessor {
+        constructor(state, env) {
+          this.state = state;
+          this.env = env;
+        }
+
+        async run(event, step) {
+          // Process shipping data
+          const shippingDetails = await step.do('process-shipping', async () => {
+            console.log("Processing shipping", event.payload);
+            return {
+              success: true,
+              shipmentId: event.payload.shipmentId,
+              message: "Shipment scheduled successfully"
+            };
+          });
+
+          return shippingDetails;
+        }
+      }
+
+      export default {
+        async fetch(request, env, ctx) {
+          const url = new URL(request.url);
+
+          // Add endpoints to trigger workflows for testing
+          if (url.pathname === '/trigger-email-workflow') {
+            try {
+              // Get workflow binding
+              const workflow = env.EMAIL_WORKFLOW;
+
+              if (!workflow) {
+                return new Response(JSON.stringify({ error: "No email workflow binding found" }), {
+                  status: 500,
+                  headers: { 'Content-Type': 'application/json' }
+                });
+              }
+
+              // Create a workflow instance with parameters
+              const params = { orderId: "test-123", amount: 99.99 };
+              const instance = await workflow.create(params);
+
+              return Response.json({
+                id: instance.id,
+                details: await instance.status(),
+                success: true,
+                orderId: params.orderId,
+                message: "Order processed successfully"
+              });
+            } catch (error) {
+              console.error("Error triggering email workflow:", error);
+              return new Response(JSON.stringify({ error: error.message || "Unknown error" }), {
+                status: 500,
+                headers: { 'Content-Type': 'application/json' }
+              });
+            }
+          }
+
+          // Endpoint for the order workflow
+          if (url.pathname === '/trigger-order-workflow') {
+            try {
+              // Get workflow binding
+              const workflow = env.ORDER_WORKFLOW;
+
+              if (!workflow) {
+                return new Response(JSON.stringify({ error: "No order workflow binding found" }), {
+                  status: 500,
+                  headers: { 'Content-Type': 'application/json' }
+                });
+              }
+
+              // Create a workflow instance with parameters
+              const params = { shipmentId: "ship-456", carrier: "FastShip" };
+              const instance = await workflow.create(params);
+
+              return Response.json({
+                id: instance.id,
+                details: await instance.status(),
+                success: true,
+                shipmentId: params.shipmentId,
+                message: "Shipment scheduled successfully"
+              });
+            } catch (error) {
+              console.error("Error triggering order workflow:", error);
+              return new Response(JSON.stringify({ error: error.message || "Unknown error" }), {
+                status: 500,
+                headers: { 'Content-Type': 'application/json' }
+              });
+            }
+          }
+
+          return new Response('Worker with workflow bindings!', { status: 200 });
+        }
+      };
+    `;
+
+    let worker: Worker | undefined;
+    try {
+      // Create a workflow instance
+      const emailWorkflow = new Workflow("email-notifier", {
+        className: "EmailNotifier",
+        workflowName: "email-notification-workflow",
+      });
+
+      // Create a worker with the workflow binding
+      worker = await Worker(workerName, {
+        name: workerName,
+        script: workflowWorkerScript,
+        format: "esm",
+        bindings: {
+          EMAIL_WORKFLOW: emailWorkflow,
+        },
+        url: true, // Enable workers.dev URL to test the workflow
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+
+      expect(worker.id).toBeTruthy();
+      expect(worker.name).toEqual(workerName);
+      expect(worker.bindings).toBeDefined();
+      expect(worker.url).toBeTruthy();
+
+      // Test triggering the first workflow
+      const response = await fetch(`${worker.url!}/trigger-email-workflow`);
+      const result: any = await response.json();
+      console.log("Email workflow response:", result);
+
+      expect(response.status).toEqual(200);
+      expect(result.success).toEqual(true);
+      expect(result.orderId).toEqual("test-123");
+      expect(result.message).toEqual("Order processed successfully");
+      // Verify the instance ID is not empty
+      expect(result.id).toBeTruthy();
+      expect(typeof result.id).toBe("string");
+      expect(result.id.length).toBeGreaterThan(0);
+      // Verify the details contain valid status
+      expect(result.details).toBeDefined();
+      expect(result.details.status).toBeTruthy();
+
+      // Create a new workflow binding and update the worker
+      const orderWorkflow = new Workflow("order-processor", {
+        className: "OrderProcessor",
+        workflowName: "order-processing-workflow",
+      });
+
+      // Update the worker with multiple workflow bindings
+      worker = await Worker(workerName, {
+        name: workerName,
+        script: workflowWorkerScript,
+        format: "esm",
+        bindings: {
+          EMAIL_WORKFLOW: emailWorkflow,
+          ORDER_WORKFLOW: orderWorkflow,
+        },
+        url: true,
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+
+      expect(worker.bindings).toBeDefined();
+      expect(Object.keys(worker.bindings || {})).toHaveLength(2);
+
+      // Test triggering the second workflow
+      const orderResponse = await fetch(
+        `${worker.url!}/trigger-order-workflow`,
+      );
+      const orderResult: any = await orderResponse.json();
+      console.log("Order workflow response:", orderResult);
+
+      expect(orderResponse.status).toEqual(200);
+      expect(orderResult.success).toEqual(true);
+      expect(orderResult.shipmentId).toEqual("ship-456");
+      expect(orderResult.message).toEqual("Shipment scheduled successfully");
+      // Verify the instance ID is not empty
+      expect(orderResult.id).toBeTruthy();
+      expect(typeof orderResult.id).toBe("string");
+      expect(orderResult.id.length).toBeGreaterThan(0);
+      // Verify the details contain valid status
+      expect(orderResult.details).toBeDefined();
+      expect(orderResult.details.status).toBeTruthy();
+    } finally {
+      // Explicitly destroy resources since destroy: false is set
+      await destroy(scope);
+    }
+  });
+
+  test("create and test worker with cross-script workflow binding", async (scope) => {
+    // Create names for both workers
+    const workflowWorkerName = `${BRANCH_PREFIX}-workflow-provider-worker`;
+    const clientWorkerName = `${BRANCH_PREFIX}-workflow-client-worker`;
+
+    // Script for the worker that defines the workflow
+    const workflowProviderWorkerScript = createWorkflowProviderScript(
+      "SharedOrderProcessor",
+      workflowWorkerName,
+      "process-shared-order",
+      { orderId: "shared-123", amount: 199.99 },
+    );
+
+    // Script for the worker that uses the cross-script workflow
+    const clientWorkerScript = createClientWorkerScript(
+      clientWorkerName,
+      "trigger-shared-workflow",
+      "SHARED_ORDER_WORKFLOW",
+      "No shared workflow binding found",
+      { orderId: "shared-123", amount: 199.99 },
+    );
+
+    let workflowProviderWorker;
+    let clientWorker;
+
+    try {
+      // First create the worker that defines the workflow with its own binding
+      workflowProviderWorker = await Worker(workflowWorkerName, {
+        name: workflowWorkerName,
+        script: workflowProviderWorkerScript,
+        format: "esm",
+        url: true, // Enable workers.dev URL
+        bindings: {
+          // Create a workflow for the provider worker
+          SHARED_ORDER_WORKFLOW: new Workflow("shared-order-processor", {
+            className: "SharedOrderProcessor",
+            workflowName: "shared-order-processing-workflow",
+            // No scriptName means it binds to its own script
+          }),
+        },
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+
+      expect(workflowProviderWorker.id).toBeTruthy();
+      expect(workflowProviderWorker.name).toEqual(workflowWorkerName);
+      expect(workflowProviderWorker.url).toBeTruthy();
+
+      // Create the client worker with the cross-script workflow binding
+      clientWorker = await Worker(clientWorkerName, {
+        name: clientWorkerName,
+        script: clientWorkerScript,
+        format: "esm",
+        url: true, // Enable workers.dev URL
+        bindings: {
+          // Create a cross-script workflow binding using the same workflow details but with scriptName
+          SHARED_ORDER_WORKFLOW: new Workflow("shared-order-processor", {
+            className: "SharedOrderProcessor",
+            workflowName: "shared-order-processing-workflow",
+            scriptName: workflowWorkerName, // This makes it cross-script
+          }),
+        },
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+
+      expect(clientWorker.id).toBeTruthy();
+      expect(clientWorker.name).toEqual(clientWorkerName);
+      expect(clientWorker.url).toBeTruthy();
+      expect(clientWorker.bindings?.SHARED_ORDER_WORKFLOW).toBeDefined();
+
+      // Verify the binding configuration
+      const binding = clientWorker.bindings.SHARED_ORDER_WORKFLOW;
+      expect(binding.className).toEqual("SharedOrderProcessor");
+      expect(binding.scriptName).toEqual(workflowWorkerName);
+
+      // Test that both workers respond to basic requests
+      const workflowProviderResponse = await fetch(workflowProviderWorker.url!);
+      expect(workflowProviderResponse.status).toEqual(200);
+      const workflowProviderText = await workflowProviderResponse.text();
+      expect(workflowProviderText).toEqual(
+        "Workflow Provider Worker is running!",
+      );
+
+      const clientResponse = await fetch(clientWorker.url!);
+      expect(clientResponse.status).toEqual(200);
+      const clientText = await clientResponse.text();
+      expect(clientText).toEqual("Workflow Client Worker is running!");
+
+      // Test cross-script workflow functionality
+      const triggerResponse = await fetch(
+        `${clientWorker.url}/trigger-shared-workflow`,
+      );
+      expect(triggerResponse.status).toEqual(200);
+      const triggerData: any = await triggerResponse.json();
+
+      expect(triggerData).toMatchObject({
+        success: true,
+        clientWorker: clientWorkerName,
+        crossScriptWorking: true,
+        params: {
+          orderId: "shared-123",
+          amount: 199.99,
+        },
+      });
+
+      // Verify the instance ID is not empty
+      expect(triggerData.id).toBeTruthy();
+      expect(typeof triggerData.id).toBe("string");
+      expect(triggerData.id.length).toBeGreaterThan(0);
+      // Verify the details contain valid status
+      expect(triggerData.details).toBeDefined();
+      expect(triggerData.details.status).toBeTruthy();
+    } finally {
+      await destroy(scope);
+    }
+  }, 120000); // Increased timeout for cross-script workflow operations
+
+  test("create and test worker with cross-script workflow binding using re-exported syntax", async (scope) => {
+    // Create names for both workers
+    const workflowWorkerName = `${BRANCH_PREFIX}-workflow-provider-worker-re-exported`;
+    const clientWorkerName = `${BRANCH_PREFIX}-workflow-client-worker-re-exported`;
+
+    // Script for the worker that defines the workflow
+    const workflowProviderWorkerScript = createWorkflowProviderScript(
+      "SharedNotificationProcessor",
+      workflowWorkerName,
+      "process-shared-notification",
+      { notificationId: "notif-456", recipient: "user@example.com" },
+    );
+
+    // Script for the worker that uses the cross-script workflow
+    const clientWorkerScript = createClientWorkerScript(
+      clientWorkerName,
+      "trigger-shared-notification",
+      "SHARED_NOTIFICATION_WORKFLOW",
+      "No shared notification workflow binding found",
+      { notificationId: "notif-456", recipient: "user@example.com" },
+    );
+
+    let workflowProviderWorker;
+    let clientWorker;
+
+    try {
+      // First create the worker that defines the workflow with its own binding
+      workflowProviderWorker = await Worker(workflowWorkerName, {
+        name: workflowWorkerName,
+        script: workflowProviderWorkerScript,
+        format: "esm",
+        url: true, // Enable workers.dev URL
+        bindings: {
+          // Create a workflow for the provider worker
+          SHARED_NOTIFICATION_WORKFLOW: new Workflow(
+            "shared-notification-processor",
+            {
+              className: "SharedNotificationProcessor",
+              workflowName: "shared-notification-processing-workflow",
+              // No scriptName means it binds to its own script
+            },
+          ),
+        },
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+
+      expect(workflowProviderWorker.id).toBeTruthy();
+      expect(workflowProviderWorker.name).toEqual(workflowWorkerName);
+      expect(workflowProviderWorker.url).toBeTruthy();
+
+      expect(
+        workflowProviderWorker.bindings.SHARED_NOTIFICATION_WORKFLOW.scriptName,
+      ).toEqual(workflowWorkerName);
+
+      // Create the client worker with the cross-script workflow binding using re-exported syntax
+      clientWorker = await Worker(clientWorkerName, {
+        name: clientWorkerName,
+        script: clientWorkerScript,
+        format: "esm",
+        url: true, // Enable workers.dev URL
+        bindings: {
+          // Use the workflow binding from the first worker directly
+          SHARED_NOTIFICATION_WORKFLOW:
+            workflowProviderWorker.bindings.SHARED_NOTIFICATION_WORKFLOW,
+        },
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+
+      expect(clientWorker.id).toBeTruthy();
+      expect(clientWorker.name).toEqual(clientWorkerName);
+      expect(clientWorker.url).toBeTruthy();
+      expect(clientWorker.bindings?.SHARED_NOTIFICATION_WORKFLOW).toBeDefined();
+
+      // Verify the binding configuration
+      const binding = clientWorker.bindings.SHARED_NOTIFICATION_WORKFLOW;
+      expect(binding.className).toEqual("SharedNotificationProcessor");
+      expect(binding.scriptName).toEqual(workflowWorkerName);
+
+      // Test that both workers respond to basic requests
+      const workflowProviderResponse = await fetch(workflowProviderWorker.url!);
+      expect(workflowProviderResponse.status).toEqual(200);
+      const workflowProviderText = await workflowProviderResponse.text();
+      expect(workflowProviderText).toEqual(
+        "Workflow Provider Worker is running!",
+      );
+
+      const clientResponse = await fetch(clientWorker.url!);
+      expect(clientResponse.status).toEqual(200);
+      const clientText = await clientResponse.text();
+      expect(clientText).toEqual("Workflow Client Worker is running!");
+
+      // Test cross-script workflow functionality
+      const triggerResponse = await fetch(
+        `${clientWorker.url}/trigger-shared-notification`,
+      );
+      expect(triggerResponse.status).toEqual(200);
+      const triggerData: any = await triggerResponse.json();
+
+      expect(triggerData).toMatchObject({
+        success: true,
+        clientWorker: clientWorkerName,
+        crossScriptWorking: true,
+        params: {
+          notificationId: "notif-456",
+          recipient: "user@example.com",
+        },
+      });
+
+      // Verify the instance ID is not empty
+      expect(triggerData.id).toBeTruthy();
+      expect(typeof triggerData.id).toBe("string");
+      expect(triggerData.id.length).toBeGreaterThan(0);
+      // Verify the details contain valid status
+      expect(triggerData.details).toBeDefined();
+      expect(triggerData.details.status).toBeTruthy();
+    } finally {
+      await destroy(scope);
+    }
+  }, 120000); // Increased timeout for cross-script workflow operations
+});
+
+// Helper function to create workflow provider worker scripts
+function createWorkflowProviderScript(
+  className: string,
+  workerName: string,
+  stepName: string,
+  resultFields: Record<string, any>,
+) {
+  return `
+      // Shared workflow definition for ${stepName}
+      export class ${className} {
+        constructor(state, env) {
+          this.state = state;
+          this.env = env;
+        }
+  
+        async run(event, step) {
+          // Process ${stepName} data from event payload
+          const details = await step.do('${stepName}', async () => {
+            console.log("Processing ${stepName}", event.payload);
+            return {
+              success: true,
+              ${Object.entries(resultFields)
+                .map(([key, value]) =>
+                  typeof value === "string"
+                    ? `${key}: event.payload.${key}`
+                    : `${key}: ${JSON.stringify(value)}`,
+                )
+                .join(",\n            ")},
+              worker: '${workerName}',
+              message: "${stepName.charAt(0).toUpperCase() + stepName.slice(1)} processed successfully"
+            };
+          });
+  
+          return details;
+        }
+      }
+  
+      export default {
+        async fetch(request, env, ctx) {
+          return new Response('Workflow Provider Worker is running!', {
+            status: 200,
+            headers: { 'Content-Type': 'text/plain' }
+          });
+        }
+      };
+    `;
+}

--- a/alchemy/test/cloudflare/wrangler-json.test.ts
+++ b/alchemy/test/cloudflare/wrangler-json.test.ts
@@ -325,6 +325,7 @@ describe("WranglerJson Resource", () => {
         const workflow = new Workflow("test-workflow", {
           className: "TestWorkflow",
           workflowName: "test-workflow",
+          scriptName: "other-script",
         });
 
         const worker = await Worker(name, {
@@ -345,6 +346,7 @@ describe("WranglerJson Resource", () => {
         expect(spec.workflows?.[0].name).toEqual("test-workflow");
         expect(spec.workflows?.[0].binding).toEqual("WF");
         expect(spec.workflows?.[0].class_name).toEqual("TestWorkflow");
+        expect(spec.workflows?.[0].script_name).toEqual("other-script");
       } finally {
         await fs.rm(tempDir, { recursive: true, force: true });
         await destroy(scope);


### PR DESCRIPTION
### Method 1: Using re-exported syntax

You can directly reference the workflow binding from the provider Worker:

```ts
import { Worker, Workflow } from "alchemy/cloudflare";

// Create the provider Worker with the workflow
const host = await Worker("Host", {
  entrypoint: "./workflow-provider.ts", 
  bindings: {
    SHARED_PROCESSOR: new Workflow("shared-processor", {
      className: "SharedProcessor",
      workflowName: "shared-processing-workflow",
    }),
  },
});

// Create the client Worker using the provider's workflow binding directly
const client = await Worker("client", {
  entrypoint: "./client-worker.ts",
  bindings: {
    // Re-use the exact same workflow binding from the provider worker
    SHARED_PROCESSOR: host.bindings.SHARED_PROCESSOR,
  },
});
```

### Method 2: Using `scriptName` directly

Alternatively, when creating a workflow binding in a client Worker, you can reference a workflow defined in another Worker by specifying the `scriptName`:

```ts
import { Worker, Workflow } from "alchemy/cloudflare";

const hostWorkerName = "host"

const workflow = new Workflow("shared-processor", {
  className: "SharedProcessor",
  workflowName: "shared-processing-workflow",
  scriptName: hostWorkerName
});

// First, create the Worker that defines the workflow
const host = await Worker("host", {
  entrypoint: "./workflow-provider.ts",
  name: hostWorkerName,
  bindings: {
    // Define the workflow in this worker
    SHARED_PROCESSOR: workflow,
  },
});

// Then, create a client Worker that uses the cross-script workflow
const client = await Worker("client", {
  entrypoint: "./client-worker.ts",
  bindings: {
    // Reference the same workflow but specify which script it comes from
    SHARED_PROCESSOR: workflow,
  },
});
```