### PR TITLE
chore: update getting started guide to focus on Cloudflare Workers

### DIFF
--- a/alchemy-web/docs/getting-started.md
+++ b/alchemy-web/docs/getting-started.md
@@ -1,40 +1,100 @@
 ---
 title: Getting Started with Alchemy
-description: Quick start guide to using Alchemy, the TypeScript-native Infrastructure-as-Code library. Learn how to install, create resources, and manage their lifecycle.
+description: Quick start guide to using Alchemy, the TypeScript-native Infrastructure-as-Code library. Deploy your first Cloudflare Worker with type-safe infrastructure code.
 ---
 
 # Getting Started with Alchemy
 
+This guide walks you through deploying your first Cloudflare Worker using Alchemy, demonstrating Infrastructure-as-Code principles with a real-world, practical example.
+
 > [!TIP]
-> Read [What is Alchemy](./what-is-alchemy.md) to get an overview of Alchemy and how it's different than tradtional IaC
+> Read [What is Alchemy](./what-is-alchemy.md) to get an overview of Alchemy and how it's different than traditional IaC
 
-## Installation
+## Prerequisites
 
-Start by installing the Alchemy library using Bun (or your preferred package manager):
+You'll need:
+- [Node.js](https://nodejs.org/) or [Bun](https://bun.sh/)
+- A [Cloudflare account](https://dash.cloudflare.com/sign-up) (free tier works)
+
+## Create a New TypeScript Project
+
+Start by creating an empty TypeScript project:
+
+::: code-group
+
+```sh [bun]
+mkdir my-alchemy-app
+cd my-alchemy-app
+bun init -y
+```
+
+```sh [npm]
+mkdir my-alchemy-app
+cd my-alchemy-app
+npm init -y
+npm install -D typescript @types/node tsx
+```
+
+```sh [pnpm]
+mkdir my-alchemy-app
+cd my-alchemy-app
+pnpm init
+pnpm add -D typescript @types/node tsx
+```
+
+```sh [yarn]
+mkdir my-alchemy-app
+cd my-alchemy-app
+yarn init -y
+yarn add -D typescript @types/node tsx
+```
+
+:::
+
+## Install Dependencies
+
+Install Alchemy and the Wrangler CLI:
 
 ::: code-group
 
 ```sh [bun]
 bun add alchemy
+bun add -g wrangler
 ```
 
 ```sh [npm]
-npm add alchemy
+npm install alchemy
+npm install -g wrangler
 ```
 
 ```sh [pnpm]
 pnpm add alchemy
+pnpm add -g wrangler
 ```
 
 ```sh [yarn]
 yarn add alchemy
+yarn global add wrangler
 ```
 
 :::
 
+## Login to Cloudflare
+
+Authenticate with Cloudflare using wrangler:
+
+```sh
+wrangler login
+```
+
+This will open your browser to authenticate with your Cloudflare account.
+
+> [!TIP]
+> Alchemy automatically uses your wrangler OAuth token. See the [Cloudflare Auth](./guides/cloudflare-auth.md) guide for alternative authentication methods.
+
 ## Create Your First Alchemy App
 
-Create a file named `alchemy.run.ts` in your project directory and follow these steps:
+Create a file named `alchemy.run.ts` in your project directory:
 
 > [!TIP]
 > `alchemy.run.ts` is just a convention - you can run Alchemy in any script or JavaScript environment.
@@ -54,20 +114,18 @@ const app = await alchemy("my-first-app", {
 > [!NOTE]
 > Learn more about Alchemy scopes in [Concepts: Scope](./concepts/scope.md)
 
-### Step 2: Instantiate a Resource
-
-A Resource is just an async function that takes a unique id (e.g. `config`) and some properties.
+### Step 2: Create a Cloudflare Worker
 
 ```typescript
-import { File } from "alchemy/fs";
+import { Worker } from "alchemy/cloudflare";
 
-// Create a file resource
-const hello = await File("hello", {
-  path: "./hello.txt",
-  content: "hello world"
+// Create a simple worker
+const worker = await Worker("hello-worker", {
+  entrypoint: "./src/worker.ts",
+  url: true, // Enable workers.dev subdomain
 });
 
-console.log(`Created file at: ${hello.path}`);
+console.log(`Worker deployed at: ${worker.url}`);
 ```
 
 > [!NOTE]
@@ -75,41 +133,74 @@ console.log(`Created file at: ${hello.path}`);
 
 ### Step 3: Finalize the Application
 
-At the end of our script, call `finalize`.
-
 ```typescript
 // Finalize the app to apply changes
 await app.finalize();
 ```
 
-This is necessary for deleting what are called "orphaned resources" (more on that below).
+This is necessary for deleting what are called "orphaned resources" when resources are removed.
 
 > [!NOTE]
 > Learn more about finalization and destroying resources in [Concepts: Destroy](./concepts/destroy.md)
 
-## Run the Script
+### Step 4: Create the Worker Script
 
-Now we simply run the script. Alchemy is just pure TypeScript, so you can run it with any JS engine, e.g. `bun`:
+Create a `src/worker.ts` file with your worker code:
 
-```bash
+```typescript
+export default {
+  async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+    
+    if (url.pathname === "/hello") {
+      return Response.json({ 
+        message: "Hello from Alchemy!",
+        timestamp: new Date().toISOString(),
+        location: request.cf?.colo 
+      });
+    }
+    
+    return new Response("Welcome to Alchemy! Try /hello", { 
+      status: 200,
+      headers: { "Content-Type": "text/plain" }
+    });
+  },
+};
+```
+
+## Deploy Your Worker
+
+Run the Alchemy script to deploy your worker:
+
+::: code-group
+
+```sh [bun]
 bun ./alchemy.run.ts
 ```
+
+```sh [npm]
+npx tsx ./alchemy.run.ts
+```
+
+```sh [pnpm]
+pnpm tsx ./alchemy.run.ts
+```
+
+```sh [yarn]
+yarn tsx ./alchemy.run.ts
+```
+
+:::
 
 You will see output similar to:
 
 ```
-Create:  "my-first-app/dev/hello"
-Created: "my-first-app/dev/hello"
+Create:  "my-first-app/dev/hello-worker"
+Created: "my-first-app/dev/hello-worker"
+Worker deployed at: https://hello-worker.your-subdomain.workers.dev
 ```
 
-This indicates that Alchemy has:
-1. Identified that the resource needs to be created
-2. Successfully created the resource
-
-We now have a `./hello.txt` file in our project:
-```
-hello world
-```
+Visit the URL to see your worker in action! Try visiting `/hello` for the JSON response.
 
 > [!TIP]
 > If you're familiar with other IaC tools, this should feel similar to `terraform apply`, `pulumi up`, `cdk deploy` or `sst deploy`
@@ -122,80 +213,191 @@ After running your app, Alchemy creates a `.alchemy` directory to store state:
 .alchemy/
   my-first-app/         # app
     dev/                # stage
-      hello.txt.json  # resource
+      hello-worker.json # resource state
 ```
 
 State files help Alchemy determine whether to create, update, delete, or skip resources on subsequent runs.
 
-If you run the same script again without changes, you'll see no operations performed because the state hasn't changed.
-
 > [!NOTE]
 > Learn more about Alchemy state in [Concepts: State](./concepts/state.md)
 
-## Update our File
+## Generate wrangler.json for Local Development
 
-Let's now update our `alchemy.run.ts` script to change the content of the file:
-
-```ts
-const hello = await File("hello", {
-  // path: "./hello.txt",
-  path: "./hello-world.txt",
-  // content: "hello world"
-  content: "Hello, world!"
-});
-```
-
-Now, when we re-run the script, we'll see:
-```
-Update:  "my-first-app/dev/hello"
-Updated: "my-first-app/dev/hello"
-```
-
-And now the `hello.txt` file is gone and replaced with `hello-world.txt` with different content:
-```
-Hello, World
-```
-
-Notice how we didn't have to write any code to delete the old file?
-
-In a nutshell, that's the point of Infrastructure-as-Code - we just write code that creates the state we want and Alchemy takes care of deciding what to create, update or delete and in what order.
-
-## Destroy the Resource
-
-Let's now comment out the `File` and run it again.
+Add wrangler.json generation to your `alchemy.run.ts`:
 
 ```typescript
-// const hello = await File("hello", {
-//   path: "./hello-world.txt",
-//   content: "Hello, world!"
-// });
+import { Worker, WranglerJson } from "alchemy/cloudflare";
+
+// ... existing code ...
+
+const worker = await Worker("hello-worker", {
+  entrypoint: "./src/worker.ts",
+  url: true,
+});
+
+// Generate wrangler.json for local development
+await WranglerJson("wrangler.json", {
+  worker,
+});
+
+console.log(`Worker deployed at: ${worker.url}`);
+
+await app.finalize();
 ```
 
-> [!CAUTION]
-> Now, before we run our script again, you need to first add a "naked" impot of `alchemy/fs` at the top of our `alchemy.run.ts` script.
-> ```typescript
-> import "alchemy/fs"
-> ```
-> If you forget this, you would get an error
-> `Cannot destroy resource "my-first-app/dev/hello" type fs::File - no provider found. You may need to import the provider in your alchemy.run.ts.`
-> 
-> This is because IDEs usually remove unused imports. If you don't import the resource, the delete handler won't be registered which Alchemy needs to delete the resource.
+Run the script again to generate the `wrangler.json`:
 
-The output should look like:
+::: code-group
 
-```
-Delete:  "my-first-app/dev/hello"
-Deleted: "my-first-app/dev/hello"
+```sh [bun]
+bun ./alchemy.run.ts
 ```
 
-And the `hello-world.txt` file is now gone.
+```sh [npm]
+npx tsx ./alchemy.run.ts
+```
 
-> [!NOTE]
-> You can read more about how to destroy resoruces and stacks in [Concepts: Destroy](./concepts/destroy.md)
+```sh [pnpm]
+pnpm tsx ./alchemy.run.ts
+```
+
+```sh [yarn]
+yarn tsx ./alchemy.run.ts
+```
+
+:::
+
+## Local Development
+
+Now you can run your worker locally using `wrangler dev`:
+
+```sh
+wrangler dev
+```
+
+This starts a local development server that mirrors your deployed worker environment:
+
+```
+⛅️ wrangler 3.78.12
+-------------------
+Your worker has access to the following bindings:
+- Vars:
+  - (none)
+- Browser Rendering:
+  - (disabled)
+⎔ Starting local server...
+[wrangler:inf] Ready on http://localhost:8787
+```
+
+Visit `http://localhost:8787` to test your worker locally!
+
+## Update Your Worker
+
+Let's update our worker script to add more functionality:
+
+```typescript
+// src/worker.ts
+export default {
+  async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+    
+    if (url.pathname === "/hello") {
+      return Response.json({ 
+        message: "Hello from Alchemy!",
+        timestamp: new Date().toISOString(),
+        location: request.cf?.colo,
+        version: "2.0"
+      });
+    }
+
+    if (url.pathname === "/api/time") {
+      return Response.json({
+        time: new Date().toISOString(),
+        timezone: "UTC"
+      });
+    }
+    
+    return new Response(`
+      <h1>Welcome to Alchemy!</h1>
+      <p>Try these endpoints:</p>
+      <ul>
+        <li><a href="/hello">/hello</a> - JSON greeting</li>
+        <li><a href="/api/time">/api/time</a> - Current time</li>
+      </ul>
+    `, { 
+      status: 200,
+      headers: { "Content-Type": "text/html" }
+    });
+  },
+};
+```
+
+Deploy the update:
+
+::: code-group
+
+```sh [bun]
+bun ./alchemy.run.ts
+```
+
+```sh [npm]
+npx tsx ./alchemy.run.ts
+```
+
+```sh [pnpm]
+pnpm tsx ./alchemy.run.ts
+```
+
+```sh [yarn]
+yarn tsx ./alchemy.run.ts
+```
+
+:::
+
+You'll see:
+```
+Update:  "my-first-app/dev/hello-worker"
+Updated: "my-first-app/dev/hello-worker"
+```
+
+The beauty of Infrastructure-as-Code: Alchemy automatically detects changes and updates only what's necessary!
+
+## Tear Down
+
+When you're done, you can destroy all resources:
+
+::: code-group
+
+```sh [bun]
+bun ./alchemy.run.ts --destroy
+```
+
+```sh [npm]
+npx tsx ./alchemy.run.ts --destroy
+```
+
+```sh [pnpm]
+pnpm tsx ./alchemy.run.ts --destroy
+```
+
+```sh [yarn]
+yarn tsx ./alchemy.run.ts --destroy
+```
+
+:::
+
+Output:
+```
+Delete:  "my-first-app/dev/hello-worker"
+Deleted: "my-first-app/dev/hello-worker"
+```
+
+Your worker is now removed from Cloudflare.
 
 ## Next Steps
 
-This was a very simple example using the local file system. Now, you might want to do something more interesting like deploy some Cloudflare resources or build your own!
+You've successfully deployed your first Cloudflare Worker with Alchemy! Here are some next steps:
 
-- [Deploy a ViteJS site to Cloudflare](./guides/cloudflare-vitejs)
-- [Build your own Custom Resource](./guides/custom-resources.md)
+- [Deploy a ViteJS site to Cloudflare](./guides/cloudflare-vitejs) - Build full-stack applications
+- [Learn about Cloudflare Workers](./guides/cloudflare-worker) - Advanced worker features
+- [Build your own Custom Resource](./guides/custom-resources.md) - Extend Alchemy

--- a/alchemy-web/docs/getting-started.md
+++ b/alchemy-web/docs/getting-started.md
@@ -242,13 +242,15 @@ console.log(`Worker deployed at: ${worker.url}`);
 await app.finalize();
 ```
 
-Now update your worker to use these bindings:
+Now update your worker to use these bindings with type safety:
 
 ```typescript
 // src/worker.ts
+import type { worker } from "../alchemy.run";
+
 export default {
-  async fetch(request: Request, env: any): Promise<Response> {
-    // Store and retrieve data
+  async fetch(request: Request, env: typeof worker.Env): Promise<Response> {
+    // Store and retrieve data with type safety
     await env.KV.put("last-visit", new Date().toISOString());
     const lastVisit = await env.KV.get("last-visit");
     
@@ -256,15 +258,20 @@ export default {
       message: "Hello from Alchemy!",
       timestamp: new Date().toISOString(),
       lastVisit: lastVisit,
-      apiKey: env.API_KEY
+      apiKey: env.API_KEY // TypeScript knows this is a string
     });
   },
 };
 ```
 
-## Configure Type-Safe Bindings
+> [!NOTE]
+> The `typeof worker.Env` gives you full type safety by inferring types directly from your infrastructure definition in `alchemy.run.ts`. No code generation required!
 
-To get full TypeScript support for your bindings, create an `src/env.ts` file:
+## Alternative: Using Cloudflare Workers Environment
+
+For a more integrated development experience, you can also access bindings through the `cloudflare:workers` module.
+
+First, create an `src/env.ts` file for global type configuration:
 
 ```typescript
 // src/env.ts
@@ -293,7 +300,7 @@ Update your `tsconfig.json` to include the env types:
 }
 ```
 
-Now update your worker to use type-safe bindings:
+Now you can use the `env` import instead:
 
 ```typescript
 // src/worker.ts
@@ -316,7 +323,7 @@ export default {
 ```
 
 > [!NOTE]
-> Alchemy infers binding types directly from your infrastructure code. No code generation required - your `env.ts` file imports the worker definition and TypeScript automatically provides the correct types!
+> Both approaches give you the same type safety. The `typeof worker.Env` approach is simpler to start with, while the `cloudflare:workers` import provides a more integrated development experience with the Cloudflare Workers runtime.
 
 ## Understanding State
 

--- a/alchemy-web/docs/getting-started.md
+++ b/alchemy-web/docs/getting-started.md
@@ -16,17 +16,17 @@ You'll need:
 
 ::: code-group
 
-```sh [Node.js]
+```sh [node]
 # Install from https://nodejs.org/
 node --version
 ```
 
-```sh [Bun]
+```sh [bun]
 # Install from https://bun.sh/
 bun --version
 ```
 
-```sh [Deno]
+```sh [deno]
 # Install from https://deno.com/
 deno --version
 ```
@@ -115,8 +115,7 @@ This will open your browser to authenticate with your Cloudflare account.
 
 Create a file named `alchemy.run.ts` in your project directory:
 
-> [!TIP]
-> `alchemy.run.ts` is just a convention - you can run Alchemy in any script or JavaScript environment.
+> [!TIP] > `alchemy.run.ts` is just a convention - you can run Alchemy in any script or JavaScript environment.
 
 ### Step 1: Initialize the Alchemy Application Scope
 
@@ -169,9 +168,9 @@ Create a `src/worker.ts` file with your worker code:
 ```typescript
 export default {
   async fetch(request: Request): Promise<Response> {
-    return Response.json({ 
+    return Response.json({
       message: "Hello from Alchemy!",
-      timestamp: new Date().toISOString()
+      timestamp: new Date().toISOString(),
     });
   },
 };
@@ -221,12 +220,12 @@ Now let's add some infrastructure to our worker. We'll add a KV namespace for st
 First, update your `alchemy.run.ts` to add bindings:
 
 ```typescript
-import { Worker, KvNamespace } from "alchemy/cloudflare";
+import { Worker, KVNamespace } from "alchemy/cloudflare";
 
 // ... existing app initialization ...
 
 // Create a KV namespace for storage
-const kv = await KvNamespace("my-app-storage", {});
+const kv = await KVNamespace("my-app-storage");
 
 // Update the worker with bindings
 const worker = await Worker("hello-worker", {
@@ -238,8 +237,7 @@ const worker = await Worker("hello-worker", {
   },
 });
 
-console.log(`Worker deployed at: ${worker.url}`);
-await app.finalize();
+// ... existing app.finalize() ...
 ```
 
 Now update your worker to use these bindings with type safety:
@@ -253,12 +251,12 @@ export default {
     // Store and retrieve data with type safety
     await env.KV.put("last-visit", new Date().toISOString());
     const lastVisit = await env.KV.get("last-visit");
-    
-    return Response.json({ 
+
+    return Response.json({
       message: "Hello from Alchemy!",
       timestamp: new Date().toISOString(),
       lastVisit: lastVisit,
-      apiKey: env.API_KEY // TypeScript knows this is a string
+      apiKey: env.API_KEY, // TypeScript knows this is a string
     });
   },
 };
@@ -311,12 +309,12 @@ export default {
     // Store and retrieve data with type safety
     await env.KV.put("last-visit", new Date().toISOString());
     const lastVisit = await env.KV.get("last-visit");
-    
-    return Response.json({ 
+
+    return Response.json({
       message: "Hello from Alchemy!",
       timestamp: new Date().toISOString(),
       lastVisit: lastVisit,
-      apiKey: env.API_KEY // TypeScript knows this is a string
+      apiKey: env.API_KEY, // TypeScript knows this is a string
     });
   },
 };
@@ -414,6 +412,7 @@ yarn tsx ./alchemy.run.ts --destroy
 :::
 
 Output:
+
 ```
 Delete:  "my-first-app/dev/hello-worker"
 Deleted: "my-first-app/dev/hello-worker"


### PR DESCRIPTION
Replace File system example with practical Cloudflare Worker deployment

- Add step-by-step TypeScript project setup with multiple package managers
- Include wrangler CLI installation and authentication
- Demonstrate WranglerJson generation for local development
- Show wrangler dev local development workflow
- Maintain educational structure while being more engaging and practical
- Follow existing Cloudflare guide conventions and style

Closes #295

Generated with [Claude Code](https://claude.ai/code)