### PR TITLE
feat: anonymous telemetry with opt-out

### DIFF
--- a/alchemy-web/.vitepress/config.mts
+++ b/alchemy-web/.vitepress/config.mts
@@ -51,6 +51,7 @@ export default defineConfig({
 			await generateSidebar("Guides"),
 			await generateSidebar("Concepts"),
 			await generateProvidersSidebar(),
+			await generateSidebar("Telemetry"),
 		],
 		search: { provider: "local" },
 	},

--- a/alchemy-web/docs/telemetry/index.md
+++ b/alchemy-web/docs/telemetry/index.md
@@ -1,0 +1,94 @@
+---
+title: Telemetry
+order: 1
+---
+
+# Telemetry
+
+Alchemy collects anonymous usage telemetry to help us understand how the tool is being used and improve the developer experience. This data helps us prioritize features, identify bugs, and optimize performance.
+
+## What Data Is Collected
+
+### Events Tracked
+
+Alchemy tracks the following events during execution:
+
+- **`app.start`** - When an Alchemy application begins running
+- **`app.success`** - When an application completes successfully  
+- **`app.error`** - When an application encounters an error
+- **`resource.start`** - When a resource begins provisioning
+- **`resource.success`** - When a resource is successfully created/updated
+- **`resource.error`** - When a resource encounters an error
+- **`resource.skip`** - When a resource is skipped (e.g., already exists)
+- **`resource.read`** - When a resource is read from the cloud provider
+
+### Event Properties
+
+Each event may include additional properties:
+
+- **Elapsed time** - For `*.success` and `*.error` events, the time taken to complete
+- **Resource information** - For `resource.*` events, includes resource name and status
+- **Error details** - For `resource.error` events, includes serialized error information (with sensitive data redacted)
+
+### Metadata
+
+All events include the following metadata:
+
+- **Anonymous user ID** - A randomly generated identifier stored locally in your system's configuration directory
+- **Anonymous project ID** - Derived from your project's root git commit hash
+- **System information** - Operating system, version, architecture, CPU count, and memory
+- **Runtime details** - JavaScript runtime name and version (e.g., workerd, Bun 1.2.15, Node 22.15.0)
+- **CI provider** - If running in a CI environment (e.g., GitHub Actions)
+- **Alchemy version and phase** - The version of Alchemy being used and deployment phase
+
+## Privacy
+
+Your privacy is important to us:
+
+- **No personal information** - We do not collect usernames, email addresses, or other personally identifiable information
+- **Local storage** - Your anonymous user ID is stored locally in your system's configuration directory
+- **Data redaction** - Home directory paths are automatically redacted from stack traces and error messages
+- **Anonymous identifiers** - Project IDs are derived from git commit hashes, not repository names or URLs
+
+### First-Time Warning
+
+When Alchemy runs for the first time on your system, you'll see a warning message explaining that an anonymous user ID has been generated. This only happens once per system.
+
+## How to Opt Out
+
+You can disable telemetry collection at any time using environment variables:
+
+### Option 1: Alchemy-Specific Variable
+
+```bash
+export ALCHEMY_TELEMETRY_DISABLED=1
+```
+
+### Option 2: Universal Do Not Track
+
+Alchemy respects the [Do Not Track](https://consoledonottrack.com) standard:
+
+```bash
+export DO_NOT_TRACK=1
+```
+
+### Permanent Opt-Out
+
+To permanently disable telemetry, add either environment variable to your shell profile:
+
+```bash
+# In ~/.bashrc, ~/.zshrc, or equivalent
+echo 'export ALCHEMY_TELEMETRY_DISABLED=1' >> ~/.bashrc
+```
+
+## Data Usage
+
+The telemetry data helps us:
+
+- **Identify popular features** - Understand which Alchemy features are most commonly used
+- **Detect errors** - Find and fix bugs that users encounter in the wild
+- **Optimize performance** - Identify slow operations and bottlenecks
+- **Plan development** - Prioritize new features based on usage patterns
+- **Support compatibility** - Ensure Alchemy works well across different environments and runtimes
+
+The data is processed securely and is not shared with third parties.

--- a/alchemy-web/docs/telemetry/index.md
+++ b/alchemy-web/docs/telemetry/index.md
@@ -5,90 +5,45 @@ order: 1
 
 # Telemetry
 
-Alchemy collects anonymous usage telemetry to help us understand how the tool is being used and improve the developer experience. This data helps us prioritize features, identify bugs, and optimize performance.
+Alchemy collects anonymous usage telemetry to help us understand how the tool is being used and improve the developer experience.
 
 ## What Data Is Collected
 
-### Events Tracked
+We collect basic usage information including:
 
-Alchemy tracks the following events during execution:
-
-- **`app.start`** - When an Alchemy application begins running
-- **`app.success`** - When an application completes successfully  
-- **`app.error`** - When an application encounters an error
-- **`resource.start`** - When a resource begins provisioning
-- **`resource.success`** - When a resource is successfully created/updated
-- **`resource.error`** - When a resource encounters an error
-- **`resource.skip`** - When a resource is skipped (e.g., already exists)
-- **`resource.read`** - When a resource is read from the cloud provider
-
-### Event Properties
-
-Each event may include additional properties:
-
-- **Elapsed time** - For `*.success` and `*.error` events, the time taken to complete
-- **Resource information** - For `resource.*` events, includes resource name and status
-- **Error details** - For `resource.error` events, includes serialized error information (with sensitive data redacted)
-
-### Metadata
-
-All events include the following metadata:
-
-- **Anonymous user ID** - A randomly generated identifier stored locally in your system's configuration directory
-- **Anonymous project ID** - Derived from your project's root git commit hash
-- **System information** - Operating system, version, architecture, CPU count, and memory
-- **Runtime details** - JavaScript runtime name and version (e.g., workerd, Bun 1.2.15, Node 22.15.0)
-- **CI provider** - If running in a CI environment (e.g., GitHub Actions)
-- **Alchemy version and phase** - The version of Alchemy being used and deployment phase
+- Application and resource deployment events
+- Performance metrics (timing information)
+- Error information (with sensitive data redacted)
+- System information (OS, runtime version)
+- Anonymous identifiers (no personal information)
 
 ## Privacy
 
-Your privacy is important to us:
+We prioritize your privacy:
 
-- **No personal information** - We do not collect usernames, email addresses, or other personally identifiable information
-- **Local storage** - Your anonymous user ID is stored locally in your system's configuration directory
-- **Data redaction** - Home directory paths are automatically redacted from stack traces and error messages
-- **Anonymous identifiers** - Project IDs are derived from git commit hashes, not repository names or URLs
-
-### First-Time Warning
-
-When Alchemy runs for the first time on your system, you'll see a warning message explaining that an anonymous user ID has been generated. This only happens once per system.
+- No personal information is collected
+- All data is anonymized
+- Sensitive information is automatically redacted from error reports
 
 ## How to Opt Out
 
-You can disable telemetry collection at any time using environment variables:
+You can disable telemetry collection using environment variables:
 
-### Option 1: Alchemy-Specific Variable
-
+**Option 1: Alchemy-specific**
 ```bash
 export ALCHEMY_TELEMETRY_DISABLED=1
 ```
 
-### Option 2: Universal Do Not Track
-
-Alchemy respects the [Do Not Track](https://consoledonottrack.com) standard:
-
+**Option 2: Universal Do Not Track**
 ```bash
 export DO_NOT_TRACK=1
 ```
 
-### Permanent Opt-Out
-
-To permanently disable telemetry, add either environment variable to your shell profile:
+To permanently disable telemetry, add either variable to your shell profile:
 
 ```bash
 # In ~/.bashrc, ~/.zshrc, or equivalent
 echo 'export ALCHEMY_TELEMETRY_DISABLED=1' >> ~/.bashrc
 ```
 
-## Data Usage
-
-The telemetry data helps us:
-
-- **Identify popular features** - Understand which Alchemy features are most commonly used
-- **Detect errors** - Find and fix bugs that users encounter in the wild
-- **Optimize performance** - Identify slow operations and bottlenecks
-- **Plan development** - Prioritize new features based on usage patterns
-- **Support compatibility** - Ensure Alchemy works well across different environments and runtimes
-
-The data is processed securely and is not shared with third parties.
+This data helps us prioritize features, fix bugs, and improve performance. The data is processed securely and is not shared with third parties.

--- a/alchemy/package.json
+++ b/alchemy/package.json
@@ -145,7 +145,6 @@
     "prettier": "^3.0.0",
     "stripe": "^17.0.0",
     "turndown": "^7.0.0",
-    "xdg-app-paths": "^8.0.0",
     "yaml": "^2.0.0",
     "zod": "^3.0.0"
   },
@@ -180,7 +179,6 @@
     "vite": "^6.0.7",
     "vitepress": "^1.6.3",
     "wrangler": "^3.114.0",
-    "xdg-app-paths": "^8.3.0",
     "yaml": "^2.7.1"
   }
 }

--- a/alchemy/src/alchemy.ts
+++ b/alchemy/src/alchemy.ts
@@ -15,6 +15,7 @@ import { isRuntime } from "./runtime/global.ts";
 import { Scope } from "./scope.ts";
 import { secret } from "./secret.ts";
 import type { StateStoreType } from "./state.ts";
+import { TelemetryClient } from "./util/telemetry/client.ts";
 
 /**
  * Type alias for semantic highlighting of `alchemy` as a type keyword
@@ -112,13 +113,21 @@ async function _alchemy(
 ): Promise<Scope | string | never> {
   if (typeof args[0] === "string") {
     const [appName, options] = args as [string, AlchemyOptions?];
-    const phase = options?.phase ?? "up";
+    const phase = isRuntime ? "read" : (options?.phase ?? "up");
+    const telemetryClient =
+      options?.parent?.telemetryClient ??
+      TelemetryClient.create({
+        phase,
+        enabled: options?.telemetry ?? true,
+        quiet: options?.quiet ?? false,
+      });
     const root = new Scope({
       ...options,
       appName,
       stage: options?.stage ?? process.env.ALCHEMY_STAGE,
-      phase: isRuntime ? "read" : phase,
+      phase,
       password: options?.password ?? process.env.ALCHEMY_PASSWORD,
+      telemetryClient,
     });
     try {
       Scope.storage.enterWith(root);
@@ -291,6 +300,13 @@ export interface AlchemyOptions {
    * Required if using alchemy.secret() in this scope.
    */
   password?: string;
+  /**
+   * Whether to send anonymous telemetry data to the Alchemy team.
+   * You can also opt out by setting the `DO_NOT_TRACK` or `ALCHEMY_TELEMETRY_DISABLED` environment variables to a truthy value.
+   *
+   * @default true
+   */
+  telemetry?: boolean;
 }
 
 export interface ScopeOptions extends AlchemyOptions {
@@ -337,9 +353,17 @@ async function run<T>(
           RunOptions,
           (this: Scope, scope: Scope) => Promise<T>,
         ]);
+  const telemetryClient =
+    options?.parent?.telemetryClient ??
+    TelemetryClient.create({
+      phase: isRuntime ? "read" : (options?.phase ?? "up"),
+      enabled: options?.telemetry ?? true,
+      quiet: options?.quiet ?? false,
+    });
   const _scope = new Scope({
     ...options,
     scopeName: id,
+    telemetryClient,
   });
   try {
     if (options?.isResource !== true && _scope.parent) {

--- a/alchemy/src/cloudflare/auth.ts
+++ b/alchemy/src/cloudflare/auth.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import type { Secret } from "../secret.ts";
+import { createXdgAppPaths } from "../util/xdg-paths.ts";
 /**
  * Authentication options for Cloudflare API
  */
@@ -195,9 +196,9 @@ async function findWranglerConfig(): Promise<string> {
     `${environment === "production" ? "default.toml" : `${environment}.toml`}`,
   );
 
-  const xdgAppPaths = (await import("xdg-app-paths")).default;
+  const xdgAppPaths = createXdgAppPaths(".wrangler");
   //TODO: We should implement a custom path --global-config and/or the WRANGLER_HOME type environment variable
-  const configDir = xdgAppPaths(".wrangler").config(); // New XDG compliant config path
+  const configDir = xdgAppPaths.config(); // New XDG compliant config path
   const legacyConfigDir = path.join(os.homedir(), ".wrangler"); // Legacy config in user's home directory
 
   // Check for the .wrangler directory in root if it is not there then use the XDG compliant path.

--- a/alchemy/src/resource.ts
+++ b/alchemy/src/resource.ts
@@ -137,9 +137,15 @@ export function Resource<
       const otherResource = scope.resources.get(resourceID);
       if (otherResource?.[ResourceKind] !== type) {
         scope.fail();
-        throw new Error(
+        const error = new Error(
           `Resource ${resourceID} already exists in the stack and is of a different type: '${otherResource?.[ResourceKind]}' !== '${type}'`,
         );
+        scope.telemetryClient.record({
+          event: "resource.error",
+          resource: type,
+          error,
+        });
+        throw error;
       }
     }
 

--- a/alchemy/src/scope.ts
+++ b/alchemy/src/scope.ts
@@ -4,8 +4,9 @@ import { destroyAll } from "./destroy.ts";
 import { FileSystemStateStore } from "./fs/file-system-state-store.ts";
 import { ResourceID, type PendingResource } from "./resource.ts";
 import type { StateStore, StateStoreType } from "./state.ts";
+import type { ITelemetryClient } from "./util/telemetry/client.ts";
 
-export type ScopeOptions = {
+export interface ScopeOptions {
   appName?: string;
   stage?: string;
   parent?: Scope;
@@ -14,7 +15,8 @@ export type ScopeOptions = {
   stateStore?: StateStoreType;
   quiet?: boolean;
   phase?: Phase;
-};
+  telemetryClient?: ITelemetryClient;
+}
 
 // TODO: support browser
 const DEFAULT_STAGE = process.env.ALCHEMY_STAGE ?? process.env.USER ?? "dev";
@@ -55,9 +57,11 @@ export class Scope {
   public readonly stateStore: StateStoreType;
   public readonly quiet: boolean;
   public readonly phase: Phase;
+  public readonly telemetryClient: ITelemetryClient;
 
   private isErrored = false;
   private finalized = false;
+  private startedAt = performance.now();
 
   private deferred: (() => Promise<any>)[] = [];
 
@@ -88,6 +92,11 @@ export class Scope {
       this.parent?.stateStore ??
       ((scope) => new FileSystemStateStore(scope));
     this.state = this.stateStore(this);
+    if (!options.telemetryClient && !this.parent?.telemetryClient) {
+      throw new Error("Telemetry client is required");
+    }
+    this.telemetryClient =
+      options.telemetryClient ?? this.parent?.telemetryClient!;
   }
 
   public get root(): Scope {
@@ -124,7 +133,7 @@ export class Scope {
   }
 
   public async init() {
-    await this.state.init?.();
+    await Promise.all([this.state.init?.(), this.rootTelemetryClient?.init()]);
   }
 
   public async deinit() {
@@ -144,8 +153,23 @@ export class Scope {
     return this.finalize();
   }
 
+  /**
+   * The telemetry client for the root scope.
+   * This is used so that app-level hooks are only called once.
+   */
+  private get rootTelemetryClient(): ITelemetryClient | null {
+    if (!this.parent) {
+      return this.telemetryClient;
+    }
+    return null;
+  }
+
   public async finalize() {
     if (this.phase === "read") {
+      this.rootTelemetryClient?.record({
+        event: "app.success",
+        elapsed: performance.now() - this.startedAt,
+      });
       return;
     }
     if (this.finalized) {
@@ -155,7 +179,7 @@ export class Scope {
       const last = Scope.globals.pop();
       if (last !== this) {
         throw new Error(
-          "Running in AsyncLocaStorage.enterWith emultation mode and attempted to finalize a global Scope that wasn't top of the stack",
+          "Running in AsyncLocaStorage.enterWith emulation mode and attempted to finalize a global Scope that wasn't top of the stack",
         );
       }
     }
@@ -176,9 +200,20 @@ export class Scope {
         quiet: this.quiet,
         strategy: "sequential",
       });
+      this.rootTelemetryClient?.record({
+        event: "app.success",
+        elapsed: performance.now() - this.startedAt,
+      });
     } else {
       console.warn("Scope is in error, skipping finalize");
+      this.rootTelemetryClient?.record({
+        event: "app.error",
+        error: new Error("Scope failed"),
+        elapsed: performance.now() - this.startedAt,
+      });
     }
+
+    await this.rootTelemetryClient?.finalize();
   }
 
   /**

--- a/alchemy/src/scope.ts
+++ b/alchemy/src/scope.ts
@@ -133,7 +133,7 @@ export class Scope {
   }
 
   public async init() {
-    await Promise.all([this.state.init?.(), this.rootTelemetryClient?.init()]);
+    await Promise.all([this.state.init?.(), this.telemetryClient.ready]);
   }
 
   public async deinit() {

--- a/alchemy/src/test/bun.ts
+++ b/alchemy/src/test/bun.ts
@@ -6,6 +6,7 @@ import { alchemy } from "../alchemy.ts";
 import { DOStateStore } from "../cloudflare/index.ts";
 import { Scope } from "../scope.ts";
 import type { StateStoreType } from "../state.ts";
+import { NoopTelemetryClient } from "../util/telemetry/index.ts";
 
 /**
  * Extend the Alchemy interface to include test functionality
@@ -134,6 +135,7 @@ export function test(meta: ImportMeta, defaultOptions?: TestOptions): test {
     // parent: globalTestScope,
     stateStore: defaultOptions?.stateStore,
     phase: "up",
+    telemetryClient: new NoopTelemetryClient(),
   });
 
   test.beforeAll = (fn: (scope: Scope) => Promise<void>) => {

--- a/alchemy/src/test/vitest.ts
+++ b/alchemy/src/test/vitest.ts
@@ -4,6 +4,7 @@ import { alchemy } from "../alchemy.ts";
 import { DOStateStore } from "../cloudflare/index.ts";
 import { Scope } from "../scope.ts";
 import type { StateStoreType } from "../state.ts";
+import { NoopTelemetryClient } from "../util/telemetry/client.ts";
 
 /**
  * Extend the Alchemy interface to include test functionality
@@ -133,6 +134,7 @@ export function test(meta: ImportMeta, defaultOptions?: TestOptions): test {
     scopeName: `${defaultOptions.prefix ? `${defaultOptions.prefix}-` : ""}${path.basename(meta.filename)}`,
     stateStore: defaultOptions?.stateStore,
     phase: "up",
+    telemetryClient: new NoopTelemetryClient(),
   });
 
   test.beforeAll = (fn: (scope: Scope) => Promise<void>) => {

--- a/alchemy/src/util/telemetry/client.ts
+++ b/alchemy/src/util/telemetry/client.ts
@@ -145,11 +145,7 @@ export class TelemetryClient implements ITelemetryClient {
     try {
       renameSync(path, tempPath);
     } catch (error) {
-      if (
-        error instanceof Error &&
-        "code" in error &&
-        error.code === "ENOENT"
-      ) {
+      if (error instanceof Error && error.message.includes("ENOENT")) {
         // ignore
       } else {
         throw error;

--- a/alchemy/src/util/telemetry/client.ts
+++ b/alchemy/src/util/telemetry/client.ts
@@ -1,0 +1,135 @@
+import {
+  type WriteStream,
+  createWriteStream,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+} from "node:fs";
+import { readFile, unlink } from "node:fs/promises";
+import { join } from "node:path";
+import type { Phase } from "../../alchemy.ts";
+import { INGEST_URL, STATE_DIR, TELEMETRY_DISABLED } from "./constants.ts";
+import { context } from "./context.ts";
+import type { Telemetry } from "./types.ts";
+
+export interface TelemetryClientOptions {
+  phase: Phase;
+  enabled: boolean;
+  quiet: boolean;
+}
+
+export interface ITelemetryClient {
+  record(event: Telemetry.EventInput): void;
+  finalize(): Promise<void>;
+}
+
+export class NoopTelemetryClient implements ITelemetryClient {
+  record(_: Telemetry.EventInput) {}
+  finalize() {
+    return Promise.resolve();
+  }
+}
+
+export class TelemetryClient implements ITelemetryClient {
+  private path: string;
+  private writeStream: WriteStream;
+  private promises: Promise<unknown>[];
+
+  constructor(readonly context: Telemetry.Context) {
+    if (!existsSync(STATE_DIR)) {
+      mkdirSync(STATE_DIR, { recursive: true });
+    }
+
+    const files = readdirSync(STATE_DIR);
+    this.promises = files.map((file) => this.flush(join(STATE_DIR, file)));
+
+    this.path = join(STATE_DIR, `session-${this.context.sessionId}.jsonl`);
+    this.writeStream = createWriteStream(this.path, { flags: "a" });
+  }
+
+  record(event: Telemetry.EventInput) {
+    const payload = {
+      ...event,
+      error: this.serializeError(event.error),
+      context: this.context,
+      timestamp: Date.now(),
+    } as Telemetry.Event;
+    this.writeStream?.write(`${JSON.stringify(payload)}\n`);
+  }
+
+  private serializeError(
+    error: Telemetry.ErrorInput | undefined,
+  ): Telemetry.SerializedError | undefined {
+    if (!error) {
+      return undefined;
+    }
+    if (error instanceof Error) {
+      return {
+        name: error.name,
+        message: error.message,
+        stack: error.stack,
+      };
+    }
+    return error;
+  }
+
+  async finalize() {
+    await new Promise((resolve) => this.writeStream.end(resolve));
+    this.promises.push(this.flush(this.path));
+    await Promise.allSettled(this.promises).then((results) => {
+      for (const result of results) {
+        if (result.status === "rejected") {
+          console.warn(result.reason);
+        }
+      }
+    });
+  }
+
+  async flush(path: string) {
+    const events = await readFile(path, "utf-8").then((file) => {
+      const events: Telemetry.Event[] = [];
+      for (const line of file.split("\n")) {
+        if (line) {
+          events.push(JSON.parse(line));
+        }
+      }
+      return events;
+    });
+    await this.send(events);
+    await unlink(path);
+  }
+
+  private async send(events: Telemetry.Event[]) {
+    const response = await fetch(INGEST_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(events),
+    });
+    if (!response.ok) {
+      throw new Error(
+        `Failed to send telemetry: ${response.status} ${response.statusText} - ${await response.text()}`,
+      );
+    }
+  }
+
+  static async create({
+    phase,
+    enabled,
+    quiet,
+  }: TelemetryClientOptions): Promise<ITelemetryClient> {
+    if (!enabled || TELEMETRY_DISABLED) {
+      if (!quiet) {
+        console.warn("[Alchemy] Telemetry is disabled.");
+      }
+      return new NoopTelemetryClient();
+    }
+    return new TelemetryClient(
+      await context({
+        sessionId: crypto.randomUUID(),
+        phase,
+      }),
+    );
+  }
+}

--- a/alchemy/src/util/telemetry/client.ts
+++ b/alchemy/src/util/telemetry/client.ts
@@ -1,5 +1,6 @@
 import { type WriteStream, createWriteStream, renameSync } from "node:fs";
 import { mkdir, mkdtemp, readdir, readFile, unlink } from "node:fs/promises";
+import os from "node:os";
 import { basename, join } from "node:path";
 import type { Phase } from "../../alchemy.ts";
 import { INGEST_URL, STATE_DIR, TELEMETRY_DISABLED } from "./constants.ts";
@@ -115,9 +116,11 @@ export class TelemetryClient implements ITelemetryClient {
     }
     if (error instanceof Error) {
       return {
+        ...error, // include additional properties from error object
         name: error.name,
         message: error.message,
-        stack: error.stack,
+        // TODO: maybe redact more of the stack trace?
+        stack: error.stack?.replaceAll(os.homedir(), "~"), // redact home directory
       };
     }
     return error;

--- a/alchemy/src/util/telemetry/constants.ts
+++ b/alchemy/src/util/telemetry/constants.ts
@@ -1,0 +1,14 @@
+import xdgAppPaths from "xdg-app-paths";
+
+const xdg = xdgAppPaths("alchemy");
+
+export const CONFIG_DIR = xdg.config();
+export const STATE_DIR = xdg.state();
+
+export const TELEMETRY_DISABLED =
+  !!process.env.ALCHEMY_TELEMETRY_DISABLED || !!process.env.DO_NOT_TRACK;
+
+// TODO(sam): replace with permanent URL
+export const INGEST_URL =
+  process.env.ALCHEMY_TELEMETRY_URL ??
+  "https://bc6398b3703c4615972fda998c8d09f1.pipelines.cloudflare.com";

--- a/alchemy/src/util/telemetry/constants.ts
+++ b/alchemy/src/util/telemetry/constants.ts
@@ -11,4 +11,4 @@ export const TELEMETRY_DISABLED =
 // TODO(sam): replace with permanent URL
 export const INGEST_URL =
   process.env.ALCHEMY_TELEMETRY_URL ??
-  "https://b75a323ba8074abd80abe83abd01d092.pipelines.cloudflare.com";
+  "https://5fbb5d5ca66f44b685468684cfceb325.pipelines.cloudflare.com";

--- a/alchemy/src/util/telemetry/constants.ts
+++ b/alchemy/src/util/telemetry/constants.ts
@@ -11,4 +11,4 @@ export const TELEMETRY_DISABLED =
 // TODO(sam): replace with permanent URL
 export const INGEST_URL =
   process.env.ALCHEMY_TELEMETRY_URL ??
-  "https://bc6398b3703c4615972fda998c8d09f1.pipelines.cloudflare.com";
+  "https://b75a323ba8074abd80abe83abd01d092.pipelines.cloudflare.com";

--- a/alchemy/src/util/telemetry/constants.ts
+++ b/alchemy/src/util/telemetry/constants.ts
@@ -1,6 +1,6 @@
-import xdgAppPaths from "xdg-app-paths";
+import { createXdgAppPaths } from "../xdg-paths.js";
 
-const xdg = xdgAppPaths("alchemy");
+const xdg = createXdgAppPaths("alchemy");
 
 export const CONFIG_DIR = xdg.config();
 export const STATE_DIR = xdg.state();

--- a/alchemy/src/util/telemetry/context.ts
+++ b/alchemy/src/util/telemetry/context.ts
@@ -1,0 +1,154 @@
+import { exec } from "node:child_process";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import os from "node:os";
+import { join } from "node:path";
+import pkg from "../../../package.json" with { type: "json" };
+import type { Phase } from "../../alchemy.ts";
+import { CONFIG_DIR } from "./constants.ts";
+import type { Telemetry } from "./types.ts";
+
+async function userId() {
+  const path = join(CONFIG_DIR, "id");
+
+  try {
+    return (await readFile(path, "utf-8")).trim();
+  } catch {}
+
+  try {
+    await mkdir(CONFIG_DIR, { recursive: true });
+  } catch {}
+
+  const id = crypto.randomUUID();
+  try {
+    await writeFile(path, id);
+    console.warn(
+      [
+        "Attention: To help improve Alchemy, we now collect anonymous usage, performance, and error data.",
+        "You can opt out by setting the ALCHEMY_TELEMETRY_DISABLED or DO_NOT_TRACK environment variable to a truthy value.",
+      ].join("\n"),
+    );
+  } catch {
+    return null;
+  }
+
+  return id;
+}
+
+function projectId() {
+  return new Promise<string | null>((resolve) => {
+    exec("git rev-list --max-parents=0 HEAD", (err, stdout) => {
+      if (err) {
+        resolve(null);
+        return;
+      }
+      resolve(stdout.trim());
+    });
+  });
+}
+
+function system(): Telemetry.Context["system"] {
+  return {
+    platform: os.platform(),
+    osVersion: os.release(),
+    arch: os.arch(),
+    cpus: os.cpus().length,
+    memory: os.totalmem() / 1024 / 1024,
+  };
+}
+
+declare global {
+  var Deno:
+    | {
+        version: {
+          deno: string;
+        };
+      }
+    | undefined;
+  var EdgeRuntime: Record<string, unknown> | undefined;
+}
+
+const RUNTIMES = [
+  {
+    name: "bun",
+    detect: () => !!globalThis.Bun,
+    version: () => globalThis.Bun?.version,
+  },
+  {
+    name: "deno",
+    detect: () => !!globalThis.Deno,
+    version: () => globalThis.Deno?.version?.deno,
+  },
+  {
+    name: "workerd",
+    detect: () => !!globalThis.EdgeRuntime,
+    version: () => null,
+  },
+  {
+    name: "node",
+    detect: () => !!globalThis.process?.versions?.node,
+    version: () => process.versions.node,
+  },
+] as const;
+
+function runtime(): Telemetry.Context["runtime"] {
+  for (const runtime of RUNTIMES) {
+    if (runtime.detect()) {
+      return {
+        name: runtime.name,
+        version: runtime.version() ?? null,
+      };
+    }
+  }
+  return {
+    name: null,
+    version: null,
+  };
+}
+
+const PROVIDERS = [
+  { env: "GITHUB_ACTIONS", provider: "GitHub Actions", isCI: true },
+  { env: "GITLAB_CI", provider: "GitLab CI", isCI: true },
+  { env: "CIRCLECI", provider: "CircleCI", isCI: true },
+  { env: "JENKINS_URL", provider: "Jenkins", isCI: true },
+  { env: "TRAVIS", provider: "Travis CI", isCI: true },
+  { env: "NOW_BUILDER", provider: "Vercel", isCI: true },
+  { env: "VERCEL", provider: "Vercel", isCI: false },
+];
+
+function environment(): Telemetry.Context["environment"] {
+  for (const provider of PROVIDERS) {
+    if (process.env[provider.env]) {
+      return {
+        provider: provider.provider,
+        isCI: provider.isCI,
+      };
+    }
+  }
+  return {
+    provider: null,
+    isCI: !!process.env.CI,
+  };
+}
+
+export async function context(input: {
+  sessionId: string;
+  phase: Phase;
+}): Promise<Telemetry.Context> {
+  const env = environment();
+  const [uid, pid] = await Promise.all([
+    env.isCI ? null : userId(),
+    projectId(),
+  ]);
+  return {
+    userId: uid,
+    projectId: pid,
+    sessionId: input.sessionId,
+    system: system(),
+    runtime: runtime(),
+    environment: env,
+    alchemy: {
+      version: pkg.version,
+      phase: input.phase,
+    },
+  };
+}

--- a/alchemy/src/util/telemetry/index.ts
+++ b/alchemy/src/util/telemetry/index.ts
@@ -1,0 +1,2 @@
+export * from "./client.ts";
+export * from "./types.ts";

--- a/alchemy/src/util/telemetry/types.ts
+++ b/alchemy/src/util/telemetry/types.ts
@@ -44,8 +44,8 @@ export namespace Telemetry {
 
   export type ErrorInput = Error | SerializedError;
 
-  export interface ScopeEvent extends BaseEvent {
-    event: "scope.start" | "scope.success" | "scope.error";
+  export interface AppEvent extends BaseEvent {
+    event: "app.start" | "app.success" | "app.error";
     elapsed?: number;
     error?: SerializedError;
   }
@@ -70,9 +70,9 @@ export namespace Telemetry {
     replaced?: boolean;
   }
 
-  export type Event = ScopeEvent | ResourceEvent;
+  export type Event = AppEvent | ResourceEvent;
   export type EventInput = (
-    | Omit<ScopeEvent, "context" | "timestamp" | "error">
+    | Omit<AppEvent, "context" | "timestamp" | "error">
     | Omit<ResourceEvent, "context" | "timestamp" | "error">
   ) & {
     error?: ErrorInput;

--- a/alchemy/src/util/telemetry/types.ts
+++ b/alchemy/src/util/telemetry/types.ts
@@ -1,0 +1,80 @@
+import type { Phase } from "../../alchemy.ts";
+
+export namespace Telemetry {
+  export interface Context {
+    userId: string | null;
+    projectId: string | null;
+    sessionId: string;
+
+    system: {
+      platform: string;
+      osVersion: string;
+      arch: string;
+      cpus: number;
+      memory: number;
+    };
+
+    runtime: {
+      name: string | null;
+      version: string | null;
+    };
+
+    environment: {
+      provider: string | null;
+      isCI: boolean;
+    };
+
+    alchemy: {
+      version: string;
+      phase: Phase;
+    };
+  }
+
+  export interface BaseEvent {
+    event: string;
+    context: Context;
+    timestamp: number;
+  }
+
+  export interface SerializedError {
+    name?: string;
+    message: string;
+    stack?: string;
+  }
+
+  export type ErrorInput = Error | SerializedError;
+
+  export interface ScopeEvent extends BaseEvent {
+    event: "scope.start" | "scope.success" | "scope.error";
+    elapsed?: number;
+    error?: SerializedError;
+  }
+
+  export interface ResourceEvent extends BaseEvent {
+    event:
+      | "resource.start"
+      | "resource.success"
+      | "resource.error"
+      | "resource.skip"
+      | "resource.read";
+    resource: string;
+    status?:
+      | "creating"
+      | "created"
+      | "updating"
+      | "updated"
+      | "deleting"
+      | "deleted";
+    elapsed?: number;
+    error?: SerializedError;
+    replaced?: boolean;
+  }
+
+  export type Event = ScopeEvent | ResourceEvent;
+  export type EventInput = (
+    | Omit<ScopeEvent, "context" | "timestamp" | "error">
+    | Omit<ResourceEvent, "context" | "timestamp" | "error">
+  ) & {
+    error?: ErrorInput;
+  };
+}

--- a/alchemy/src/util/telemetry/types.ts
+++ b/alchemy/src/util/telemetry/types.ts
@@ -2,8 +2,11 @@ import type { Phase } from "../../alchemy.ts";
 
 export namespace Telemetry {
   export interface Context {
+    /** Random UUID generated once per machine and stored in XDG config directory (e.g. `~/Library/Preferences/alchemy` on Mac). Null for CI environments. */
     userId: string | null;
+    /** Root commit hash for the git repository. Anonymous, stable identifier for anyone using git. */
     projectId: string | null;
+    /** UUID generated once per application run. */
     sessionId: string;
 
     system: {

--- a/alchemy/src/util/xdg-paths.ts
+++ b/alchemy/src/util/xdg-paths.ts
@@ -1,0 +1,40 @@
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+/**
+ * Vendored XDG Base Directory Specification implementation
+ * Provides cross-platform directory paths for config and state
+ */
+export function createXdgAppPaths(appName: string) {
+  const platform = process.platform;
+  const home = homedir();
+
+  function config(): string {
+    if (platform === "win32") {
+      return join(process.env.LOCALAPPDATA || join(home, "AppData", "Local"), appName);
+    } else if (platform === "darwin") {
+      return join(home, "Library", "Preferences", appName);
+    } else {
+      // Linux/Unix - follow XDG Base Directory Specification
+      const xdgConfigHome = process.env.XDG_CONFIG_HOME || join(home, ".config");
+      return join(xdgConfigHome, appName);
+    }
+  }
+
+  function state(): string {
+    if (platform === "win32") {
+      return join(process.env.LOCALAPPDATA || join(home, "AppData", "Local"), appName);
+    } else if (platform === "darwin") {
+      return join(home, "Library", "Application Support", appName);
+    } else {
+      // Linux/Unix - follow XDG Base Directory Specification
+      const xdgStateHome = process.env.XDG_STATE_HOME || join(home, ".local", "state");
+      return join(xdgStateHome, appName);
+    }
+  }
+
+  return {
+    config,
+    state,
+  };
+}

--- a/alchemy/src/util/xdg-paths.ts
+++ b/alchemy/src/util/xdg-paths.ts
@@ -11,24 +11,32 @@ export function createXdgAppPaths(appName: string) {
 
   function config(): string {
     if (platform === "win32") {
-      return join(process.env.LOCALAPPDATA || join(home, "AppData", "Local"), appName);
+      return join(
+        process.env.LOCALAPPDATA || join(home, "AppData", "Local"),
+        appName,
+      );
     } else if (platform === "darwin") {
       return join(home, "Library", "Preferences", appName);
     } else {
       // Linux/Unix - follow XDG Base Directory Specification
-      const xdgConfigHome = process.env.XDG_CONFIG_HOME || join(home, ".config");
+      const xdgConfigHome =
+        process.env.XDG_CONFIG_HOME || join(home, ".config");
       return join(xdgConfigHome, appName);
     }
   }
 
   function state(): string {
     if (platform === "win32") {
-      return join(process.env.LOCALAPPDATA || join(home, "AppData", "Local"), appName);
+      return join(
+        process.env.LOCALAPPDATA || join(home, "AppData", "Local"),
+        appName,
+      );
     } else if (platform === "darwin") {
       return join(home, "Library", "Application Support", appName);
     } else {
       // Linux/Unix - follow XDG Base Directory Specification
-      const xdgStateHome = process.env.XDG_STATE_HOME || join(home, ".local", "state");
+      const xdgStateHome =
+        process.env.XDG_STATE_HOME || join(home, ".local", "state");
       return join(xdgStateHome, appName);
     }
   }

--- a/alchemy/tsconfig.json
+++ b/alchemy/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../tsconfig.base.json",
-  "include": ["src/**/*.ts", "src/**/*.js"],
+  "include": ["package.json", "src/**/*.ts", "src/**/*.js"],
   "compilerOptions": {
     "composite": true,
     "noEmit": false,

--- a/alchemy/tsconfig.test.json
+++ b/alchemy/tsconfig.test.json
@@ -1,6 +1,11 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["src/**/*.ts", "test/**/*.ts", "src/runtime/shims.js"],
+  "include": [
+    "package.json",
+    "src/**/*.ts",
+    "test/**/*.ts",
+    "src/runtime/shims.js"
+  ],
   "compilerOptions": {
     "rootDir": ".",
     "noEmit": true,

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "fix": "biome check --write",
     "deploy:repo": "bun ./stacks/repo.run.ts",
     "deploy:website": "bun ./stacks/website.run.ts",
+    "deploy:telemetry": "bun ./stacks/telemetry.run.ts",
     "generate:docs": "bun ./stacks/docs.run.ts",
     "generate:aws-control": "bun ./scripts/generate-aws-control.ts",
     "publish:npm": "bun run --filter alchemy publish:npm",

--- a/stacks/telemetry.run.ts
+++ b/stacks/telemetry.run.ts
@@ -1,8 +1,15 @@
-import { Pipeline, R2Bucket } from "../alchemy/src/cloudflare/index.js";
+import {
+  DOStateStore,
+  Pipeline,
+  R2Bucket,
+} from "../alchemy/src/cloudflare/index.js";
 import alchemy from "../alchemy/src/index.js";
 import env from "./env.js";
 
-const app = await alchemy("alchemy:telemetry", env);
+const app = await alchemy("alchemy:telemetry", {
+  ...env,
+  stateStore: (scope) => new DOStateStore(scope),
+});
 
 const bucket = await R2Bucket("telemetry-bucket", {
   name: "alchemy-telemetry-bucket",

--- a/stacks/telemetry.run.ts
+++ b/stacks/telemetry.run.ts
@@ -1,0 +1,29 @@
+import { Pipeline, R2Bucket } from "../alchemy/src/cloudflare/index.js";
+import alchemy from "../alchemy/src/index.js";
+import env from "./env.js";
+
+const app = await alchemy("alchemy:telemetry", env);
+
+const bucket = await R2Bucket("telemetry-bucket", {
+  name: "alchemy-telemetry-bucket",
+});
+
+const pipeline = await Pipeline("telemetry-pipeline", {
+  name: "alchemy-telemetry-pipeline",
+  source: [{ type: "http", format: "json" }],
+  destination: {
+    type: "r2",
+    format: "json",
+    path: {
+      bucket: bucket.name,
+    },
+    credentials: {
+      accessKeyId: await alchemy.secret.env.R2_ACCESS_KEY_ID,
+      secretAccessKey: await alchemy.secret.env.R2_SECRET_ACCESS_KEY,
+    },
+  },
+});
+
+console.log(`Pipeline endpoint: ${pipeline.endpoint}`);
+
+await app.finalize();


### PR DESCRIPTION
## Events & Properties
- Events: `app.start`, `app.success`, `app.error`, `resource.start`, `resource.success`, `resource.error`, `resource.skip`, `resource.read`
- Properties:
  - elapsed time for `*.success` and `*.error` events
  - resource name and status for `resource.*` events
  - serialized error for `resource.error`
- Metadata (included in all events):
   - anonymous user ID (stored in XDG config directory)
   - anonymous project ID (uses root git commit hash for project)
   - system info (e.g. OS, version, arch, CPU count, memory)
   - runtime name and version (e.g. workerd, Bun 1.2.15, Node 22.15.0)
   - CI provider if applicable (e.g. GitHub Actions)
   - Alchemy version and phase

## Privacy
- Warning shown when anonymous user ID is generated for first time on system
- Opt out by setting `ALCHEMY_TELEMETRY_DISABLED` or [`DO_NOT_TRACK`](https://consoledonottrack.com) environment variable
- Home directory is redacted in stack traces when sent (may want to make this more robust?)

## Questions
- The telemetry client is designed to be initialized once when the Alchemy top-level scope is created, and "finalized" (i.e. post events to CF) when that top-level scope is finalized. As a result, it's important that child scopes have a reference to the parent (see change to [Website](https://github.com/sam-goodwin/alchemy/pull/302/files#diff-239026316b15b953f955783913d0c97674cf6fe1b35df7be29cca608c9399a02) resource; should we make this more automatic e.g. by updating the _run function instead?)
- Currently telemetry is disabled in the test env. Should we enable it? I have a feeling we might want to use a different endpoint when we're running our CI just to avoid polluting our user metrics.
- I used the `xdg-app-paths` config directory to store the user ID. Would you prefer if we did this without the third-party dependency?
- Logs are buffered to the XDG cache directory. Should we use .alchemy instead?

## Tasks
- [x] Telemetry client
- [x] Stack for R2 bucket and pipeline to ingest events
- [x] User information and opt out:
- [x] Buffer events to file; if upload fails, retry on next run
- [x] Initialize on per-app basis
- [x] Instrument at resource level
- [x] Upload batch when root scope exits
- [x] @sam-goodwin: Run [`stacks/telemetry.run.ts`](https://github.com/sam-goodwin/alchemy/pull/302/files#diff-59ab410dd13ec4f1aea77ea58dc275ab5ea89684397b341246da7265be458f61) from root and set endpoint URL in [`alchemy/src/utils/telemetry/constants.ts`](https://github.com/sam-goodwin/alchemy/pull/302/files#diff-badbc808bbf4ef7256b72ea9359ac1505a0f0139cdcbea9ae5ac6b48059de0b9) (I used the direct CF endpoint URL because ingest via Workers typically took 1-2 seconds, while via CF took around 500 ms)