### PR TITLE
feat: add getZoneByDomain function for Cloudflare zone lookup

### DIFF
--- a/alchemy/src/cloudflare/zone.ts
+++ b/alchemy/src/cloudflare/zone.ts
@@ -567,7 +567,9 @@ export async function getZoneByDomain(
 ): Promise<Zone | null> {
   const api = await createCloudflareApi(options);
 
-  const response = await api.get(`/zones?name=${encodeURIComponent(domainName)}`);
+  const response = await api.get(
+    `/zones?name=${encodeURIComponent(domainName)}`,
+  );
 
   if (!response.ok) {
     throw new Error(
@@ -575,7 +577,8 @@ export async function getZoneByDomain(
     );
   }
 
-  const zones = ((await response.json()) as { result: CloudflareZone[] }).result;
+  const zones = ((await response.json()) as { result: CloudflareZone[] })
+    .result;
 
   if (zones.length === 0) {
     return null;
@@ -587,7 +590,6 @@ export async function getZoneByDomain(
   const settings = await getZoneSettings(api, zoneData.id);
 
   return {
-    type: "cloudflare::Zone",
     id: zoneData.id,
     name: zoneData.name,
     type: zoneData.type,

--- a/alchemy/src/cloudflare/zone.ts
+++ b/alchemy/src/cloudflare/zone.ts
@@ -165,9 +165,9 @@ export interface ZoneProps extends CloudflareApiOptions {
 }
 
 /**
- * Output returned after Zone creation/update
+ * Zone data structure (used for lookup functions)
  */
-export interface Zone extends Resource<"cloudflare::Zone"> {
+export interface ZoneData {
   /**
    * The ID of the zone
    */
@@ -245,6 +245,11 @@ export interface Zone extends Resource<"cloudflare::Zone"> {
     minTlsVersion: MinTLSVersionValue;
   };
 }
+
+/**
+ * Output returned after Zone creation/update
+ */
+export interface Zone extends Resource<"cloudflare::Zone">, ZoneData {}
 
 /**
  * A Cloudflare Zone represents a domain and its configuration settings on Cloudflare.
@@ -564,7 +569,7 @@ async function getZoneSettings(
 export async function getZoneByDomain(
   domainName: string,
   options: Partial<CloudflareApiOptions> = {},
-): Promise<Zone | null> {
+): Promise<ZoneData | null> {
   const api = await createCloudflareApi(options);
 
   const response = await api.get(

--- a/alchemy/test/cloudflare/zone.test.ts
+++ b/alchemy/test/cloudflare/zone.test.ts
@@ -155,7 +155,7 @@ describe("Zone Resource", () => {
   test("getZoneByDomain lookup function", async (scope) => {
     const lookupTestDomain = `${BRANCH_PREFIX}-lookup-test.dev`;
     let zone: Zone | undefined;
-    
+
     try {
       // Create a test zone
       zone = await Zone(lookupTestDomain, {
@@ -185,9 +185,10 @@ describe("Zone Resource", () => {
       expect(foundZone!.settings.alwaysUseHttps).toEqual("on");
 
       // Test lookup of non-existent domain
-      const nonExistentZone = await getZoneByDomain(`${BRANCH_PREFIX}-non-existent.dev`);
+      const nonExistentZone = await getZoneByDomain(
+        `${BRANCH_PREFIX}-non-existent.dev`,
+      );
       expect(nonExistentZone).toBeNull();
-
     } finally {
       // Always clean up
       await destroy(scope);

--- a/alchemy/test/cloudflare/zone.test.ts
+++ b/alchemy/test/cloudflare/zone.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect } from "vitest";
 import { alchemy } from "../../src/alchemy.ts";
 import { createCloudflareApi } from "../../src/cloudflare/api.ts";
-import { Zone } from "../../src/cloudflare/zone.ts";
+import { Zone, getZoneByDomain } from "../../src/cloudflare/zone.ts";
 import { destroy } from "../../src/destroy.ts";
 import { BRANCH_PREFIX } from "../util.ts";
 
@@ -147,6 +147,55 @@ describe("Zone Resource", () => {
         const text = await getDeletedResponse.text();
         expect(text).toContain("Invalid zone identifier");
         // seriously, wtf, why 400?
+        expect(getDeletedResponse.status).toEqual(400);
+      }
+    }
+  });
+
+  test("getZoneByDomain lookup function", async (scope) => {
+    const lookupTestDomain = `${BRANCH_PREFIX}-lookup-test.dev`;
+    let zone: Zone | undefined;
+    
+    try {
+      // Create a test zone
+      zone = await Zone(lookupTestDomain, {
+        name: lookupTestDomain,
+        type: "full",
+        jumpStart: false,
+        settings: {
+          ssl: "flexible",
+          alwaysUseHttps: "on",
+        },
+      });
+
+      expect(zone.id).toBeTruthy();
+      expect(zone.name).toEqual(lookupTestDomain);
+
+      // Use getZoneByDomain to look up the zone we just created
+      const foundZone = await getZoneByDomain(lookupTestDomain);
+
+      // Verify the lookup returned the correct zone
+      expect(foundZone).toBeTruthy();
+      expect(foundZone!.id).toEqual(zone.id);
+      expect(foundZone!.name).toEqual(lookupTestDomain);
+      expect(foundZone!.type).toEqual("full");
+      expect(foundZone!.accountId).toEqual(zone.accountId);
+      expect(foundZone!.nameservers).toEqual(zone.nameservers);
+      expect(foundZone!.settings.ssl).toEqual("flexible");
+      expect(foundZone!.settings.alwaysUseHttps).toEqual("on");
+
+      // Test lookup of non-existent domain
+      const nonExistentZone = await getZoneByDomain(`${BRANCH_PREFIX}-non-existent.dev`);
+      expect(nonExistentZone).toBeNull();
+
+    } finally {
+      // Always clean up
+      await destroy(scope);
+
+      if (zone) {
+        const getDeletedResponse = await api.get(`/zones/${zone.id}`);
+        const text = await getDeletedResponse.text();
+        expect(text).toContain("Invalid zone identifier");
         expect(getDeletedResponse.status).toEqual(400);
       }
     }


### PR DESCRIPTION
Implements a new function `getZoneByDomain` that looks up Cloudflare zones by domain name using the list zones API.

## Changes
- Added `getZoneByDomain` function in `alchemy/src/cloudflare/zone.ts`
- Uses `/zones?name=` API endpoint to filter by domain name
- Returns complete Zone object with settings or null if not found
- Supports custom API options for authentication
- Automatically exported from `cloudflare/index.ts`
- Includes comprehensive JSDoc documentation with examples

Closes #312

Generated with [Claude Code](https://claude.ai/code)