### PR TITLE
fix: improve error message when secret value is undefined

### DIFF
--- a/alchemy/src/secret.ts
+++ b/alchemy/src/secret.ts
@@ -106,7 +106,16 @@ export function secret<S extends string | undefined>(
   name?: string,
 ): Secret {
   if (unencrypted === undefined) {
-    throw new Error("Secret cannot be undefined");
+    throw new Error(
+      "Secret value cannot be undefined. This usually happens when:\n" +
+      "  1. An environment variable is not set (e.g., process.env.API_KEY is undefined)\n" +
+      "  2. A required credential or password is missing\n" +
+      "  3. The alchemy application password is not configured\n\n" +
+      "To fix this:\n" +
+      "  • Check that all required environment variables are set in your .env file\n" +
+      "  • Ensure your alchemy app has a password: alchemy('app', { password: process.env.SECRET_PASSPHRASE })\n" +
+      "  • Verify the secret value exists before calling secret()"
+    );
   }
   return new Secret(unencrypted, name);
 }


### PR DESCRIPTION
Fixes #299

Improved the error message in the `secret()` function when undefined values are passed. The previous message "Secret cannot be undefined" was not helpful for developers trying to understand why their code failed.

The new error message provides:
1. Common causes (missing env vars, missing passwords, missing credentials)
2. Actionable steps to fix the issue
3. Specific examples of proper configuration

This will help developers quickly identify and resolve issues when they forget to set required environment variables or configure their alchemy application properly.

Generated with [Claude Code](https://claude.ai/code)