### PR TITLE
chore: update guides to use code groups for package manager commands

### DIFF
--- a/alchemy-web/docs/guides/cloudflare-auth.md
+++ b/alchemy-web/docs/guides/cloudflare-auth.md
@@ -23,9 +23,26 @@ CLOUDFLARE_API_TOKEN=<token>
 ```
 
 Or set when running your script:
-```sh
+
+::: code-group
+
+```sh [bun]
 CLOUDFLARE_API_TOKEN=<token> bun ./alchemy.run.ts
 ```
+
+```sh [npm]
+CLOUDFLARE_API_TOKEN=<token> npx tsx ./alchemy.run.ts
+```
+
+```sh [pnpm]
+CLOUDFLARE_API_TOKEN=<token> pnpm tsx ./alchemy.run.ts
+```
+
+```sh [yarn]
+CLOUDFLARE_API_TOKEN=<token> yarn tsx ./alchemy.run.ts
+```
+
+:::
 
 You can explciitly set an `apiToken` when creating a Cloudflare Resource, such as a `Worker`:
 
@@ -43,14 +60,48 @@ await Worker("my-worker", {
 If you don't specify `CLOUDFLARE_API_KEY` or `CLOUDFLARE_API_TOKEN`, then Alchemy will use the OAuth Token and Refresh Token to authenticate with Cloudflare.
 
 First, make sure you've logged in with wrangler:
-```sh
-wrangler login
+
+::: code-group
+
+```sh [bun]
+bun wrangler login
 ```
 
+```sh [npm]
+npx wrangler login
+```
+
+```sh [pnpm]
+pnpm wrangler login
+```
+
+```sh [yarn]
+yarn wrangler login
+```
+
+:::
+
 Then, run your script (without `CLOUDFLARE_API_KEY` or `CLOUDFLARE_API_TOKEN` environment variables):
-```sh
+
+::: code-group
+
+```sh [bun]
 bun ./alchemy.run.ts
 ```
+
+```sh [npm]
+npx tsx ./alchemy.run.ts
+```
+
+```sh [pnpm]
+pnpm tsx ./alchemy.run.ts
+```
+
+```sh [yarn]
+yarn tsx ./alchemy.run.ts
+```
+
+:::
 
 ## Global API Key
 
@@ -69,9 +120,26 @@ CLOUDFLARE_API_KEY=<token>
 ```
 
 Or set when running your script:
-```sh
+
+::: code-group
+
+```sh [bun]
 CLOUDFLARE_API_KEY=<token> bun ./alchemy.run.ts
 ```
+
+```sh [npm]
+CLOUDFLARE_API_KEY=<token> npx tsx ./alchemy.run.ts
+```
+
+```sh [pnpm]
+CLOUDFLARE_API_KEY=<token> pnpm tsx ./alchemy.run.ts
+```
+
+```sh [yarn]
+CLOUDFLARE_API_KEY=<token> yarn tsx ./alchemy.run.ts
+```
+
+:::
 
 You can explciitly set an `apiKey` when creating a Cloudflare Resource, such as a `Worker`:
 
@@ -91,9 +159,25 @@ When using [Global API Keys](#global-api-key), Alchemy must be configured with t
 
 By default, Alchemy will use the `CLOUDFLARE_EMAIL` if set
 
-```sh
+::: code-group
+
+```sh [bun]
 CLOUDFLARE_EMAIL=me@example.com CLOUDFLARE_API_KEY=<token> bun ./alchemy.run.ts
 ```
+
+```sh [npm]
+CLOUDFLARE_EMAIL=me@example.com CLOUDFLARE_API_KEY=<token> npx tsx ./alchemy.run.ts
+```
+
+```sh [pnpm]
+CLOUDFLARE_EMAIL=me@example.com CLOUDFLARE_API_KEY=<token> pnpm tsx ./alchemy.run.ts
+```
+
+```sh [yarn]
+CLOUDFLARE_EMAIL=me@example.com CLOUDFLARE_API_KEY=<token> yarn tsx ./alchemy.run.ts
+```
+
+:::
 
 You can explicitly set `email` when creating a Cloudlfare Resource:
 
@@ -113,19 +197,54 @@ await Worker("my-worker", {
 
 By default, Alchemy will resolve the account ID from the API or OAuth token.
 
-```sh
+::: code-group
+
+```sh [bun]
 # will use wrangler login and resolve the first account you have acces to (ideal for personal accounts)
 bun ./alchemy.run.ts
 ```
+
+```sh [npm]
+# will use wrangler login and resolve the first account you have acces to (ideal for personal accounts)
+npx tsx ./alchemy.run.ts
+```
+
+```sh [pnpm]
+# will use wrangler login and resolve the first account you have acces to (ideal for personal accounts)
+pnpm tsx ./alchemy.run.ts
+```
+
+```sh [yarn]
+# will use wrangler login and resolve the first account you have acces to (ideal for personal accounts)
+yarn tsx ./alchemy.run.ts
+```
+
+:::
 
 > [!CAUTION]
 > If your token has access to more than one account, Alchemy chooses the first one arbitrarily.
 
 You can override the default account ID with the `CLOUDFLARE_ACCOUNT_ID` environment variable:
 
-```sh
+::: code-group
+
+```sh [bun]
 CLOUDFLARE_ACCOUNT_ID=<account-id> bun ./alchemy.run.ts
 ```
+
+```sh [npm]
+CLOUDFLARE_ACCOUNT_ID=<account-id> npx tsx ./alchemy.run.ts
+```
+
+```sh [pnpm]
+CLOUDFLARE_ACCOUNT_ID=<account-id> pnpm tsx ./alchemy.run.ts
+```
+
+```sh [yarn]
+CLOUDFLARE_ACCOUNT_ID=<account-id> yarn tsx ./alchemy.run.ts
+```
+
+:::
 
 Or by setting `accountId` when creating a Cloudflare Resource:
 ```ts

--- a/alchemy-web/docs/guides/cloudflare-nuxt-pipeline.md
+++ b/alchemy-web/docs/guides/cloudflare-nuxt-pipeline.md
@@ -12,17 +12,55 @@ This guide walks through deploying a full-stack Nuxt 3 application with a backen
 
 Start by creating a new Nuxt 3 project:
 
-```sh
+::: code-group
+
+```sh [bun]
 bun create nuxt-app 
 cd my-nuxt-app
 bun install
 ```
 
+```sh [npm]
+npm create nuxt-app 
+cd my-nuxt-app
+npm install
+```
+
+```sh [pnpm]
+pnpm create nuxt-app 
+cd my-nuxt-app
+pnpm install
+```
+
+```sh [yarn]
+yarn create nuxt-app 
+cd my-nuxt-app
+yarn install
+```
+
+:::
+
 Install alchemy and Cloudflare:
 
-```sh
+::: code-group
+
+```sh [bun]
 bun add alchemy cloudflare
 ```
+
+```sh [npm]
+npm install alchemy cloudflare
+```
+
+```sh [pnpm]
+pnpm add alchemy cloudflare
+```
+
+```sh [yarn]
+yarn add alchemy cloudflare
+```
+
+:::
 
 ## Configure Nuxt for Cloudflare
 
@@ -252,15 +290,47 @@ button {
 
 Login to Cloudflare:
 
-```sh
-wrangler login
+::: code-group
+
+```sh [bun]
+bun wrangler login
 ```
+
+```sh [npm]
+npx wrangler login
+```
+
+```sh [pnpm]
+pnpm wrangler login
+```
+
+```sh [yarn]
+yarn wrangler login
+```
+
+:::
 
 Run your Alchemy script to deploy the application:
 
-```sh
+::: code-group
+
+```sh [bun]
 bun ./alchemy.run
 ```
+
+```sh [npm]
+npx tsx ./alchemy.run
+```
+
+```sh [pnpm]
+pnpm tsx ./alchemy.run
+```
+
+```sh [yarn]
+yarn tsx ./alchemy.run
+```
+
+:::
 
 It should output the URL of your deployed site:
 
@@ -276,9 +346,25 @@ Click the URL to see your site. Test sending data via the form; it should appear
 
 To run your application locally, use the Nuxt development server:
 
-```sh
+::: code-group
+
+```sh [bun]
 bun run dev
 ```
+
+```sh [npm]
+npm run dev
+```
+
+```sh [pnpm]
+pnpm run dev
+```
+
+```sh [yarn]
+yarn run dev
+```
+
+:::
 
 This will start a local development server:
 
@@ -293,6 +379,22 @@ Nuxt 3.9.0 with Nitro 2.8.1
 
 When you're finished experimenting, you can tear down the application:
 
-```sh
+::: code-group
+
+```sh [bun]
 bun ./alchemy.run --destroy
-``` 
+```
+
+```sh [npm]
+npx tsx ./alchemy.run --destroy
+```
+
+```sh [pnpm]
+pnpm tsx ./alchemy.run --destroy
+```
+
+```sh [yarn]
+yarn tsx ./alchemy.run --destroy
+```
+
+:::

--- a/alchemy-web/docs/guides/cloudflare-redwood.md
+++ b/alchemy-web/docs/guides/cloudflare-redwood.md
@@ -12,16 +12,55 @@ This guide demonstrates how to deploy a Redwood application with Drizzle to Clou
 
 Start by creating a new Redwood project using the Drizzle template:
 
-```bash
+::: code-group
+
+```sh [bun]
 bunx degit redwoodjs/example-drizzle my-cloudflare-app
 cd my-cloudflare-app
 bun install
 ```
 
+```sh [npm]
+npx degit redwoodjs/example-drizzle my-cloudflare-app
+cd my-cloudflare-app
+npm install
+```
+
+```sh [pnpm]
+pnpm dlx degit redwoodjs/example-drizzle my-cloudflare-app
+cd my-cloudflare-app
+pnpm install
+```
+
+```sh [yarn]
+yarn dlx degit redwoodjs/example-drizzle my-cloudflare-app
+cd my-cloudflare-app
+yarn install
+```
+
+:::
+
 Install `cloudflare` and `alchemy`:
-```sh
+
+::: code-group
+
+```sh [bun]
 bun add alchemy cloudflare
 ```
+
+```sh [npm]
+npm install alchemy cloudflare
+```
+
+```sh [pnpm]
+pnpm add alchemy cloudflare
+```
+
+```sh [yarn]
+yarn add alchemy cloudflare
+```
+
+:::
 
 ## Create `alchemy.run.ts`
 
@@ -73,15 +112,47 @@ console.log({
 
 Login to Cloudflare:
 
-```sh
-wrangler login
+::: code-group
+
+```sh [bun]
+bun wrangler login
 ```
+
+```sh [npm]
+npx wrangler login
+```
+
+```sh [pnpm]
+pnpm wrangler login
+```
+
+```sh [yarn]
+yarn wrangler login
+```
+
+:::
 
 Run `alchemy.run.ts` script to deploy:
 
-```sh
+::: code-group
+
+```sh [bun]
 bun ./alchemy.run
 ```
+
+```sh [npm]
+npx tsx ./alchemy.run
+```
+
+```sh [pnpm]
+pnpm tsx ./alchemy.run
+```
+
+```sh [yarn]
+yarn tsx ./alchemy.run
+```
+
+:::
 
 It should log out the URL of your deployed site:
 ```sh
@@ -142,9 +213,25 @@ export const posts = sqliteTable("posts", {
 
 After modifying the schema, generate a migration:
 
-```sh
+::: code-group
+
+```sh [bun]
 bun migrate:new
 ```
+
+```sh [npm]
+npm run migrate:new
+```
+
+```sh [pnpm]
+pnpm migrate:new
+```
+
+```sh [yarn]
+yarn migrate:new
+```
+
+:::
 
 This will create a new migration file in the `drizzle` directory.
 
@@ -152,9 +239,25 @@ This will create a new migration file in the `drizzle` directory.
 
 Now that we've modified the schema and generated migrations, let's redeploy our application with the updated database schema:
 
-```sh
+::: code-group
+
+```sh [bun]
 bun ./alchemy.run
 ```
+
+```sh [npm]
+npx tsx ./alchemy.run
+```
+
+```sh [pnpm]
+pnpm tsx ./alchemy.run
+```
+
+```sh [yarn]
+yarn tsx ./alchemy.run
+```
+
+:::
 
 The D1Database resource will automatically apply migrations from the directory we specified earlier (`migrationsDir: "drizzle"`).
 
@@ -163,9 +266,25 @@ The D1Database resource will automatically apply migrations from the directory w
 
 Redwood has integrated development tooling. Run the development server:
 
-```sh
+::: code-group
+
+```sh [bun]
 bun run dev
 ```
+
+```sh [npm]
+npm run dev
+```
+
+```sh [pnpm]
+pnpm run dev
+```
+
+```sh [yarn]
+yarn run dev
+```
+
+:::
 
 This will start both the web and API sides of your Redwood application:
 
@@ -183,6 +302,22 @@ This will start both the web and API sides of your Redwood application:
 
 That's it! You can now tear down the app (if you want to):
 
-```bash
+::: code-group
+
+```sh [bun]
 bun ./alchemy.run --destroy
 ```
+
+```sh [npm]
+npx tsx ./alchemy.run --destroy
+```
+
+```sh [pnpm]
+pnpm tsx ./alchemy.run --destroy
+```
+
+```sh [yarn]
+yarn tsx ./alchemy.run --destroy
+```
+
+:::

--- a/alchemy-web/docs/guides/cloudflare-tanstack-start.md
+++ b/alchemy-web/docs/guides/cloudflare-tanstack-start.md
@@ -12,11 +12,33 @@ This guide walks through how to deploy a TanStack Start application to Cloudflar
 
 Start by creating a TanStack Start project:
 
-```sh
+::: code-group
+
+```sh [bun]
 bunx gitpick TanStack/router/tree/main/examples/react/start-basic start-basic
 cd start-basic
 bun install
 ```
+
+```sh [npm]
+npx gitpick TanStack/router/tree/main/examples/react/start-basic start-basic
+cd start-basic
+npm install
+```
+
+```sh [pnpm]
+pnpm dlx gitpick TanStack/router/tree/main/examples/react/start-basic start-basic
+cd start-basic
+pnpm install
+```
+
+```sh [yarn]
+yarn dlx gitpick TanStack/router/tree/main/examples/react/start-basic start-basic
+cd start-basic
+yarn install
+```
+
+:::
 
 > [!NOTE]
 > See TanStack's [Quick Start](https://tanstack.com/start/latest/docs/framework/react/quick-start) guide for more details on TanStack Start applications.
@@ -25,9 +47,25 @@ bun install
 
 Install the required dependencies:
 
-```sh
+::: code-group
+
+```sh [bun]
 bun add alchemy cloudflare
 ```
+
+```sh [npm]
+npm install alchemy cloudflare
+```
+
+```sh [pnpm]
+pnpm add alchemy cloudflare
+```
+
+```sh [yarn]
+yarn add alchemy cloudflare
+```
+
+:::
 
 ## Create `alchemy.run.ts`
 
@@ -127,15 +165,47 @@ export const DEPLOY_URL = typeof window !== "undefined" ? window.location.origin
 
 Login to Cloudflare:
 
-```sh
-wrangler login
+::: code-group
+
+```sh [bun]
+bun wrangler login
 ```
+
+```sh [npm]
+npx wrangler login
+```
+
+```sh [pnpm]
+pnpm wrangler login
+```
+
+```sh [yarn]
+yarn wrangler login
+```
+
+:::
 
 Run your Alchemy script to deploy the application:
 
-```sh
+::: code-group
+
+```sh [bun]
 bun ./alchemy.run
 ```
+
+```sh [npm]
+npx tsx ./alchemy.run
+```
+
+```sh [pnpm]
+pnpm tsx ./alchemy.run
+```
+
+```sh [yarn]
+yarn tsx ./alchemy.run
+```
+
+:::
 
 It should output the URL of your deployed site:
 
@@ -151,9 +221,25 @@ Click the URL to see your TanStack Start application live!
 
 To run your application locally, use the TanStack Start development server:
 
-```sh
+::: code-group
+
+```sh [bun]
 bun run dev
 ```
+
+```sh [npm]
+npm run dev
+```
+
+```sh [pnpm]
+pnpm run dev
+```
+
+```sh [yarn]
+yarn run dev
+```
+
+:::
 
 This will start a local development server with hot module reloading:
 
@@ -169,8 +255,24 @@ This will start a local development server with hot module reloading:
 
 When you're finished experimenting, you can tear down the application:
 
-```bash
+::: code-group
+
+```sh [bun]
 bun ./alchemy.run --destroy
 ```
+
+```sh [npm]
+npx tsx ./alchemy.run --destroy
+```
+
+```sh [pnpm]
+pnpm tsx ./alchemy.run --destroy
+```
+
+```sh [yarn]
+yarn tsx ./alchemy.run --destroy
+```
+
+:::
 
 This will remove all Cloudflare resources created by this deployment.


### PR DESCRIPTION
Updates all guides in alchemy-web/docs/guides/ to use standardized code groups for package manager specific instructions.

## Changes

- Convert individual commands to code groups with bun, npm, pnpm, yarn options
- Update cloudflare-auth.md: 5 command sections standardized
- Update cloudflare-tanstack-start.md: 5 command sections standardized
- Update cloudflare-redwood.md: 6 command sections standardized
- Update cloudflare-nuxt-pipeline.md: 5 command sections standardized
- Maintain consistent formatting across all installation, login, deployment, dev, and teardown commands

Fixed #290

Generated with [Claude Code](https://claude.ai/code)