### PR TITLE
feat(cloudflare): support binding to an external worker by name

### DIFF
--- a/alchemy/src/cloudflare/bindings.ts
+++ b/alchemy/src/cloudflare/bindings.ts
@@ -18,10 +18,10 @@ import type { KVNamespaceResource } from "./kv-namespace.ts";
 import type { PipelineResource } from "./pipeline.ts";
 import type { QueueResource } from "./queue.ts";
 import type { VectorizeIndexResource } from "./vectorize-index.ts";
-import type { WorkerStub } from "./worker-stub.ts";
-import type { Worker } from "./worker.ts";
-import type { Workflow } from "./workflow.ts";
 import type { VersionMetadata } from "./version-metadata.ts";
+import type { WorkerStub } from "./worker-stub.ts";
+import type { Worker, WorkerRef } from "./worker.ts";
+import type { Workflow } from "./workflow.ts";
 
 export type Bindings = {
   [bindingName: string]: Binding;
@@ -57,6 +57,7 @@ export type Binding =
   | VectorizeIndexResource
   | Worker
   | WorkerStub
+  | WorkerRef
   | Workflow
   | BrowserRendering
   | VersionMetadata

--- a/alchemy/src/cloudflare/bound.ts
+++ b/alchemy/src/cloudflare/bound.ts
@@ -13,9 +13,9 @@ import type { HyperdriveResource as _Hyperdrive } from "./hyperdrive.ts";
 import type { PipelineResource as _Pipeline } from "./pipeline.ts";
 import type { QueueResource as _Queue } from "./queue.ts";
 import type { VectorizeIndexResource as _VectorizeIndex } from "./vectorize-index.ts";
-import type { Worker as _Worker } from "./worker.ts";
-import type { Workflow as _Workflow } from "./workflow.ts";
 import type { VersionMetadata as _VersionMetadata } from "./version-metadata.ts";
+import type { Worker as _Worker, WorkerRef } from "./worker.ts";
+import type { Workflow as _Workflow } from "./workflow.ts";
 
 export type Bound<T extends Binding> = T extends _DurableObjectNamespace<
   infer O
@@ -23,7 +23,7 @@ export type Bound<T extends Binding> = T extends _DurableObjectNamespace<
   ? DurableObjectNamespace<O>
   : T extends { type: "kv_namespace" }
     ? KVNamespace
-    : T extends _Worker<any, infer RPC>
+    : T extends _Worker<any, infer RPC> | WorkerRef<infer RPC>
       ? Service<RPC> & {
           // cloudflare's Rpc.Provider type loses mapping between properties (jump to definition)
           // we fix that using Pick to re-connect mappings

--- a/alchemy/src/cloudflare/worker-metadata.ts
+++ b/alchemy/src/cloudflare/worker-metadata.ts
@@ -358,7 +358,6 @@ export async function prepareWorkerMetadata<B extends Bindings>(
           "namespaceId" in binding ? binding.namespaceId : binding.id,
       });
     } else if (binding.type === "service") {
-      console.log(binding);
       meta.bindings.push({
         type: "service",
         name: bindingName,

--- a/alchemy/src/cloudflare/worker-metadata.ts
+++ b/alchemy/src/cloudflare/worker-metadata.ts
@@ -358,10 +358,11 @@ export async function prepareWorkerMetadata<B extends Bindings>(
           "namespaceId" in binding ? binding.namespaceId : binding.id,
       });
     } else if (binding.type === "service") {
+      console.log(binding);
       meta.bindings.push({
         type: "service",
         name: bindingName,
-        service: binding.name,
+        service: "service" in binding ? binding.service : binding.name,
       });
     } else if (binding.type === "durable_object_namespace") {
       meta.bindings.push({

--- a/alchemy/src/cloudflare/worker.ts
+++ b/alchemy/src/cloudflare/worker.ts
@@ -23,6 +23,7 @@ import {
   type Binding,
   type Bindings,
   Json,
+  type WorkerBindingService,
   type WorkerBindingSpec,
 } from "./bindings.ts";
 import type { Bound } from "./bound.ts";
@@ -383,6 +384,56 @@ export type Worker<
      */
     compatibilityFlags: string[];
   };
+
+/**
+ * Represents a reference to a Cloudflare Worker service.
+ *
+ * @template RPC - The type of the worker's RPC entrypoint, defaults to Rpc.WorkerEntrypointBranded.
+ *
+ * This interface extends all properties of WorkerBindingService except for "name".
+ * It also includes an optional __rpc__ property for type branding.
+ */
+export type WorkerRef<
+  RPC extends Rpc.WorkerEntrypointBranded = Rpc.WorkerEntrypointBranded,
+> = Omit<WorkerBindingService, "name"> & {
+  /**
+   * Optional type branding for the worker's RPC entrypoint.
+   */
+  __rpc__?: RPC;
+};
+
+/**
+ * Creates a reference to a Cloudflare Worker service.
+ *
+ * @example
+ * // Create a reference to a Cloudflare Worker service:
+ * const ref = WorkerRef({
+ *   service: "my-worker",
+ *   environment: "production",
+ *   namespace: "main"
+ * });
+ *
+ * // Optionally, you can specify only the service:
+ * const ref2 = WorkerRef({ service: "my-worker" });
+ *
+ * // You can also specify the RPC type for stronger typing:
+ * interface MyWorkerRPC extends Rpc.WorkerEntrypointBranded {
+ *   myMethod(arg: string): Promise<number>;
+ * }
+ * const typedRef = WorkerRef<MyWorkerRPC>({ service: "my-worker" });
+ */
+export function WorkerRef<
+  RPC extends Rpc.WorkerEntrypointBranded = Rpc.WorkerEntrypointBranded,
+>(options?: {
+  service: string;
+  environment?: string;
+  namespace?: string;
+}): WorkerRef<RPC> {
+  return {
+    ...options,
+    type: "service",
+  } as WorkerRef<RPC>;
+}
 
 /**
  * A Cloudflare Worker is a serverless function that can be deployed to the Cloudflare network.

--- a/alchemy/src/cloudflare/wrangler.json.ts
+++ b/alchemy/src/cloudflare/wrangler.json.ts
@@ -447,7 +447,7 @@ function processBindings(
       // Service binding
       services.push({
         binding: bindingName,
-        service: binding.name,
+        service: "name" in binding ? binding.name : binding.service,
       });
     } else if (binding.type === "kv_namespace") {
       // KV Namespace binding

--- a/alchemy/test/cloudflare/bucket.test.ts
+++ b/alchemy/test/cloudflare/bucket.test.ts
@@ -45,11 +45,6 @@ describe("R2 Bucket Resource", async () => {
       const gotBucket = await getBucket(api, testId);
       expect(gotBucket.result.name).toEqual(testId);
 
-      // Check if bucket exists by listing buckets
-      const buckets = await listBuckets(api);
-      const foundBucket = buckets.find((b) => b.Name === testId);
-      expect(foundBucket).toBeTruthy();
-
       // Update the bucket to enable public access
       bucket = await R2Bucket(testId, {
         name: testId,
@@ -74,28 +69,29 @@ describe("R2 Bucket Resource", async () => {
   test("bucket with jurisdiction", async (scope) => {
     const api = await createCloudflareApi();
     const euBucketName = `${testId}-eu`;
-    const euBucket = await R2Bucket(euBucketName, {
-      name: euBucketName,
-      jurisdiction: "eu",
-      adopt: true,
-    });
-
+    let euBucket: R2Bucket | undefined;
     try {
+      euBucket = await R2Bucket(euBucketName, {
+        name: euBucketName,
+        jurisdiction: "eu",
+        adopt: true,
+      });
       // Create a bucket with EU jurisdiction
       expect(euBucket.name).toEqual(euBucketName);
       expect(euBucket.jurisdiction).toEqual("eu");
 
-      // Check if bucket exists by listing buckets
-      const buckets = await listBuckets(api, {
+      // Check if bucket exists by getting it explicitly
+      const gotBucket = await getBucket(api, euBucketName, {
         jurisdiction: "eu",
       });
-      const foundBucket = buckets.find((b) => b.Name === euBucketName);
-      expect(foundBucket).toBeTruthy();
+      expect(gotBucket.result.name).toEqual(euBucketName);
 
       // Note: S3 API doesn't expose jurisdiction info, so we can't verify that aspect
     } finally {
       await alchemy.destroy(scope);
-      await assertBucketDeleted(euBucket);
+      if (euBucket) {
+        await assertBucketDeleted(euBucket);
+      }
     }
   });
 
@@ -167,12 +163,6 @@ describe("R2 Bucket Resource", async () => {
     } finally {
       // Destroy the bucket which should empty it first
       await alchemy.destroy(scope);
-
-      console.log(
-        "Note: Manual cleanup may be needed for bucket:",
-        bucket?.name,
-      );
-      console.log("Visit the Cloudflare dashboard to verify bucket deletion");
     }
   });
 
@@ -239,7 +229,7 @@ describe("R2 Bucket Resource", async () => {
   });
 });
 
-async function assertBucketDeleted(bucket: R2Bucket) {
+async function assertBucketDeleted(bucket: R2Bucket, attempt = 0) {
   const api = await createCloudflareApi();
   try {
     if (!bucket.name) {
@@ -253,7 +243,12 @@ async function assertBucketDeleted(bucket: R2Bucket) {
     const foundBucket = buckets.find((b) => b.Name === bucket.name);
 
     if (foundBucket) {
-      throw new Error(`Bucket ${bucket.name} was not deleted as expected`);
+      if (attempt > 30) {
+        throw new Error(`Bucket ${bucket.name} was not deleted as expected`);
+      } else {
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+        await assertBucketDeleted(bucket, attempt + 1);
+      }
     }
   } catch (error: any) {
     // If we get a 404 or NoSuchBucket error, the bucket was deleted


### PR DESCRIPTION
## Reference Workers by Name

Use `WorkerRef` to reference an existing worker by its service name rather than by resource instance. This is useful for worker-to-worker bindings when you need to reference a worker that already exists.

```ts
import { Worker, WorkerRef } from "alchemy/cloudflare";

const callerWorker = await Worker("caller", {
  bindings: {
    TARGET_WORKER: WorkerRef({
      // reference the worker by name (not created with Alchemy)
      service: "target-worker"
    })
  },
});
```

### RPC Type

If you're using a WorkerEntrypoint RPC, you can provide its type:

```ts
import { Worker, WorkerRef } from "alchemy/cloudflare";
import type { MyWorkerEntrypoint } from "./src/worker.ts";

const callerWorker = await Worker("caller", {
  name: "caller-worker",
  bindings: {
    TARGET_WORKER: WorkerRef<MyWorkerEntrypoint>({
      service: "target-worker",
      environment: "production", // Optional
      namespace: "main"           // Optional
    })
  },
});
```
