### PR TITLE
fix(aws): update fast-json-patch import for Node.js compatibility

### DIFF
--- a/alchemy/src/aws/control/resource.ts
+++ b/alchemy/src/aws/control/resource.ts
@@ -1,4 +1,5 @@
-import { compare } from "fast-json-patch";
+import jsonpatch from "fast-json-patch";
+const compare = jsonpatch.compare;
 import type { Context } from "../../context.ts";
 import {
   registerDynamicResource,


### PR DESCRIPTION
Fixes import issue where `{ compare }` named export doesn't work in Node.js but works in Bun. Changed to default import pattern:

- import { compare } from "fast-json-patch";
+ import jsonpatch from "fast-json-patch";
+ const compare = jsonpatch.compare;

This resolves the SyntaxError when running in Node.js runtime.

Fixes #310

Generated with [Claude Code](https://claude.ai/code)