### PR TITLE
feat: implement Phase 1 Kubernetes provider with core resources

### DIFF
--- a/alchemy/package.json
+++ b/alchemy/package.json
@@ -86,6 +86,10 @@
       "bun": "./src/vercel/index.ts",
       "import": "./lib/vercel/index.js"
     },
+    "./k8s": {
+      "bun": "./src/k8s/index.ts",
+      "import": "./lib/k8s/index.js"
+    },
     "./shadcn": {
       "bun": "./src/web/shadcn.ts",
       "import": "./lib/web/shadcn.js"
@@ -128,6 +132,7 @@
     "@cloudflare/unenv-preset": "^2.3.1",
     "@cloudflare/workers-shared": "^0.17.5",
     "@iarna/toml": "^2.2.5",
+    "@kubernetes/client-node": "^1.0.0",
     "@octokit/rest": "^21.1.1",
     "@swc/core": "^1.11.24",
     "ai": "^4.0.0",

--- a/alchemy/src/k8s/client.ts
+++ b/alchemy/src/k8s/client.ts
@@ -1,0 +1,222 @@
+import * as k8s from "@kubernetes/client-node";
+
+/**
+ * Configuration options for the Kubernetes client
+ */
+export interface KubernetesClientOptions {
+  /**
+   * Path to kubeconfig file. Defaults to ~/.kube/config
+   */
+  kubeconfig?: string;
+  
+  /**
+   * Kubernetes context to use from kubeconfig
+   */
+  context?: string;
+  
+  /**
+   * Cluster configuration for direct connection
+   */
+  cluster?: {
+    /**
+     * Server URL (e.g., https://kubernetes.example.com:6443)
+     */
+    server: string;
+    
+    /**
+     * Certificate authority data (base64 encoded)
+     */
+    certificateAuthorityData?: string;
+    
+    /**
+     * Skip TLS verification (not recommended for production)
+     */
+    skipTlsVerify?: boolean;
+  };
+  
+  /**
+   * User credentials for authentication
+   */
+  user?: {
+    /**
+     * Client certificate data (base64 encoded)
+     */
+    clientCertificateData?: string;
+    
+    /**
+     * Client key data (base64 encoded)
+     */
+    clientKeyData?: string;
+    
+    /**
+     * Bearer token for service account authentication
+     */
+    token?: string;
+    
+    /**
+     * Username for basic authentication
+     */
+    username?: string;
+    
+    /**
+     * Password for basic authentication
+     */
+    password?: string;
+  };
+  
+  /**
+   * Default namespace for operations (defaults to 'default')
+   */
+  defaultNamespace?: string;
+}
+
+/**
+ * Kubernetes API client wrapper that provides a unified interface
+ * for interacting with Kubernetes resources
+ */
+export class KubernetesClient {
+  public readonly kc: k8s.KubeConfig;
+  public readonly coreV1Api: k8s.CoreV1Api;
+  public readonly appsV1Api: k8s.AppsV1Api;
+  public readonly networkingV1Api: k8s.NetworkingV1Api;
+  public readonly rbacV1Api: k8s.RbacAuthorizationV1Api;
+  public readonly defaultNamespace: string;
+
+  constructor(options: KubernetesClientOptions = {}) {
+    this.kc = new k8s.KubeConfig();
+    this.defaultNamespace = options.defaultNamespace || "default";
+
+    // Configure the Kubernetes client based on options
+    if (options.cluster && options.user) {
+      // Direct configuration
+      this.kc.loadFromOptions({
+        clusters: [{
+          name: "default-cluster",
+          server: options.cluster.server,
+          caData: options.cluster.certificateAuthorityData,
+          skipTLSVerify: options.cluster.skipTlsVerify,
+        }],
+        users: [{
+          name: "default-user",
+          certData: options.user.clientCertificateData,
+          keyData: options.user.clientKeyData,
+          token: options.user.token,
+          username: options.user.username,
+          password: options.user.password,
+        }],
+        contexts: [{
+          name: "default-context",
+          cluster: "default-cluster",
+          user: "default-user",
+          namespace: this.defaultNamespace,
+        }],
+        currentContext: "default-context",
+      });
+    } else if (options.kubeconfig) {
+      // Load from specific kubeconfig file
+      this.kc.loadFromFile(options.kubeconfig);
+    } else {
+      // Try to load from default locations
+      try {
+        this.kc.loadFromDefault();
+      } catch (error) {
+        // If no default config is found, try in-cluster config
+        try {
+          this.kc.loadFromCluster();
+        } catch (clusterError) {
+          throw new Error(
+            `Failed to load Kubernetes configuration. Tried default kubeconfig and in-cluster config. Original errors: ${error}, ${clusterError}`
+          );
+        }
+      }
+    }
+
+    // Set context if specified
+    if (options.context) {
+      this.kc.setCurrentContext(options.context);
+    }
+
+    // Initialize API clients
+    this.coreV1Api = this.kc.makeApiClient(k8s.CoreV1Api);
+    this.appsV1Api = this.kc.makeApiClient(k8s.AppsV1Api);
+    this.networkingV1Api = this.kc.makeApiClient(k8s.NetworkingV1Api);
+    this.rbacV1Api = this.kc.makeApiClient(k8s.RbacAuthorizationV1Api);
+  }
+
+  /**
+   * Get the current namespace from context, or fall back to default
+   */
+  getCurrentNamespace(): string {
+    const currentContext = this.kc.getCurrentContext();
+    if (currentContext) {
+      const context = this.kc.getContextObject(currentContext);
+      return context?.namespace || this.defaultNamespace;
+    }
+    return this.defaultNamespace;
+  }
+
+  /**
+   * Check if the client can connect to the Kubernetes API
+   */
+  async healthCheck(): Promise<boolean> {
+    try {
+      await this.coreV1Api.getAPIVersions();
+      return true;
+    } catch (error) {
+      console.error("Kubernetes health check failed:", error);
+      return false;
+    }
+  }
+}
+
+/**
+ * Create a Kubernetes client with the provided options
+ */
+export function createKubernetesClient(
+  options: KubernetesClientOptions = {}
+): KubernetesClient {
+  return new KubernetesClient(options);
+}
+
+/**
+ * Get a default Kubernetes client that uses standard kubeconfig resolution
+ */
+let defaultClient: KubernetesClient | undefined;
+
+export function getDefaultKubernetesClient(): KubernetesClient {
+  if (!defaultClient) {
+    defaultClient = createKubernetesClient();
+  }
+  return defaultClient;
+}
+
+/**
+ * Handle common Kubernetes API errors and provide helpful error messages
+ */
+export function handleKubernetesError(error: any, operation: string, resourceType: string, resourceName: string): never {
+  if (error.response) {
+    const { status, statusText, body } = error.response;
+    let message = `Failed to ${operation} ${resourceType} '${resourceName}': ${status} ${statusText}`;
+    
+    if (body && body.message) {
+      message += ` - ${body.message}`;
+    }
+    
+    // Add specific guidance for common errors
+    if (status === 401) {
+      message += ". Check your Kubernetes authentication credentials.";
+    } else if (status === 403) {
+      message += ". Check your Kubernetes RBAC permissions.";
+    } else if (status === 404) {
+      message += ". The resource may not exist or the namespace may be incorrect.";
+    } else if (status === 409) {
+      message += ". A resource with this name already exists.";
+    }
+    
+    throw new Error(message);
+  } else if (error.message) {
+    throw new Error(`Failed to ${operation} ${resourceType} '${resourceName}': ${error.message}`);
+  } else {
+    throw new Error(`Failed to ${operation} ${resourceType} '${resourceName}': Unknown error`);
+  }
+}

--- a/alchemy/src/k8s/config-map.ts
+++ b/alchemy/src/k8s/config-map.ts
@@ -1,0 +1,321 @@
+import type { Context } from "../context.ts";
+import { Resource } from "../resource.ts";
+import { createKubernetesClient, handleKubernetesError, type KubernetesClientOptions } from "./client.ts";
+
+/**
+ * Properties for creating or updating a Kubernetes ConfigMap
+ */
+export interface ConfigMapProps extends KubernetesClientOptions {
+  /**
+   * Name of the ConfigMap. If not provided, the resource ID will be used.
+   */
+  name?: string;
+
+  /**
+   * Namespace where the ConfigMap should be created. Defaults to 'default'.
+   */
+  namespace?: string;
+
+  /**
+   * Labels are key-value pairs used for organizing and selecting ConfigMaps
+   */
+  labels?: Record<string, string>;
+
+  /**
+   * Annotations are arbitrary metadata that can be attached to the ConfigMap
+   */
+  annotations?: Record<string, string>;
+
+  /**
+   * Data contains the configuration data.
+   * Each key must consist of alphanumeric characters, '-', '_' or '.'.
+   * Values are always stored as strings.
+   */
+  data?: Record<string, string>;
+
+  /**
+   * BinaryData contains the binary data.
+   * Each key must consist of alphanumeric characters, '-', '_' or '.'.
+   * Values are base64 encoded byte arrays.
+   */
+  binaryData?: Record<string, string>;
+
+  /**
+   * Whether the ConfigMap should be immutable.
+   * Immutable ConfigMaps cannot be updated once created.
+   */
+  immutable?: boolean;
+}
+
+/**
+ * Output returned after ConfigMap creation/update
+ */
+export interface ConfigMap extends Resource<"k8s::ConfigMap"> {
+  /**
+   * Name of the ConfigMap
+   */
+  name: string;
+
+  /**
+   * Namespace of the ConfigMap
+   */
+  namespace: string;
+
+  /**
+   * Labels applied to the ConfigMap
+   */
+  labels?: Record<string, string>;
+
+  /**
+   * Annotations applied to the ConfigMap
+   */
+  annotations?: Record<string, string>;
+
+  /**
+   * Configuration data
+   */
+  data?: Record<string, string>;
+
+  /**
+   * Binary configuration data
+   */
+  binaryData?: Record<string, string>;
+
+  /**
+   * Whether the ConfigMap is immutable
+   */
+  immutable?: boolean;
+
+  /**
+   * Creation timestamp
+   */
+  creationTimestamp?: string;
+
+  /**
+   * Resource version for optimistic concurrency control
+   */
+  resourceVersion?: string;
+
+  /**
+   * Unique identifier for the ConfigMap
+   */
+  uid?: string;
+}
+
+/**
+ * Creates and manages Kubernetes ConfigMaps.
+ *
+ * ConfigMaps allow you to decouple configuration artifacts from image content
+ * to keep containerized applications portable. They store non-confidential data
+ * in key-value pairs and can be consumed as environment variables, command-line
+ * arguments, or configuration files in volumes.
+ *
+ * @example
+ * ## Basic application configuration
+ *
+ * Create a ConfigMap with application settings
+ *
+ * ```ts
+ * const appConfig = await ConfigMap("app-config", {
+ *   namespace: "production",
+ *   data: {
+ *     "database.host": "db.example.com",
+ *     "database.port": "5432",
+ *     "log.level": "info",
+ *     "feature.enabled": "true"
+ *   }
+ * });
+ * ```
+ *
+ * @example
+ * ## Configuration file content
+ *
+ * Store entire configuration files in a ConfigMap
+ *
+ * ```ts
+ * const nginxConfig = await ConfigMap("nginx-config", {
+ *   namespace: "web",
+ *   data: {
+ *     "nginx.conf": `
+ *       server {
+ *         listen 80;
+ *         server_name example.com;
+ *         location / {
+ *           proxy_pass http://backend:3000;
+ *         }
+ *       }
+ *     `,
+ *     "mime.types": "text/html html htm shtml;"
+ *   }
+ * });
+ * ```
+ *
+ * @example
+ * ## Mixed data and binary data
+ *
+ * Create a ConfigMap with both text and binary content
+ *
+ * ```ts
+ * const mixedConfig = await ConfigMap("mixed-config", {
+ *   namespace: "production",
+ *   data: {
+ *     "config.yaml": `
+ *       api:
+ *         version: v1
+ *         timeout: 30s
+ *     `,
+ *     "database.url": "postgresql://user:pass@host:5432/db"
+ *   },
+ *   binaryData: {
+ *     "keystore.jks": "base64encodedkeystoredata=="
+ *   }
+ * });
+ * ```
+ *
+ * @example
+ * ## Immutable ConfigMap
+ *
+ * Create an immutable ConfigMap for production stability
+ *
+ * ```ts
+ * const immutableConfig = await ConfigMap("prod-config-v1", {
+ *   namespace: "production",
+ *   data: {
+ *     "api.endpoint": "https://api.prod.company.com",
+ *     "cache.ttl": "3600",
+ *     "max.connections": "100"
+ *   },
+ *   immutable: true,
+ *   labels: {
+ *     version: "v1.0.0",
+ *     environment: "production"
+ *   }
+ * });
+ * ```
+ */
+export const ConfigMap = Resource(
+  "k8s::ConfigMap",
+  async function (this: Context<ConfigMap>, id: string, props: ConfigMapProps = {}): Promise<ConfigMap> {
+    const client = createKubernetesClient(props);
+    const configMapName = props.name || id;
+    const namespace = props.namespace || client.getCurrentNamespace();
+
+    if (this.phase === "delete") {
+      try {
+        await client.coreV1Api.deleteNamespacedConfigMap(configMapName, namespace);
+        console.log(`Deleted ConfigMap: ${configMapName} in namespace: ${namespace}`);
+      } catch (error: any) {
+        if (error.response?.status === 404) {
+          console.log(`ConfigMap ${configMapName} not found in namespace ${namespace}, already deleted`);
+        } else {
+          handleKubernetesError(error, "delete", "ConfigMap", configMapName);
+        }
+      }
+      return this.destroy();
+    }
+
+    try {
+      if (this.phase === "create") {
+        // Create the ConfigMap
+        const configMapSpec = {
+          apiVersion: "v1",
+          kind: "ConfigMap",
+          metadata: {
+            name: configMapName,
+            namespace: namespace,
+            labels: props.labels,
+            annotations: props.annotations,
+          },
+          data: props.data,
+          binaryData: props.binaryData,
+          immutable: props.immutable,
+        };
+
+        const createResponse = await client.coreV1Api.createNamespacedConfigMap(namespace, configMapSpec);
+        console.log(`Created ConfigMap: ${configMapName} in namespace: ${namespace}`);
+
+        return this({
+          name: configMapName,
+          namespace: namespace,
+          labels: createResponse.body.metadata?.labels,
+          annotations: createResponse.body.metadata?.annotations,
+          data: createResponse.body.data,
+          binaryData: createResponse.body.binaryData,
+          immutable: createResponse.body.immutable,
+          creationTimestamp: createResponse.body.metadata?.creationTimestamp,
+          resourceVersion: createResponse.body.metadata?.resourceVersion,
+          uid: createResponse.body.metadata?.uid,
+        });
+      } else {
+        // Update existing ConfigMap
+        // Note: Immutable ConfigMaps cannot be updated
+        if (this.output?.immutable) {
+          throw new Error(`Cannot update immutable ConfigMap: ${configMapName}`);
+        }
+
+        const patchBody = {
+          metadata: {
+            labels: props.labels,
+            annotations: props.annotations,
+          },
+          data: props.data,
+          binaryData: props.binaryData,
+        };
+
+        const patchResponse = await client.coreV1Api.patchNamespacedConfigMap(
+          configMapName,
+          namespace,
+          patchBody,
+          undefined, // pretty
+          undefined, // dryRun
+          undefined, // fieldManager
+          undefined, // fieldValidation
+          undefined, // force
+          {
+            headers: { "Content-Type": "application/merge-patch+json" },
+          }
+        );
+
+        console.log(`Updated ConfigMap: ${configMapName} in namespace: ${namespace}`);
+
+        return this({
+          name: configMapName,
+          namespace: namespace,
+          labels: patchResponse.body.metadata?.labels,
+          annotations: patchResponse.body.metadata?.annotations,
+          data: patchResponse.body.data,
+          binaryData: patchResponse.body.binaryData,
+          immutable: patchResponse.body.immutable,
+          creationTimestamp: patchResponse.body.metadata?.creationTimestamp,
+          resourceVersion: patchResponse.body.metadata?.resourceVersion,
+          uid: patchResponse.body.metadata?.uid,
+        });
+      }
+    } catch (error: any) {
+      if (error.response?.status === 409 && this.phase === "create") {
+        // ConfigMap already exists, get its current state
+        try {
+          const getResponse = await client.coreV1Api.readNamespacedConfigMap(configMapName, namespace);
+          console.log(`ConfigMap ${configMapName} already exists in namespace ${namespace}, adopting it`);
+
+          return this({
+            name: configMapName,
+            namespace: namespace,
+            labels: getResponse.body.metadata?.labels,
+            annotations: getResponse.body.metadata?.annotations,
+            data: getResponse.body.data,
+            binaryData: getResponse.body.binaryData,
+            immutable: getResponse.body.immutable,
+            creationTimestamp: getResponse.body.metadata?.creationTimestamp,
+            resourceVersion: getResponse.body.metadata?.resourceVersion,
+            uid: getResponse.body.metadata?.uid,
+          });
+        } catch (getError: any) {
+          handleKubernetesError(getError, "get", "ConfigMap", configMapName);
+        }
+      } else {
+        handleKubernetesError(error, this.phase === "create" ? "create" : "update", "ConfigMap", configMapName);
+      }
+    }
+  }
+);

--- a/alchemy/src/k8s/deployment.ts
+++ b/alchemy/src/k8s/deployment.ts
@@ -1,0 +1,454 @@
+import type { Context } from "../context.ts";
+import { Resource } from "../resource.ts";
+import { createKubernetesClient, handleKubernetesError, type KubernetesClientOptions } from "./client.ts";
+import type { 
+  KubernetesMetadata, 
+  LabelSelector, 
+  PodTemplateSpec,
+  Container,
+  Volume
+} from "./types.ts";
+
+/**
+ * Properties for creating or updating a Kubernetes Deployment
+ */
+export interface DeploymentProps extends KubernetesClientOptions {
+  /**
+   * Name of the deployment. If not provided, the resource ID will be used.
+   */
+  name?: string;
+
+  /**
+   * Namespace where the deployment should be created. Defaults to 'default'.
+   */
+  namespace?: string;
+
+  /**
+   * Labels are key-value pairs used for organizing and selecting deployments
+   */
+  labels?: Record<string, string>;
+
+  /**
+   * Annotations are arbitrary metadata that can be attached to the deployment
+   */
+  annotations?: Record<string, string>;
+
+  /**
+   * Number of desired replicas. Defaults to 1.
+   */
+  replicas?: number;
+
+  /**
+   * Label selector for pods. Must match the template metadata labels.
+   */
+  selector: LabelSelector;
+
+  /**
+   * Pod template that describes the pods that will be created
+   */
+  template: PodTemplateSpec;
+
+  /**
+   * Deployment strategy for rolling updates
+   */
+  strategy?: {
+    /**
+     * Type of deployment strategy
+     */
+    type?: "RollingUpdate" | "Recreate";
+
+    /**
+     * Rolling update configuration
+     */
+    rollingUpdate?: {
+      /**
+       * Maximum number of pods that can be unavailable during update
+       */
+      maxUnavailable?: number | string;
+
+      /**
+       * Maximum number of pods that can be created above desired replica count
+       */
+      maxSurge?: number | string;
+    };
+  };
+
+  /**
+   * Minimum number of seconds for which a newly created pod should be ready
+   */
+  minReadySeconds?: number;
+
+  /**
+   * Number of old ReplicaSets to retain for rollback
+   */
+  revisionHistoryLimit?: number;
+
+  /**
+   * Indicates that the deployment is paused
+   */
+  paused?: boolean;
+
+  /**
+   * Maximum time in seconds for a deployment to make progress
+   */
+  progressDeadlineSeconds?: number;
+}
+
+/**
+ * Output returned after Deployment creation/update
+ */
+export interface Deployment extends Resource<"k8s::Deployment"> {
+  /**
+   * Name of the deployment
+   */
+  name: string;
+
+  /**
+   * Namespace of the deployment
+   */
+  namespace: string;
+
+  /**
+   * Labels applied to the deployment
+   */
+  labels?: Record<string, string>;
+
+  /**
+   * Annotations applied to the deployment
+   */
+  annotations?: Record<string, string>;
+
+  /**
+   * Desired number of replicas
+   */
+  replicas?: number;
+
+  /**
+   * Label selector for pods
+   */
+  selector: LabelSelector;
+
+  /**
+   * Pod template specification
+   */
+  template: PodTemplateSpec;
+
+  /**
+   * Deployment strategy
+   */
+  strategy?: {
+    type?: "RollingUpdate" | "Recreate";
+    rollingUpdate?: {
+      maxUnavailable?: number | string;
+      maxSurge?: number | string;
+    };
+  };
+
+  /**
+   * Current status of the deployment
+   */
+  status?: {
+    /**
+     * Number of replicas observed by the deployment controller
+     */
+    observedGeneration?: number;
+
+    /**
+     * Total number of non-terminated pods targeted by this deployment
+     */
+    replicas?: number;
+
+    /**
+     * Number of non-terminated pods with the desired template spec
+     */
+    updatedReplicas?: number;
+
+    /**
+     * Number of ready replicas for this deployment
+     */
+    readyReplicas?: number;
+
+    /**
+     * Number of available replicas for this deployment
+     */
+    availableReplicas?: number;
+
+    /**
+     * Number of unavailable replicas for this deployment
+     */
+    unavailableReplicas?: number;
+
+    /**
+     * Deployment conditions
+     */
+    conditions?: Array<{
+      type: string;
+      status: "True" | "False" | "Unknown";
+      lastUpdateTime?: string;
+      lastTransitionTime?: string;
+      reason?: string;
+      message?: string;
+    }>;
+  };
+
+  /**
+   * Creation timestamp
+   */
+  creationTimestamp?: string;
+
+  /**
+   * Resource version for optimistic concurrency control
+   */
+  resourceVersion?: string;
+
+  /**
+   * Unique identifier for the deployment
+   */
+  uid?: string;
+}
+
+/**
+ * Creates and manages Kubernetes Deployments.
+ *
+ * Deployments provide declarative updates for Pods and ReplicaSets. They manage
+ * rolling updates, scaling, and rollback capabilities for stateless applications.
+ *
+ * @example
+ * ## Basic web application deployment
+ *
+ * Create a simple nginx deployment with 3 replicas
+ *
+ * ```ts
+ * const webApp = await Deployment("web-app", {
+ *   namespace: "production",
+ *   replicas: 3,
+ *   selector: {
+ *     matchLabels: { app: "web-app" }
+ *   },
+ *   template: {
+ *     metadata: {
+ *       labels: { app: "web-app" }
+ *     },
+ *     spec: {
+ *       containers: [{
+ *         name: "nginx",
+ *         image: "nginx:1.20",
+ *         ports: [{ containerPort: 80 }]
+ *       }]
+ *     }
+ *   }
+ * });
+ * ```
+ *
+ * @example
+ * ## Application with environment variables and resource limits
+ *
+ * Deploy an API server with configuration from environment variables
+ *
+ * ```ts
+ * const apiServer = await Deployment("api-server", {
+ *   namespace: "production",
+ *   replicas: 2,
+ *   selector: {
+ *     matchLabels: { app: "api-server", version: "v1" }
+ *   },
+ *   template: {
+ *     metadata: {
+ *       labels: { app: "api-server", version: "v1" }
+ *     },
+ *     spec: {
+ *       containers: [{
+ *         name: "api",
+ *         image: "myapp/api:v1.2.3",
+ *         ports: [{ containerPort: 8080 }],
+ *         env: [
+ *           { name: "NODE_ENV", value: "production" },
+ *           { name: "PORT", value: "8080" }
+ *         ],
+ *         resources: {
+ *           requests: { cpu: "100m", memory: "128Mi" },
+ *           limits: { cpu: "500m", memory: "512Mi" }
+ *         }
+ *       }]
+ *     }
+ *   }
+ * });
+ * ```
+ *
+ * @example
+ * ## Deployment with ConfigMap and Secret volumes
+ *
+ * Deploy an application that uses ConfigMap for configuration and Secret for credentials
+ *
+ * ```ts
+ * const app = await Deployment("my-app", {
+ *   namespace: "production",
+ *   replicas: 1,
+ *   selector: {
+ *     matchLabels: { app: "my-app" }
+ *   },
+ *   template: {
+ *     metadata: {
+ *       labels: { app: "my-app" }
+ *     },
+ *     spec: {
+ *       containers: [{
+ *         name: "app",
+ *         image: "myapp:latest",
+ *         ports: [{ containerPort: 3000 }],
+ *         volumeMounts: [
+ *           { name: "config", mountPath: "/etc/config" },
+ *           { name: "secrets", mountPath: "/etc/secrets", readOnly: true }
+ *         ]
+ *       }],
+ *       volumes: [
+ *         { name: "config", configMap: { name: "app-config" } },
+ *         { name: "secrets", secret: { secretName: "app-secrets" } }
+ *       ]
+ *     }
+ *   }
+ * });
+ * ```
+ */
+export const Deployment = Resource(
+  "k8s::Deployment",
+  async function (this: Context<Deployment>, id: string, props: DeploymentProps): Promise<Deployment> {
+    const client = createKubernetesClient(props);
+    const deploymentName = props.name || id;
+    const namespace = props.namespace || client.getCurrentNamespace();
+
+    if (this.phase === "delete") {
+      try {
+        await client.appsV1Api.deleteNamespacedDeployment(deploymentName, namespace);
+        console.log(`Deleted deployment: ${deploymentName} in namespace: ${namespace}`);
+      } catch (error: any) {
+        if (error.response?.status === 404) {
+          console.log(`Deployment ${deploymentName} not found in namespace ${namespace}, already deleted`);
+        } else {
+          handleKubernetesError(error, "delete", "deployment", deploymentName);
+        }
+      }
+      return this.destroy();
+    }
+
+    try {
+      if (this.phase === "create") {
+        // Create the deployment
+        const deploymentSpec = {
+          apiVersion: "apps/v1",
+          kind: "Deployment",
+          metadata: {
+            name: deploymentName,
+            namespace: namespace,
+            labels: props.labels,
+            annotations: props.annotations,
+          },
+          spec: {
+            replicas: props.replicas ?? 1,
+            selector: props.selector,
+            template: props.template,
+            strategy: props.strategy,
+            minReadySeconds: props.minReadySeconds,
+            revisionHistoryLimit: props.revisionHistoryLimit,
+            paused: props.paused,
+            progressDeadlineSeconds: props.progressDeadlineSeconds,
+          },
+        };
+
+        const createResponse = await client.appsV1Api.createNamespacedDeployment(namespace, deploymentSpec);
+        console.log(`Created deployment: ${deploymentName} in namespace: ${namespace}`);
+
+        return this({
+          name: deploymentName,
+          namespace: namespace,
+          labels: createResponse.body.metadata?.labels,
+          annotations: createResponse.body.metadata?.annotations,
+          replicas: createResponse.body.spec?.replicas,
+          selector: createResponse.body.spec?.selector,
+          template: createResponse.body.spec?.template,
+          strategy: createResponse.body.spec?.strategy,
+          status: createResponse.body.status,
+          creationTimestamp: createResponse.body.metadata?.creationTimestamp,
+          resourceVersion: createResponse.body.metadata?.resourceVersion,
+          uid: createResponse.body.metadata?.uid,
+        });
+      } else {
+        // Update existing deployment
+        const patchBody = {
+          metadata: {
+            labels: props.labels,
+            annotations: props.annotations,
+          },
+          spec: {
+            replicas: props.replicas ?? 1,
+            selector: props.selector,
+            template: props.template,
+            strategy: props.strategy,
+            minReadySeconds: props.minReadySeconds,
+            revisionHistoryLimit: props.revisionHistoryLimit,
+            paused: props.paused,
+            progressDeadlineSeconds: props.progressDeadlineSeconds,
+          },
+        };
+
+        const patchResponse = await client.appsV1Api.patchNamespacedDeployment(
+          deploymentName,
+          namespace,
+          patchBody,
+          undefined, // pretty
+          undefined, // dryRun
+          undefined, // fieldManager
+          undefined, // fieldValidation
+          undefined, // force
+          {
+            headers: { "Content-Type": "application/merge-patch+json" },
+          }
+        );
+
+        console.log(`Updated deployment: ${deploymentName} in namespace: ${namespace}`);
+
+        return this({
+          name: deploymentName,
+          namespace: namespace,
+          labels: patchResponse.body.metadata?.labels,
+          annotations: patchResponse.body.metadata?.annotations,
+          replicas: patchResponse.body.spec?.replicas,
+          selector: patchResponse.body.spec?.selector,
+          template: patchResponse.body.spec?.template,
+          strategy: patchResponse.body.spec?.strategy,
+          status: patchResponse.body.status,
+          creationTimestamp: patchResponse.body.metadata?.creationTimestamp,
+          resourceVersion: patchResponse.body.metadata?.resourceVersion,
+          uid: patchResponse.body.metadata?.uid,
+        });
+      }
+    } catch (error: any) {
+      if (error.response?.status === 409 && this.phase === "create") {
+        // Deployment already exists, get its current state
+        try {
+          const getResponse = await client.appsV1Api.readNamespacedDeployment(deploymentName, namespace);
+          console.log(`Deployment ${deploymentName} already exists in namespace ${namespace}, adopting it`);
+
+          return this({
+            name: deploymentName,
+            namespace: namespace,
+            labels: getResponse.body.metadata?.labels,
+            annotations: getResponse.body.metadata?.annotations,
+            replicas: getResponse.body.spec?.replicas,
+            selector: getResponse.body.spec?.selector,
+            template: getResponse.body.spec?.template,
+            strategy: getResponse.body.spec?.strategy,
+            status: getResponse.body.status,
+            creationTimestamp: getResponse.body.metadata?.creationTimestamp,
+            resourceVersion: getResponse.body.metadata?.resourceVersion,
+            uid: getResponse.body.metadata?.uid,
+          });
+        } catch (getError: any) {
+          handleKubernetesError(getError, "get", "deployment", deploymentName);
+        }
+      } else {
+        handleKubernetesError(error, this.phase === "create" ? "create" : "update", "deployment", deploymentName);
+      }
+    }
+  }
+);

--- a/alchemy/src/k8s/index.ts
+++ b/alchemy/src/k8s/index.ts
@@ -1,0 +1,18 @@
+/**
+ * Alchemy Kubernetes Provider
+ *
+ * This module provides Alchemy resources for managing Kubernetes infrastructure.
+ * It includes support for core Kubernetes resources like Namespaces, Deployments,
+ * Services, ConfigMaps, and Secrets.
+ */
+
+// Export client and shared types
+export * from "./client.ts";
+export * from "./types.ts";
+
+// Export Phase 1 core resources
+export * from "./namespace.ts";
+export * from "./deployment.ts";
+export * from "./service.ts";
+export * from "./config-map.ts";
+export * from "./secret.ts";

--- a/alchemy/src/k8s/namespace.ts
+++ b/alchemy/src/k8s/namespace.ts
@@ -1,0 +1,227 @@
+import type { Context } from "../context.ts";
+import { Resource } from "../resource.ts";
+import { createKubernetesClient, handleKubernetesError, type KubernetesClientOptions } from "./client.ts";
+import type { KubernetesMetadata } from "./types.ts";
+
+/**
+ * Properties for creating or updating a Kubernetes Namespace
+ */
+export interface NamespaceProps extends KubernetesClientOptions {
+  /**
+   * Name of the namespace. Must be unique within the cluster.
+   * If not provided, the resource ID will be used.
+   */
+  name?: string;
+
+  /**
+   * Labels are key-value pairs used for organizing and selecting namespaces
+   */
+  labels?: Record<string, string>;
+
+  /**
+   * Annotations are arbitrary metadata that can be attached to the namespace
+   */
+  annotations?: Record<string, string>;
+}
+
+/**
+ * Output returned after Namespace creation/update
+ */
+export interface Namespace extends Resource<"k8s::Namespace"> {
+  /**
+   * Name of the namespace
+   */
+  name: string;
+
+  /**
+   * Labels applied to the namespace
+   */
+  labels?: Record<string, string>;
+
+  /**
+   * Annotations applied to the namespace
+   */
+  annotations?: Record<string, string>;
+
+  /**
+   * Current status of the namespace
+   */
+  status?: {
+    /**
+     * Phase indicates the current lifecycle phase of the namespace
+     */
+    phase?: "Active" | "Terminating";
+  };
+
+  /**
+   * Creation timestamp
+   */
+  creationTimestamp?: string;
+
+  /**
+   * Resource version for optimistic concurrency control
+   */
+  resourceVersion?: string;
+
+  /**
+   * Unique identifier for the namespace
+   */
+  uid?: string;
+}
+
+/**
+ * Creates and manages Kubernetes Namespaces.
+ *
+ * Namespaces provide a mechanism for isolating groups of resources within a single cluster.
+ * Names of resources need to be unique within a namespace, but not across namespaces.
+ *
+ * @example
+ * ## Basic namespace creation
+ *
+ * Create a simple namespace with default settings
+ *
+ * ```ts
+ * const namespace = await Namespace("my-app", {
+ *   name: "my-application"
+ * });
+ * ```
+ *
+ * @example
+ * ## Namespace with labels and annotations
+ *
+ * Create a namespace with organizational metadata
+ *
+ * ```ts
+ * const namespace = await Namespace("production-ns", {
+ *   name: "production",
+ *   labels: {
+ *     environment: "production",
+ *     team: "backend"
+ *   },
+ *   annotations: {
+ *     "description": "Production environment namespace",
+ *     "contact": "backend-team@company.com"
+ *   }
+ * });
+ * ```
+ *
+ * @example
+ * ## Namespace for development environment
+ *
+ * Create a development namespace with appropriate labeling
+ *
+ * ```ts
+ * const devNamespace = await Namespace("dev-environment", {
+ *   name: "development",
+ *   labels: {
+ *     environment: "development",
+ *     tier: "non-production"
+ *   }
+ * });
+ * ```
+ */
+export const Namespace = Resource(
+  "k8s::Namespace",
+  async function (this: Context<Namespace>, id: string, props: NamespaceProps = {}): Promise<Namespace> {
+    const client = createKubernetesClient(props);
+    const namespaceName = props.name || id;
+
+    if (this.phase === "delete") {
+      try {
+        await client.coreV1Api.deleteNamespace(namespaceName);
+        console.log(`Deleted namespace: ${namespaceName}`);
+      } catch (error: any) {
+        if (error.response?.status === 404) {
+          console.log(`Namespace ${namespaceName} not found, already deleted`);
+        } else {
+          handleKubernetesError(error, "delete", "namespace", namespaceName);
+        }
+      }
+      return this.destroy();
+    }
+
+    try {
+      if (this.phase === "create") {
+        // Create the namespace
+        const namespaceSpec = {
+          apiVersion: "v1",
+          kind: "Namespace",
+          metadata: {
+            name: namespaceName,
+            labels: props.labels,
+            annotations: props.annotations,
+          },
+        };
+
+        const createResponse = await client.coreV1Api.createNamespace(namespaceSpec);
+        console.log(`Created namespace: ${namespaceName}`);
+
+        return this({
+          name: namespaceName,
+          labels: createResponse.body.metadata?.labels,
+          annotations: createResponse.body.metadata?.annotations,
+          status: createResponse.body.status,
+          creationTimestamp: createResponse.body.metadata?.creationTimestamp,
+          resourceVersion: createResponse.body.metadata?.resourceVersion,
+          uid: createResponse.body.metadata?.uid,
+        });
+      } else {
+        // Update existing namespace
+        // Note: Only labels and annotations can be updated on namespaces
+        const patchBody = {
+          metadata: {
+            labels: props.labels,
+            annotations: props.annotations,
+          },
+        };
+
+        const patchResponse = await client.coreV1Api.patchNamespace(
+          namespaceName,
+          patchBody,
+          undefined, // pretty
+          undefined, // dryRun
+          undefined, // fieldManager
+          undefined, // fieldValidation
+          undefined, // force
+          {
+            headers: { "Content-Type": "application/merge-patch+json" },
+          }
+        );
+
+        console.log(`Updated namespace: ${namespaceName}`);
+
+        return this({
+          name: namespaceName,
+          labels: patchResponse.body.metadata?.labels,
+          annotations: patchResponse.body.metadata?.annotations,
+          status: patchResponse.body.status,
+          creationTimestamp: patchResponse.body.metadata?.creationTimestamp,
+          resourceVersion: patchResponse.body.metadata?.resourceVersion,
+          uid: patchResponse.body.metadata?.uid,
+        });
+      }
+    } catch (error: any) {
+      if (error.response?.status === 409 && this.phase === "create") {
+        // Namespace already exists, get its current state
+        try {
+          const getResponse = await client.coreV1Api.readNamespace(namespaceName);
+          console.log(`Namespace ${namespaceName} already exists, adopting it`);
+
+          return this({
+            name: namespaceName,
+            labels: getResponse.body.metadata?.labels,
+            annotations: getResponse.body.metadata?.annotations,
+            status: getResponse.body.status,
+            creationTimestamp: getResponse.body.metadata?.creationTimestamp,
+            resourceVersion: getResponse.body.metadata?.resourceVersion,
+            uid: getResponse.body.metadata?.uid,
+          });
+        } catch (getError: any) {
+          handleKubernetesError(getError, "get", "namespace", namespaceName);
+        }
+      } else {
+        handleKubernetesError(error, this.phase === "create" ? "create" : "update", "namespace", namespaceName);
+      }
+    }
+  }
+);

--- a/alchemy/src/k8s/secret.ts
+++ b/alchemy/src/k8s/secret.ts
@@ -1,0 +1,350 @@
+import type { Context } from "../context.ts";
+import { Resource } from "../resource.ts";
+import { createKubernetesClient, handleKubernetesError, type KubernetesClientOptions } from "./client.ts";
+
+/**
+ * Properties for creating or updating a Kubernetes Secret
+ */
+export interface SecretProps extends KubernetesClientOptions {
+  /**
+   * Name of the Secret. If not provided, the resource ID will be used.
+   */
+  name?: string;
+
+  /**
+   * Namespace where the Secret should be created. Defaults to 'default'.
+   */
+  namespace?: string;
+
+  /**
+   * Labels are key-value pairs used for organizing and selecting Secrets
+   */
+  labels?: Record<string, string>;
+
+  /**
+   * Annotations are arbitrary metadata that can be attached to the Secret
+   */
+  annotations?: Record<string, string>;
+
+  /**
+   * Type of secret. Different types may be handled differently by various controllers.
+   */
+  type?: 
+    | "Opaque"
+    | "kubernetes.io/service-account-token"
+    | "kubernetes.io/dockercfg"
+    | "kubernetes.io/dockerconfigjson"
+    | "kubernetes.io/basic-auth"
+    | "kubernetes.io/ssh-auth"
+    | "kubernetes.io/tls"
+    | "bootstrap.kubernetes.io/token"
+    | string;
+
+  /**
+   * Data contains the secret data. Each key must consist of alphanumeric characters,
+   * '-', '_' or '.'. The serialized form of the secret data is a base64 encoded string,
+   * representing the arbitrary (possibly non-string) data value here.
+   */
+  data?: Record<string, string>;
+
+  /**
+   * StringData allows specifying non-binary secret data in string form.
+   * It is provided as a convenience for creating secrets from string values.
+   * The values will be base64 encoded automatically when the secret is created.
+   */
+  stringData?: Record<string, string>;
+
+  /**
+   * Whether the Secret should be immutable.
+   * Immutable Secrets cannot be updated once created.
+   */
+  immutable?: boolean;
+}
+
+/**
+ * Output returned after Secret creation/update
+ */
+export interface Secret extends Resource<"k8s::Secret"> {
+  /**
+   * Name of the Secret
+   */
+  name: string;
+
+  /**
+   * Namespace of the Secret
+   */
+  namespace: string;
+
+  /**
+   * Labels applied to the Secret
+   */
+  labels?: Record<string, string>;
+
+  /**
+   * Annotations applied to the Secret
+   */
+  annotations?: Record<string, string>;
+
+  /**
+   * Type of secret
+   */
+  type?: string;
+
+  /**
+   * Secret data (base64 encoded)
+   */
+  data?: Record<string, string>;
+
+  /**
+   * Whether the Secret is immutable
+   */
+  immutable?: boolean;
+
+  /**
+   * Creation timestamp
+   */
+  creationTimestamp?: string;
+
+  /**
+   * Resource version for optimistic concurrency control
+   */
+  resourceVersion?: string;
+
+  /**
+   * Unique identifier for the Secret
+   */
+  uid?: string;
+}
+
+/**
+ * Creates and manages Kubernetes Secrets.
+ *
+ * Secrets let you store and manage sensitive information, such as passwords,
+ * OAuth tokens, SSH keys, and other credentials. Storing confidential information
+ * in Secrets is more secure and flexible than putting it verbatim in a Pod
+ * definition or in a container image.
+ *
+ * @example
+ * ## Basic secret with string data
+ *
+ * Create a secret with database credentials using string data
+ *
+ * ```ts
+ * const dbSecret = await Secret("database-credentials", {
+ *   namespace: "production",
+ *   type: "Opaque",
+ *   stringData: {
+ *     username: "admin",
+ *     password: "super-secret-password",
+ *     host: "db.internal.company.com",
+ *     port: "5432"
+ *   }
+ * });
+ * ```
+ *
+ * @example
+ * ## TLS certificate secret
+ *
+ * Create a TLS secret for HTTPS termination
+ *
+ * ```ts
+ * const tlsSecret = await Secret("tls-certificate", {
+ *   namespace: "web",
+ *   type: "kubernetes.io/tls",
+ *   stringData: {
+ *     "tls.crt": "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----",
+ *     "tls.key": "-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----"
+ *   }
+ * });
+ * ```
+ *
+ * @example
+ * ## Docker registry secret
+ *
+ * Create a secret for pulling images from a private Docker registry
+ *
+ * ```ts
+ * const registrySecret = await Secret("docker-registry", {
+ *   namespace: "production",
+ *   type: "kubernetes.io/dockerconfigjson",
+ *   stringData: {
+ *     ".dockerconfigjson": JSON.stringify({
+ *       auths: {
+ *         "private-registry.company.com": {
+ *           username: "deployment",
+ *           password: "registry-token",
+ *           email: "devops@company.com",
+ *           auth: btoa("deployment:registry-token")
+ *         }
+ *       }
+ *     })
+ *   }
+ * });
+ * ```
+ *
+ * @example
+ * ## SSH authentication secret
+ *
+ * Create a secret for SSH key authentication
+ *
+ * ```ts
+ * const sshSecret = await Secret("ssh-key", {
+ *   namespace: "ci-cd",
+ *   type: "kubernetes.io/ssh-auth",
+ *   stringData: {
+ *     "ssh-privatekey": "-----BEGIN OPENSSH PRIVATE KEY-----\n...\n-----END OPENSSH PRIVATE KEY-----",
+ *     "ssh-publickey": "ssh-rsa AAAAB3NzaC1yc2E... user@host"
+ *   }
+ * });
+ * ```
+ *
+ * @example
+ * ## API keys and tokens
+ *
+ * Create an immutable secret for API keys in production
+ *
+ * ```ts
+ * const apiSecret = await Secret("api-keys", {
+ *   namespace: "production",
+ *   type: "Opaque",
+ *   stringData: {
+ *     "stripe-api-key": "sk_live_...",
+ *     "github-token": "ghp_...",
+ *     "jwt-secret": "very-long-random-secret-key"
+ *   },
+ *   immutable: true,
+ *   labels: {
+ *     version: "v1.0.0",
+ *     environment: "production"
+ *   }
+ * });
+ * ```
+ */
+export const Secret = Resource(
+  "k8s::Secret",
+  async function (this: Context<Secret>, id: string, props: SecretProps = {}): Promise<Secret> {
+    const client = createKubernetesClient(props);
+    const secretName = props.name || id;
+    const namespace = props.namespace || client.getCurrentNamespace();
+
+    if (this.phase === "delete") {
+      try {
+        await client.coreV1Api.deleteNamespacedSecret(secretName, namespace);
+        console.log(`Deleted Secret: ${secretName} in namespace: ${namespace}`);
+      } catch (error: any) {
+        if (error.response?.status === 404) {
+          console.log(`Secret ${secretName} not found in namespace ${namespace}, already deleted`);
+        } else {
+          handleKubernetesError(error, "delete", "Secret", secretName);
+        }
+      }
+      return this.destroy();
+    }
+
+    try {
+      if (this.phase === "create") {
+        // Create the Secret
+        const secretSpec = {
+          apiVersion: "v1",
+          kind: "Secret",
+          metadata: {
+            name: secretName,
+            namespace: namespace,
+            labels: props.labels,
+            annotations: props.annotations,
+          },
+          type: props.type || "Opaque",
+          data: props.data,
+          stringData: props.stringData,
+          immutable: props.immutable,
+        };
+
+        const createResponse = await client.coreV1Api.createNamespacedSecret(namespace, secretSpec);
+        console.log(`Created Secret: ${secretName} in namespace: ${namespace}`);
+
+        return this({
+          name: secretName,
+          namespace: namespace,
+          labels: createResponse.body.metadata?.labels,
+          annotations: createResponse.body.metadata?.annotations,
+          type: createResponse.body.type,
+          data: createResponse.body.data,
+          immutable: createResponse.body.immutable,
+          creationTimestamp: createResponse.body.metadata?.creationTimestamp,
+          resourceVersion: createResponse.body.metadata?.resourceVersion,
+          uid: createResponse.body.metadata?.uid,
+        });
+      } else {
+        // Update existing Secret
+        // Note: Immutable Secrets cannot be updated
+        if (this.output?.immutable) {
+          throw new Error(`Cannot update immutable Secret: ${secretName}`);
+        }
+
+        const patchBody = {
+          metadata: {
+            labels: props.labels,
+            annotations: props.annotations,
+          },
+          type: props.type || "Opaque",
+          data: props.data,
+          stringData: props.stringData,
+        };
+
+        const patchResponse = await client.coreV1Api.patchNamespacedSecret(
+          secretName,
+          namespace,
+          patchBody,
+          undefined, // pretty
+          undefined, // dryRun
+          undefined, // fieldManager
+          undefined, // fieldValidation
+          undefined, // force
+          {
+            headers: { "Content-Type": "application/merge-patch+json" },
+          }
+        );
+
+        console.log(`Updated Secret: ${secretName} in namespace: ${namespace}`);
+
+        return this({
+          name: secretName,
+          namespace: namespace,
+          labels: patchResponse.body.metadata?.labels,
+          annotations: patchResponse.body.metadata?.annotations,
+          type: patchResponse.body.type,
+          data: patchResponse.body.data,
+          immutable: patchResponse.body.immutable,
+          creationTimestamp: patchResponse.body.metadata?.creationTimestamp,
+          resourceVersion: patchResponse.body.metadata?.resourceVersion,
+          uid: patchResponse.body.metadata?.uid,
+        });
+      }
+    } catch (error: any) {
+      if (error.response?.status === 409 && this.phase === "create") {
+        // Secret already exists, get its current state
+        try {
+          const getResponse = await client.coreV1Api.readNamespacedSecret(secretName, namespace);
+          console.log(`Secret ${secretName} already exists in namespace ${namespace}, adopting it`);
+
+          return this({
+            name: secretName,
+            namespace: namespace,
+            labels: getResponse.body.metadata?.labels,
+            annotations: getResponse.body.metadata?.annotations,
+            type: getResponse.body.type,
+            data: getResponse.body.data,
+            immutable: getResponse.body.immutable,
+            creationTimestamp: getResponse.body.metadata?.creationTimestamp,
+            resourceVersion: getResponse.body.metadata?.resourceVersion,
+            uid: getResponse.body.metadata?.uid,
+          });
+        } catch (getError: any) {
+          handleKubernetesError(getError, "get", "Secret", secretName);
+        }
+      } else {
+        handleKubernetesError(error, this.phase === "create" ? "create" : "update", "Secret", secretName);
+      }
+    }
+  }
+);

--- a/alchemy/src/k8s/service.ts
+++ b/alchemy/src/k8s/service.ts
@@ -1,0 +1,486 @@
+import type { Context } from "../context.ts";
+import { Resource } from "../resource.ts";
+import { createKubernetesClient, handleKubernetesError, type KubernetesClientOptions } from "./client.ts";
+import type { ServicePort } from "./types.ts";
+
+/**
+ * Properties for creating or updating a Kubernetes Service
+ */
+export interface ServiceProps extends KubernetesClientOptions {
+  /**
+   * Name of the service. If not provided, the resource ID will be used.
+   */
+  name?: string;
+
+  /**
+   * Namespace where the service should be created. Defaults to 'default'.
+   */
+  namespace?: string;
+
+  /**
+   * Labels are key-value pairs used for organizing and selecting services
+   */
+  labels?: Record<string, string>;
+
+  /**
+   * Annotations are arbitrary metadata that can be attached to the service
+   */
+  annotations?: Record<string, string>;
+
+  /**
+   * Route service traffic to pods with label keys and values matching this selector.
+   * Required for all service types except ExternalName.
+   */
+  selector?: Record<string, string>;
+
+  /**
+   * List of ports that are exposed by this service
+   */
+  ports: ServicePort[];
+
+  /**
+   * Type of service
+   */
+  type?: "ClusterIP" | "NodePort" | "LoadBalancer" | "ExternalName";
+
+  /**
+   * ClusterIP is the IP address of the service. Usually assigned automatically.
+   * Valid values are "None", empty string "", or a valid IP address.
+   * Setting this to "None" makes this a headless service.
+   */
+  clusterIP?: string;
+
+  /**
+   * List of IP addresses for which nodes in the cluster will also accept traffic
+   */
+  externalIPs?: string[];
+
+  /**
+   * External name for ExternalName type services
+   */
+  externalName?: string;
+
+  /**
+   * Load balancer IP for LoadBalancer type services
+   */
+  loadBalancerIP?: string;
+
+  /**
+   * List of source ranges that will be allowed access to the load balancer
+   */
+  loadBalancerSourceRanges?: string[];
+
+  /**
+   * External traffic policy for NodePort and LoadBalancer services
+   */
+  externalTrafficPolicy?: "Cluster" | "Local";
+
+  /**
+   * Session affinity configuration
+   */
+  sessionAffinity?: "None" | "ClientIP";
+
+  /**
+   * Session affinity configuration options
+   */
+  sessionAffinityConfig?: {
+    clientIP?: {
+      timeoutSeconds?: number;
+    };
+  };
+
+  /**
+   * Health check node port for externalTrafficPolicy=Local
+   */
+  healthCheckNodePort?: number;
+
+  /**
+   * Whether to publish not-ready addresses
+   */
+  publishNotReadyAddresses?: boolean;
+
+  /**
+   * IP families for dual-stack support
+   */
+  ipFamilies?: ("IPv4" | "IPv6")[];
+
+  /**
+   * IP family policy for dual-stack support
+   */
+  ipFamilyPolicy?: "SingleStack" | "PreferDualStack" | "RequireDualStack";
+}
+
+/**
+ * Output returned after Service creation/update
+ */
+export interface Service extends Resource<"k8s::Service"> {
+  /**
+   * Name of the service
+   */
+  name: string;
+
+  /**
+   * Namespace of the service
+   */
+  namespace: string;
+
+  /**
+   * Labels applied to the service
+   */
+  labels?: Record<string, string>;
+
+  /**
+   * Annotations applied to the service
+   */
+  annotations?: Record<string, string>;
+
+  /**
+   * Label selector for pods
+   */
+  selector?: Record<string, string>;
+
+  /**
+   * Ports exposed by the service
+   */
+  ports: ServicePort[];
+
+  /**
+   * Type of service
+   */
+  type?: "ClusterIP" | "NodePort" | "LoadBalancer" | "ExternalName";
+
+  /**
+   * Cluster IP address assigned to the service
+   */
+  clusterIP?: string;
+
+  /**
+   * External IPs for the service
+   */
+  externalIPs?: string[];
+
+  /**
+   * External name for ExternalName services
+   */
+  externalName?: string;
+
+  /**
+   * Load balancer IP
+   */
+  loadBalancerIP?: string;
+
+  /**
+   * Session affinity setting
+   */
+  sessionAffinity?: "None" | "ClientIP";
+
+  /**
+   * Current status of the service
+   */
+  status?: {
+    /**
+     * Load balancer status for LoadBalancer type services
+     */
+    loadBalancer?: {
+      /**
+       * Ingress points for the load balancer
+       */
+      ingress?: Array<{
+        ip?: string;
+        hostname?: string;
+        ports?: Array<{
+          port: number;
+          protocol: string;
+          error?: string;
+        }>;
+      }>;
+    };
+
+    /**
+     * Service conditions
+     */
+    conditions?: Array<{
+      type: string;
+      status: "True" | "False" | "Unknown";
+      lastTransitionTime?: string;
+      reason?: string;
+      message?: string;
+    }>;
+  };
+
+  /**
+   * Creation timestamp
+   */
+  creationTimestamp?: string;
+
+  /**
+   * Resource version for optimistic concurrency control
+   */
+  resourceVersion?: string;
+
+  /**
+   * Unique identifier for the service
+   */
+  uid?: string;
+}
+
+/**
+ * Creates and manages Kubernetes Services.
+ *
+ * Services enable network access to a set of Pods. They provide stable networking
+ * for dynamic Pod IP addresses and offer load balancing across Pod replicas.
+ *
+ * @example
+ * ## Basic ClusterIP service
+ *
+ * Create an internal service for a web application
+ *
+ * ```ts
+ * const webService = await Service("web-service", {
+ *   namespace: "production",
+ *   selector: { app: "web-app" },
+ *   ports: [{
+ *     port: 80,
+ *     targetPort: 8080,
+ *     protocol: "TCP"
+ *   }],
+ *   type: "ClusterIP"
+ * });
+ * ```
+ *
+ * @example
+ * ## LoadBalancer service for external access
+ *
+ * Create a load balancer service to expose an application to the internet
+ *
+ * ```ts
+ * const publicService = await Service("public-api", {
+ *   namespace: "production",
+ *   selector: { app: "api-server", tier: "web" },
+ *   ports: [{
+ *     name: "http",
+ *     port: 80,
+ *     targetPort: 8080,
+ *     protocol: "TCP"
+ *   }, {
+ *     name: "https",
+ *     port: 443,
+ *     targetPort: 8443,
+ *     protocol: "TCP"
+ *   }],
+ *   type: "LoadBalancer",
+ *   loadBalancerSourceRanges: ["10.0.0.0/8", "192.168.0.0/16"]
+ * });
+ * ```
+ *
+ * @example
+ * ## NodePort service with session affinity
+ *
+ * Create a NodePort service with session affinity for sticky sessions
+ *
+ * ```ts
+ * const stickyService = await Service("sticky-app", {
+ *   namespace: "production",
+ *   selector: { app: "stateful-app" },
+ *   ports: [{
+ *     port: 80,
+ *     targetPort: 8080,
+ *     nodePort: 30080,
+ *     protocol: "TCP"
+ *   }],
+ *   type: "NodePort",
+ *   sessionAffinity: "ClientIP",
+ *   sessionAffinityConfig: {
+ *     clientIP: {
+ *       timeoutSeconds: 86400
+ *     }
+ *   }
+ * });
+ * ```
+ *
+ * @example
+ * ## Headless service for StatefulSets
+ *
+ * Create a headless service for direct Pod access
+ *
+ * ```ts
+ * const headlessService = await Service("database-headless", {
+ *   namespace: "production",
+ *   selector: { app: "database" },
+ *   ports: [{
+ *     port: 5432,
+ *     targetPort: 5432,
+ *     protocol: "TCP"
+ *   }],
+ *   type: "ClusterIP",
+ *   clusterIP: "None"
+ * });
+ * ```
+ */
+export const Service = Resource(
+  "k8s::Service",
+  async function (this: Context<Service>, id: string, props: ServiceProps): Promise<Service> {
+    const client = createKubernetesClient(props);
+    const serviceName = props.name || id;
+    const namespace = props.namespace || client.getCurrentNamespace();
+
+    if (this.phase === "delete") {
+      try {
+        await client.coreV1Api.deleteNamespacedService(serviceName, namespace);
+        console.log(`Deleted service: ${serviceName} in namespace: ${namespace}`);
+      } catch (error: any) {
+        if (error.response?.status === 404) {
+          console.log(`Service ${serviceName} not found in namespace ${namespace}, already deleted`);
+        } else {
+          handleKubernetesError(error, "delete", "service", serviceName);
+        }
+      }
+      return this.destroy();
+    }
+
+    try {
+      if (this.phase === "create") {
+        // Create the service
+        const serviceSpec = {
+          apiVersion: "v1",
+          kind: "Service",
+          metadata: {
+            name: serviceName,
+            namespace: namespace,
+            labels: props.labels,
+            annotations: props.annotations,
+          },
+          spec: {
+            selector: props.selector,
+            ports: props.ports,
+            type: props.type || "ClusterIP",
+            clusterIP: props.clusterIP,
+            externalIPs: props.externalIPs,
+            externalName: props.externalName,
+            loadBalancerIP: props.loadBalancerIP,
+            loadBalancerSourceRanges: props.loadBalancerSourceRanges,
+            externalTrafficPolicy: props.externalTrafficPolicy,
+            sessionAffinity: props.sessionAffinity || "None",
+            sessionAffinityConfig: props.sessionAffinityConfig,
+            healthCheckNodePort: props.healthCheckNodePort,
+            publishNotReadyAddresses: props.publishNotReadyAddresses,
+            ipFamilies: props.ipFamilies,
+            ipFamilyPolicy: props.ipFamilyPolicy,
+          },
+        };
+
+        const createResponse = await client.coreV1Api.createNamespacedService(namespace, serviceSpec);
+        console.log(`Created service: ${serviceName} in namespace: ${namespace}`);
+
+        return this({
+          name: serviceName,
+          namespace: namespace,
+          labels: createResponse.body.metadata?.labels,
+          annotations: createResponse.body.metadata?.annotations,
+          selector: createResponse.body.spec?.selector,
+          ports: createResponse.body.spec?.ports || [],
+          type: createResponse.body.spec?.type as any,
+          clusterIP: createResponse.body.spec?.clusterIP,
+          externalIPs: createResponse.body.spec?.externalIPs,
+          externalName: createResponse.body.spec?.externalName,
+          loadBalancerIP: createResponse.body.spec?.loadBalancerIP,
+          sessionAffinity: createResponse.body.spec?.sessionAffinity as any,
+          status: createResponse.body.status,
+          creationTimestamp: createResponse.body.metadata?.creationTimestamp,
+          resourceVersion: createResponse.body.metadata?.resourceVersion,
+          uid: createResponse.body.metadata?.uid,
+        });
+      } else {
+        // Update existing service
+        const patchBody = {
+          metadata: {
+            labels: props.labels,
+            annotations: props.annotations,
+          },
+          spec: {
+            selector: props.selector,
+            ports: props.ports,
+            type: props.type || "ClusterIP",
+            externalIPs: props.externalIPs,
+            externalName: props.externalName,
+            loadBalancerIP: props.loadBalancerIP,
+            loadBalancerSourceRanges: props.loadBalancerSourceRanges,
+            externalTrafficPolicy: props.externalTrafficPolicy,
+            sessionAffinity: props.sessionAffinity || "None",
+            sessionAffinityConfig: props.sessionAffinityConfig,
+            healthCheckNodePort: props.healthCheckNodePort,
+            publishNotReadyAddresses: props.publishNotReadyAddresses,
+            ipFamilies: props.ipFamilies,
+            ipFamilyPolicy: props.ipFamilyPolicy,
+          },
+        };
+
+        const patchResponse = await client.coreV1Api.patchNamespacedService(
+          serviceName,
+          namespace,
+          patchBody,
+          undefined, // pretty
+          undefined, // dryRun
+          undefined, // fieldManager
+          undefined, // fieldValidation
+          undefined, // force
+          {
+            headers: { "Content-Type": "application/merge-patch+json" },
+          }
+        );
+
+        console.log(`Updated service: ${serviceName} in namespace: ${namespace}`);
+
+        return this({
+          name: serviceName,
+          namespace: namespace,
+          labels: patchResponse.body.metadata?.labels,
+          annotations: patchResponse.body.metadata?.annotations,
+          selector: patchResponse.body.spec?.selector,
+          ports: patchResponse.body.spec?.ports || [],
+          type: patchResponse.body.spec?.type as any,
+          clusterIP: patchResponse.body.spec?.clusterIP,
+          externalIPs: patchResponse.body.spec?.externalIPs,
+          externalName: patchResponse.body.spec?.externalName,
+          loadBalancerIP: patchResponse.body.spec?.loadBalancerIP,
+          sessionAffinity: patchResponse.body.spec?.sessionAffinity as any,
+          status: patchResponse.body.status,
+          creationTimestamp: patchResponse.body.metadata?.creationTimestamp,
+          resourceVersion: patchResponse.body.metadata?.resourceVersion,
+          uid: patchResponse.body.metadata?.uid,
+        });
+      }
+    } catch (error: any) {
+      if (error.response?.status === 409 && this.phase === "create") {
+        // Service already exists, get its current state
+        try {
+          const getResponse = await client.coreV1Api.readNamespacedService(serviceName, namespace);
+          console.log(`Service ${serviceName} already exists in namespace ${namespace}, adopting it`);
+
+          return this({
+            name: serviceName,
+            namespace: namespace,
+            labels: getResponse.body.metadata?.labels,
+            annotations: getResponse.body.metadata?.annotations,
+            selector: getResponse.body.spec?.selector,
+            ports: getResponse.body.spec?.ports || [],
+            type: getResponse.body.spec?.type as any,
+            clusterIP: getResponse.body.spec?.clusterIP,
+            externalIPs: getResponse.body.spec?.externalIPs,
+            externalName: getResponse.body.spec?.externalName,
+            loadBalancerIP: getResponse.body.spec?.loadBalancerIP,
+            sessionAffinity: getResponse.body.spec?.sessionAffinity as any,
+            status: getResponse.body.status,
+            creationTimestamp: getResponse.body.metadata?.creationTimestamp,
+            resourceVersion: getResponse.body.metadata?.resourceVersion,
+            uid: getResponse.body.metadata?.uid,
+          });
+        } catch (getError: any) {
+          handleKubernetesError(getError, "get", "service", serviceName);
+        }
+      } else {
+        handleKubernetesError(error, this.phase === "create" ? "create" : "update", "service", serviceName);
+      }
+    }
+  }
+);

--- a/alchemy/src/k8s/types.ts
+++ b/alchemy/src/k8s/types.ts
@@ -1,0 +1,619 @@
+/**
+ * Common Kubernetes resource metadata
+ */
+export interface KubernetesMetadata {
+  /**
+   * Name of the resource. Must be unique within the namespace.
+   */
+  name?: string;
+  
+  /**
+   * Namespace of the resource. Defaults to 'default' if not specified.
+   */
+  namespace?: string;
+  
+  /**
+   * Labels are key-value pairs used for grouping and selecting resources
+   */
+  labels?: Record<string, string>;
+  
+  /**
+   * Annotations are arbitrary metadata that can be attached to resources
+   */
+  annotations?: Record<string, string>;
+}
+
+/**
+ * Common properties for all Kubernetes resources
+ */
+export interface KubernetesResourceProps {
+  /**
+   * Standard Kubernetes metadata
+   */
+  metadata?: KubernetesMetadata;
+  
+  /**
+   * Kubernetes client configuration options
+   */
+  kubeconfig?: string;
+  context?: string;
+}
+
+/**
+ * Label selector for matching resources
+ */
+export interface LabelSelector {
+  /**
+   * Direct label matching (key: value)
+   */
+  matchLabels?: Record<string, string>;
+  
+  /**
+   * Expression-based label matching
+   */
+  matchExpressions?: Array<{
+    key: string;
+    operator: "In" | "NotIn" | "Exists" | "DoesNotExist";
+    values?: string[];
+  }>;
+}
+
+/**
+ * Resource requirements for containers
+ */
+export interface ResourceRequirements {
+  /**
+   * Resource limits (maximum allowed)
+   */
+  limits?: {
+    cpu?: string;
+    memory?: string;
+    [key: string]: string | undefined;
+  };
+  
+  /**
+   * Resource requests (minimum required)
+   */
+  requests?: {
+    cpu?: string;
+    memory?: string;
+    [key: string]: string | undefined;
+  };
+}
+
+/**
+ * Container port configuration
+ */
+export interface ContainerPort {
+  /**
+   * Port number
+   */
+  containerPort: number;
+  
+  /**
+   * Protocol (TCP, UDP, or SCTP)
+   */
+  protocol?: "TCP" | "UDP" | "SCTP";
+  
+  /**
+   * Name for the port (optional)
+   */
+  name?: string;
+  
+  /**
+   * Host port to bind to (optional)
+   */
+  hostPort?: number;
+  
+  /**
+   * Host IP to bind to (optional)
+   */
+  hostIP?: string;
+}
+
+/**
+ * Environment variable for containers
+ */
+export interface EnvVar {
+  /**
+   * Environment variable name
+   */
+  name: string;
+  
+  /**
+   * Environment variable value (direct value)
+   */
+  value?: string;
+  
+  /**
+   * Source for the environment variable value
+   */
+  valueFrom?: {
+    /**
+     * Reference to a ConfigMap key
+     */
+    configMapKeyRef?: {
+      name: string;
+      key: string;
+      optional?: boolean;
+    };
+    
+    /**
+     * Reference to a Secret key
+     */
+    secretKeyRef?: {
+      name: string;
+      key: string;
+      optional?: boolean;
+    };
+    
+    /**
+     * Reference to a field in the resource
+     */
+    fieldRef?: {
+      fieldPath: string;
+      apiVersion?: string;
+    };
+    
+    /**
+     * Reference to a resource field
+     */
+    resourceFieldRef?: {
+      resource: string;
+      containerName?: string;
+      divisor?: string;
+    };
+  };
+}
+
+/**
+ * Volume mount for containers
+ */
+export interface VolumeMount {
+  /**
+   * Name of the volume to mount
+   */
+  name: string;
+  
+  /**
+   * Path where the volume should be mounted in the container
+   */
+  mountPath: string;
+  
+  /**
+   * Path within the volume from which the container's volume should be mounted
+   */
+  subPath?: string;
+  
+  /**
+   * Whether the volume should be mounted read-only
+   */
+  readOnly?: boolean;
+  
+  /**
+   * Mount propagation setting
+   */
+  mountPropagation?: string;
+  
+  /**
+   * Expanded path within the volume from which the container's volume should be mounted
+   */
+  subPathExpr?: string;
+}
+
+/**
+ * Volume definition for pods
+ */
+export interface Volume {
+  /**
+   * Name of the volume
+   */
+  name: string;
+  
+  /**
+   * EmptyDir volume (temporary directory)
+   */
+  emptyDir?: {
+    medium?: string;
+    sizeLimit?: string;
+  };
+  
+  /**
+   * HostPath volume (mount from host filesystem)
+   */
+  hostPath?: {
+    path: string;
+    type?: string;
+  };
+  
+  /**
+   * ConfigMap volume
+   */
+  configMap?: {
+    name: string;
+    optional?: boolean;
+    defaultMode?: number;
+    items?: Array<{
+      key: string;
+      path: string;
+      mode?: number;
+    }>;
+  };
+  
+  /**
+   * Secret volume
+   */
+  secret?: {
+    secretName: string;
+    optional?: boolean;
+    defaultMode?: number;
+    items?: Array<{
+      key: string;
+      path: string;
+      mode?: number;
+    }>;
+  };
+  
+  /**
+   * PersistentVolumeClaim volume
+   */
+  persistentVolumeClaim?: {
+    claimName: string;
+    readOnly?: boolean;
+  };
+}
+
+/**
+ * Container specification
+ */
+export interface Container {
+  /**
+   * Name of the container
+   */
+  name: string;
+  
+  /**
+   * Container image
+   */
+  image: string;
+  
+  /**
+   * Image pull policy
+   */
+  imagePullPolicy?: "Always" | "Never" | "IfNotPresent";
+  
+  /**
+   * Command to run in the container
+   */
+  command?: string[];
+  
+  /**
+   * Arguments to the command
+   */
+  args?: string[];
+  
+  /**
+   * Environment variables
+   */
+  env?: EnvVar[];
+  
+  /**
+   * Ports to expose from the container
+   */
+  ports?: ContainerPort[];
+  
+  /**
+   * Volume mounts
+   */
+  volumeMounts?: VolumeMount[];
+  
+  /**
+   * Resource requirements
+   */
+  resources?: ResourceRequirements;
+  
+  /**
+   * Working directory for the container
+   */
+  workingDir?: string;
+  
+  /**
+   * Liveness probe
+   */
+  livenessProbe?: Probe;
+  
+  /**
+   * Readiness probe
+   */
+  readinessProbe?: Probe;
+  
+  /**
+   * Startup probe
+   */
+  startupProbe?: Probe;
+  
+  /**
+   * Security context for the container
+   */
+  securityContext?: SecurityContext;
+}
+
+/**
+ * Probe definition for health checks
+ */
+export interface Probe {
+  /**
+   * HTTP GET probe
+   */
+  httpGet?: {
+    path?: string;
+    port: number | string;
+    host?: string;
+    scheme?: "HTTP" | "HTTPS";
+    httpHeaders?: Array<{
+      name: string;
+      value: string;
+    }>;
+  };
+  
+  /**
+   * TCP socket probe
+   */
+  tcpSocket?: {
+    port: number | string;
+    host?: string;
+  };
+  
+  /**
+   * Exec probe
+   */
+  exec?: {
+    command?: string[];
+  };
+  
+  /**
+   * Initial delay before probe starts
+   */
+  initialDelaySeconds?: number;
+  
+  /**
+   * Period between probes
+   */
+  periodSeconds?: number;
+  
+  /**
+   * Timeout for probe
+   */
+  timeoutSeconds?: number;
+  
+  /**
+   * Number of failures before considering unhealthy
+   */
+  failureThreshold?: number;
+  
+  /**
+   * Number of successes before considering healthy
+   */
+  successThreshold?: number;
+}
+
+/**
+ * Security context for containers and pods
+ */
+export interface SecurityContext {
+  /**
+   * Run as user ID
+   */
+  runAsUser?: number;
+  
+  /**
+   * Run as group ID
+   */
+  runAsGroup?: number;
+  
+  /**
+   * Run as non-root user
+   */
+  runAsNonRoot?: boolean;
+  
+  /**
+   * Whether container runs in privileged mode
+   */
+  privileged?: boolean;
+  
+  /**
+   * Whether to allow privilege escalation
+   */
+  allowPrivilegeEscalation?: boolean;
+  
+  /**
+   * Read-only root filesystem
+   */
+  readOnlyRootFilesystem?: boolean;
+  
+  /**
+   * Capabilities to add/drop
+   */
+  capabilities?: {
+    add?: string[];
+    drop?: string[];
+  };
+  
+  /**
+   * SELinux options
+   */
+  seLinuxOptions?: {
+    level?: string;
+    role?: string;
+    type?: string;
+    user?: string;
+  };
+}
+
+/**
+ * Pod template specification
+ */
+export interface PodTemplateSpec {
+  /**
+   * Metadata for the pod template
+   */
+  metadata?: KubernetesMetadata;
+  
+  /**
+   * Pod specification
+   */
+  spec?: PodSpec;
+}
+
+/**
+ * Pod specification
+ */
+export interface PodSpec {
+  /**
+   * List of containers in the pod
+   */
+  containers: Container[];
+  
+  /**
+   * List of init containers
+   */
+  initContainers?: Container[];
+  
+  /**
+   * Restart policy for containers
+   */
+  restartPolicy?: "Always" | "OnFailure" | "Never";
+  
+  /**
+   * Node selector for pod placement
+   */
+  nodeSelector?: Record<string, string>;
+  
+  /**
+   * Service account name
+   */
+  serviceAccountName?: string;
+  
+  /**
+   * Service account (deprecated, use serviceAccountName)
+   */
+  serviceAccount?: string;
+  
+  /**
+   * Security context for the pod
+   */
+  securityContext?: SecurityContext;
+  
+  /**
+   * Volumes available to the pod
+   */
+  volumes?: Volume[];
+  
+  /**
+   * DNS policy for the pod
+   */
+  dnsPolicy?: "ClusterFirst" | "ClusterFirstWithHostNet" | "Default" | "None";
+  
+  /**
+   * Host network setting
+   */
+  hostNetwork?: boolean;
+  
+  /**
+   * Host PID setting
+   */
+  hostPID?: boolean;
+  
+  /**
+   * Host IPC setting
+   */
+  hostIPC?: boolean;
+  
+  /**
+   * Termination grace period in seconds
+   */
+  terminationGracePeriodSeconds?: number;
+  
+  /**
+   * Image pull secrets
+   */
+  imagePullSecrets?: Array<{
+    name: string;
+  }>;
+  
+  /**
+   * Node affinity rules
+   */
+  affinity?: {
+    nodeAffinity?: any;
+    podAffinity?: any;
+    podAntiAffinity?: any;
+  };
+  
+  /**
+   * Tolerations for node taints
+   */
+  tolerations?: Array<{
+    key?: string;
+    operator?: "Exists" | "Equal";
+    value?: string;
+    effect?: "NoSchedule" | "PreferNoSchedule" | "NoExecute";
+    tolerationSeconds?: number;
+  }>;
+}
+
+/**
+ * Service port specification
+ */
+export interface ServicePort {
+  /**
+   * Name of the port
+   */
+  name?: string;
+  
+  /**
+   * Protocol (TCP, UDP, or SCTP)
+   */
+  protocol?: "TCP" | "UDP" | "SCTP";
+  
+  /**
+   * Port number
+   */
+  port: number;
+  
+  /**
+   * Target port on the pod
+   */
+  targetPort?: number | string;
+  
+  /**
+   * Node port for NodePort/LoadBalancer services
+   */
+  nodePort?: number;
+}
+
+/**
+ * Common status fields for Kubernetes resources
+ */
+export interface KubernetesStatus {
+  /**
+   * Current phase or state of the resource
+   */
+  phase?: string;
+  
+  /**
+   * Conditions represent the latest available observations of the resource's state
+   */
+  conditions?: Array<{
+    type: string;
+    status: "True" | "False" | "Unknown";
+    lastTransitionTime?: string;
+    reason?: string;
+    message?: string;
+  }>;
+  
+  /**
+   * Observed generation of the resource
+   */
+  observedGeneration?: number;
+}

--- a/alchemy/test/k8s/namespace.test.ts
+++ b/alchemy/test/k8s/namespace.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect } from "vitest";
+import { alchemy } from "../../src/alchemy.ts";
+import { destroy } from "../../src/destroy.ts";
+import { Namespace } from "../../src/k8s/namespace.ts";
+import { createKubernetesClient } from "../../src/k8s/client.ts";
+import { BRANCH_PREFIX } from "../util.ts";
+
+import "../../src/test/vitest.ts";
+
+const test = alchemy.test(import.meta, {
+  prefix: BRANCH_PREFIX,
+});
+
+describe("Kubernetes Namespace Resource", () => {
+  // Use BRANCH_PREFIX for deterministic, non-colliding resource names
+  const testId = `${BRANCH_PREFIX}-test-ns`;
+
+  test("create and delete namespace", async (scope) => {
+    let namespace: Namespace | undefined;
+
+    try {
+      // Create a test namespace
+      namespace = await Namespace(testId, {
+        name: testId,
+        labels: {
+          environment: "test",
+          "managed-by": "alchemy"
+        },
+        annotations: {
+          "description": "Test namespace for alchemy k8s provider",
+          "created-by": "alchemy-test"
+        }
+      });
+
+      expect(namespace.name).toEqual(testId);
+      expect(namespace.labels?.environment).toEqual("test");
+      expect(namespace.labels?.["managed-by"]).toEqual("alchemy");
+      expect(namespace.annotations?.description).toEqual("Test namespace for alchemy k8s provider");
+      expect(namespace.uid).toBeTruthy();
+      expect(namespace.creationTimestamp).toBeTruthy();
+      expect(namespace.resourceVersion).toBeTruthy();
+
+      // Verify namespace exists in cluster
+      const client = createKubernetesClient();
+      const getResponse = await client.coreV1Api.readNamespace(testId);
+      expect(getResponse.body.metadata?.name).toEqual(testId);
+      expect(getResponse.body.metadata?.labels?.environment).toEqual("test");
+    } finally {
+      await destroy(scope);
+
+      // Verify namespace was deleted
+      if (namespace) {
+        await assertNamespaceDeleted(namespace);
+      }
+    }
+  });
+
+  test("update namespace labels and annotations", async (scope) => {
+    const updateTestId = `${testId}-update`;
+    let namespace: Namespace | undefined;
+
+    try {
+      // Create namespace with initial labels
+      namespace = await Namespace(updateTestId, {
+        name: updateTestId,
+        labels: {
+          environment: "test",
+          version: "v1"
+        }
+      });
+
+      expect(namespace.name).toEqual(updateTestId);
+      expect(namespace.labels?.environment).toEqual("test");
+      expect(namespace.labels?.version).toEqual("v1");
+
+      // Update the namespace with new labels and annotations
+      namespace = await Namespace(updateTestId, {
+        name: updateTestId,
+        labels: {
+          environment: "production",
+          version: "v2",
+          "new-label": "added"
+        },
+        annotations: {
+          "updated": "true",
+          "timestamp": new Date().toISOString()
+        }
+      });
+
+      expect(namespace.labels?.environment).toEqual("production");
+      expect(namespace.labels?.version).toEqual("v2");
+      expect(namespace.labels?.["new-label"]).toEqual("added");
+      expect(namespace.annotations?.updated).toEqual("true");
+      expect(namespace.annotations?.timestamp).toBeTruthy();
+    } finally {
+      await destroy(scope);
+    }
+  });
+
+  test("adopt existing namespace", async (scope) => {
+    const adoptTestId = `${testId}-adopt`;
+
+    try {
+      // Create namespace directly via Kubernetes API
+      const client = createKubernetesClient();
+      await client.coreV1Api.createNamespace({
+        apiVersion: "v1",
+        kind: "Namespace",
+        metadata: {
+          name: adoptTestId,
+          labels: {
+            "pre-existing": "true"
+          }
+        }
+      });
+
+      // Now try to create the same namespace via Alchemy (should adopt it)
+      const namespace = await Namespace(adoptTestId, {
+        name: adoptTestId,
+        labels: {
+          environment: "test",
+          "managed-by": "alchemy"
+        }
+      });
+
+      expect(namespace.name).toEqual(adoptTestId);
+      expect(namespace.labels?.["pre-existing"]).toEqual("true");
+      expect(namespace.uid).toBeTruthy();
+
+      // Verify it was adopted and updated
+      const getResponse = await client.coreV1Api.readNamespace(adoptTestId);
+      expect(getResponse.body.metadata?.labels?.environment).toEqual("test");
+      expect(getResponse.body.metadata?.labels?.["managed-by"]).toEqual("alchemy");
+    } finally {
+      await destroy(scope);
+    }
+  });
+});
+
+async function assertNamespaceDeleted(namespace: Namespace) {
+  const client = createKubernetesClient();
+  try {
+    await client.coreV1Api.readNamespace(namespace.name);
+    throw new Error(`Namespace ${namespace.name} was not deleted as expected`);
+  } catch (error: any) {
+    // If we get a 404, the namespace was deleted (expected)
+    if (error.response?.status === 404) {
+      return; // This is expected
+    } else {
+      throw new Error(`Unexpected error checking if namespace was deleted: ${error}`);
+    }
+  }
+}


### PR DESCRIPTION
Implements Phase 1 of the Kubernetes provider with core foundation resources as requested in issue #292.

## Changes
- Add comprehensive Kubernetes client with multiple auth methods
- Implement core resources: Namespace, Deployment, Service, ConfigMap, Secret
- Add TypeScript interfaces for type-safe Kubernetes API interactions
- Include full CRUD lifecycle support with resource adoption
- Add comprehensive error handling with helpful messages
- Include extensive JSDoc examples for each resource
- Follow alchemy provider conventions and patterns
- Add @kubernetes/client-node peer dependency

Closes #292

Generated with [Claude Code](https://claude.ai/code)