### PR TITLE
feat(fs): allow overriding .alchemy dir

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Run affected tests
         run: |
           # Determine the base commit depending on event type
-          if [ "${{ github.event_name }}" == "pull_request_target" ]; then
+          if [ "${{ github.event_name }}" == "pull_request_target" ] || [ "${{ github.event_name }}" == "pull_request" ]; then
             # For pull requests, use PR base commit
             BASE_COMMIT="${{ github.event.pull_request.base.sha }}"
           elif [ "${{ github.event_name }}" == "push" ]; then

--- a/alchemy-web/docs/concepts/state.md
+++ b/alchemy-web/docs/concepts/state.md
@@ -80,6 +80,20 @@ This transparency helps with debugging and understanding what Alchemy is doing.
 
 ## Customizing State Storage
 
+### Change `.alchemy` directory location
+
+Perhaps you want to change the location of the `.alchemy` directory in a monorepo.
+
+```typescript
+const app = await alchemy("my-app", {
+  stateStore: (scope) => new FileSystemStateStore(scope, {
+    rootDir: path.resolve(import.meta.dir, "..", ".alchemy")
+  })
+});
+```
+
+### R2 Rest State Store
+
 Alchemy supports multiple state storage backends. You can use the default file system store or integrate with cloud services like Cloudflare R2:
 
 ```typescript

--- a/alchemy/src/fs/file-system-state-store.ts
+++ b/alchemy/src/fs/file-system-state-store.ts
@@ -11,8 +11,13 @@ const stateRootDir = path.join(process.cwd(), ".alchemy");
 export class FileSystemStateStore implements StateStore {
   public readonly dir: string;
   private initialized = false;
-  constructor(public readonly scope: Scope) {
-    this.dir = path.join(stateRootDir, ...scope.chain);
+  constructor(
+    public readonly scope: Scope,
+    options?: {
+      rootDir?: string;
+    },
+  ) {
+    this.dir = path.join(options?.rootDir ?? stateRootDir, ...scope.chain);
   }
 
   async init(): Promise<void> {

--- a/alchemy/test/aws/function.test.ts
+++ b/alchemy/test/aws/function.test.ts
@@ -357,15 +357,13 @@ describe("AWS Resources", () => {
 
         // Test function URL invocation
         const testEvent = { test: "url-event" };
-        const urlResponse = await fetch(func.functionUrl!, {
+        const urlResponse = await fetchAndExpectOK(func.functionUrl!, {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
           },
           body: JSON.stringify(testEvent),
         });
-
-        expect(urlResponse.status).toBe(200);
 
         const urlResponseBody: any = await urlResponse.json();
         expect(urlResponseBody.message).toBe("Hello from bundled handler!");
@@ -509,15 +507,13 @@ describe("AWS Resources", () => {
 
         // Test function URL invocation
         const testEvent = { test: "added-url-event" };
-        const urlResponse = await fetch(func.functionUrl!, {
+        const urlResponse = await fetchAndExpectOK(func.functionUrl!, {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
           },
           body: JSON.stringify(testEvent),
         });
-
-        expect(urlResponse.status).toBe(200);
 
         const urlResponseBody: any = await urlResponse.json();
         expect(urlResponseBody.message).toBe("Hello from bundled handler!");
@@ -661,7 +657,7 @@ describe("AWS Resources", () => {
 
         // Test function URL invocation (now in RESPONSE_STREAM mode)
         const streamTestEvent = { test: "response-stream-mode" };
-        const streamResponse = await fetch(func.functionUrl!, {
+        const streamResponse = await fetchAndExpectOK(func.functionUrl!, {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
@@ -670,7 +666,6 @@ describe("AWS Resources", () => {
         });
 
         // Check the status code
-        expect(streamResponse.status).toBe(200);
 
         // Test the URL configuration to verify the invokeMode setting was properly applied
         const urlConfig = await lambda.send(
@@ -825,13 +820,12 @@ describe("AWS Resources", () => {
         );
 
         // Test function invocation via URL
-        const response = await fetch(func.functionUrl!, {
+        const response = await fetchAndExpectOK(func.functionUrl!, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ test: "special-handler" }),
         });
 
-        expect(response.status).toBe(200);
         const body: any = await response.json();
         expect(body.message).toBe("Hello from bundled handler!");
       } finally {

--- a/alchemy/test/cloudflare/bucket.test.ts
+++ b/alchemy/test/cloudflare/bucket.test.ts
@@ -14,6 +14,7 @@ import { destroy } from "../../src/destroy.ts";
 import { BRANCH_PREFIX } from "../util.ts";
 
 import "../../src/test/vitest.ts";
+import { fetchAndExpectOK } from "./fetch-utils.ts";
 
 const test = alchemy.test(import.meta, {
   prefix: BRANCH_PREFIX,
@@ -226,8 +227,7 @@ describe("R2 Bucket Resource", async () => {
       expect(worker.bindings!.STORAGE).toBeDefined();
 
       // Test that the R2 binding is accessible in the worker
-      const response = await fetch(`${worker.url}/r2-info`);
-      expect(response.status).toEqual(200);
+      const response = await fetchAndExpectOK(`${worker.url}/r2-info`);
       const data = (await response.json()) as {
         hasR2: boolean;
         bucketName: string;

--- a/alchemy/test/cloudflare/durable-object.test.ts
+++ b/alchemy/test/cloudflare/durable-object.test.ts
@@ -8,6 +8,7 @@ import { withExponentialBackoff } from "../../src/util/retry.ts";
 import { BRANCH_PREFIX } from "../util.ts";
 
 import "../../src/test/vitest.ts";
+import { fetchAndExpectOK } from "./fetch-utils.ts";
 
 const test = alchemy.test(import.meta, {
   prefix: BRANCH_PREFIX,
@@ -335,19 +336,18 @@ describe("Durable Object Namespace", () => {
       expect(binding.scriptName).toEqual(doWorkerName);
 
       // Test that both workers respond to basic requests
-      const doProviderResponse = await fetch(doProviderWorker.url!);
-      expect(doProviderResponse.status).toEqual(200);
+      const doProviderResponse = await fetchAndExpectOK(doProviderWorker.url!);
       const doProviderText = await doProviderResponse.text();
       expect(doProviderText).toEqual("DO Provider Worker is running!");
 
-      const clientResponse = await fetch(clientWorker.url!);
-      expect(clientResponse.status).toEqual(200);
+      const clientResponse = await fetchAndExpectOK(clientWorker.url!);
       const clientText = await clientResponse.text();
       expect(clientText).toEqual("DO Client Worker is running!");
 
       // Test cross-script durable object functionality by calling increment
-      const incrementResponse = await fetch(`${clientWorker.url}/increment`);
-      expect(incrementResponse.status).toEqual(200);
+      const incrementResponse = await fetchAndExpectOK(
+        `${clientWorker.url}/increment`,
+      );
       const incrementData: any = await incrementResponse.json();
 
       expect(incrementData).toMatchObject({
@@ -361,8 +361,7 @@ describe("Durable Object Namespace", () => {
       });
 
       // Test getting the counter value
-      const getResponse = await fetch(`${clientWorker.url}/get`);
-      expect(getResponse.status).toEqual(200);
+      const getResponse = await fetchAndExpectOK(`${clientWorker.url}/get`);
       const getData: any = await getResponse.json();
 
       expect(getData).toMatchObject({
@@ -375,13 +374,19 @@ describe("Durable Object Namespace", () => {
       });
 
       // Test state persistence by making multiple increment calls
-      const firstIncrement = await fetch(`${clientWorker.url}/increment`);
+      const firstIncrement = await fetchAndExpectOK(
+        `${clientWorker.url}/increment`,
+      );
       const firstData: any = await firstIncrement.json();
 
-      const secondIncrement = await fetch(`${clientWorker.url}/increment`);
+      const secondIncrement = await fetchAndExpectOK(
+        `${clientWorker.url}/increment`,
+      );
       const secondData: any = await secondIncrement.json();
 
-      const thirdIncrement = await fetch(`${clientWorker.url}/increment`);
+      const thirdIncrement = await fetchAndExpectOK(
+        `${clientWorker.url}/increment`,
+      );
       const thirdData: any = await thirdIncrement.json();
 
       // Verify that the counter is incrementing properly across calls
@@ -697,14 +702,14 @@ export default {
       const doProviderText = await doProviderResponse.text();
       expect(doProviderText).toEqual("DO Provider Worker is running!");
 
-      const clientResponse = await fetch(clientWorker.url!);
-      expect(clientResponse.status).toEqual(200);
+      const clientResponse = await fetchAndExpectOK(clientWorker.url!);
       const clientText = await clientResponse.text();
       expect(clientText).toEqual("DO Client Worker is running!");
 
       // Test cross-script durable object functionality by calling increment
-      const incrementResponse = await fetch(`${clientWorker.url}/increment`);
-      expect(incrementResponse.status).toEqual(200);
+      const incrementResponse = await fetchAndExpectOK(
+        `${clientWorker.url}/increment`,
+      );
       const incrementData: any = await incrementResponse.json();
 
       expect(incrementData).toMatchObject({
@@ -718,8 +723,7 @@ export default {
       });
 
       // Test getting the counter value
-      const getResponse = await fetch(`${clientWorker.url}/get`);
-      expect(getResponse.status).toEqual(200);
+      const getResponse = await fetchAndExpectOK(`${clientWorker.url}/get`);
       const getData: any = await getResponse.json();
 
       expect(getData).toMatchObject({
@@ -732,13 +736,19 @@ export default {
       });
 
       // Test state persistence by making multiple increment calls
-      const firstIncrement = await fetch(`${clientWorker.url}/increment`);
+      const firstIncrement = await fetchAndExpectOK(
+        `${clientWorker.url}/increment`,
+      );
       const firstData: any = await firstIncrement.json();
 
-      const secondIncrement = await fetch(`${clientWorker.url}/increment`);
+      const secondIncrement = await fetchAndExpectOK(
+        `${clientWorker.url}/increment`,
+      );
       const secondData: any = await secondIncrement.json();
 
-      const thirdIncrement = await fetch(`${clientWorker.url}/increment`);
+      const thirdIncrement = await fetchAndExpectOK(
+        `${clientWorker.url}/increment`,
+      );
       const thirdData: any = await thirdIncrement.json();
 
       // Verify that the counter is incrementing properly across calls

--- a/biome.json
+++ b/biome.json
@@ -7,6 +7,7 @@
       "./alchemy/src/**/*.ts",
       "./alchemy/src/**/*.js",
       "./alchemy/test/**/*.ts",
+      "./alchemy-web/.vitepress/**/*.ts",
       "./scripts/**/*.ts",
       "./stacks/**/*.ts",
       "./examples/*/src/**/*.ts",
@@ -15,8 +16,8 @@
       "!examples/cloudflare-tanstack-start/src/routeTree.gen.ts",
       "!examples/cloudflare-redwood/worker-configuration.d.ts",
       "!./alchemy/src/aws/control/types.d.ts",
-      "!examples/cloudflare-tanstack-start/.output",
-      "alchemy-web/.vitepress/**/*.ts"
+      "!examples/cloudflare-tanstack-start/.output/**",
+      "!examples/cloudflare-nuxt-pipeline/.output/**"
     ],
     "maxSize": 10000000
   },


### PR DESCRIPTION
### Change `.alchemy` directory location

Perhaps you want to change the location of the `.alchemy` directory in a monorepo.

```typescript
const app = await alchemy("my-app", {
  stateStore: (scope) => new FileSystemStateStore(scope, {
    rootDir: path.resolve(import.meta.dir, "..", ".alchemy")
  })
});
```