### PR TITLE
feat(cloudflare): default Worker.url to true

### DIFF
--- a/alchemy/src/cloudflare/worker.ts
+++ b/alchemy/src/cloudflare/worker.ts
@@ -351,6 +351,8 @@ export type Worker<
     /**
      * The worker's URL if enabled
      * Format: {name}.{subdomain}.workers.dev
+     *
+     * @default true
      */
     url?: string;
 
@@ -837,7 +839,7 @@ export const _Worker = Resource(
         this,
         api,
         workerName,
-        props.url ?? false,
+        props.url ?? true,
       );
 
       // Get current timestamp


### PR DESCRIPTION
Lots of people were expecting url to be `true` by default, so changing that to minimize friction.