### PR TITLE
fix: Handle duplicate nodejs_compat flag

### DIFF
--- a/alchemy/src/cloudflare/worker.ts
+++ b/alchemy/src/cloudflare/worker.ts
@@ -635,7 +635,8 @@ export function Worker<const B extends Bindings>(
         url: true,
         compatibilityFlags: [
           "nodejs_compat",
-          ...(props.compatibilityFlags ?? []),
+          ...(props.compatibilityFlags?.filter((f) => f !== "nodejs_compat") ??
+            []),
         ],
         entrypoint: meta!.filename,
         name: workerName,


### PR DESCRIPTION
If a user passes in nodejs_compat into the worker flags, they get the lovely error:

CloudflareApiError: Error 400 uploading worker script worker 'my-file-uploader': Compatibility flag specified multiple times: nodejs_compat

Small change to filter out existing nodejs_compat flags so this case is gracefully handled