### PR TITLE
fix: fallback to console if no scope is available

### DIFF
--- a/alchemy/src/index.ts
+++ b/alchemy/src/index.ts
@@ -7,6 +7,7 @@ export * from "./serde.ts";
 export * from "./state.ts";
 export * from "./type.ts";
 export * from "./util/ignore.ts";
+export * from "./util/logger.ts";
 
 import { alchemy } from "./alchemy.ts";
 export default alchemy;

--- a/alchemy/src/scope.ts
+++ b/alchemy/src/scope.ts
@@ -33,7 +33,14 @@ export class Scope {
   public static globals: Scope[] = [];
 
   public static get(): Scope | undefined {
-    return Scope.storage.getStore();
+    const scope = Scope.storage.getStore();
+    if (!scope) {
+      if (Scope.globals.length > 0) {
+        return Scope.globals[Scope.globals.length - 1];
+      }
+      return undefined;
+    }
+    return scope;
   }
 
   public static get root(): Scope {
@@ -42,12 +49,7 @@ export class Scope {
 
   public static get current(): Scope {
     const scope = Scope.get();
-    if (!scope) {
-      if (Scope.globals.length > 0) {
-        return Scope.globals[Scope.globals.length - 1];
-      }
-      throw new Error("Not running within an Alchemy Scope");
-    }
+    if (!scope) throw new Error("Not running within an Alchemy Scope");
     return scope;
   }
 

--- a/alchemy/src/util/logger.ts
+++ b/alchemy/src/util/logger.ts
@@ -2,6 +2,16 @@ import { Scope } from "../scope.ts";
 import type { LoggerApi } from "./cli.tsx";
 
 export const logger = new Proxy({} as LoggerApi, {
-  get: (_, prop: keyof LoggerApi) =>
-    Scope.current.logger[prop].bind(Scope.current.logger),
+  get: (_, prop: keyof LoggerApi) => {
+    const logger =
+      Scope.get()?.logger ??
+      ({
+        log: console.log,
+        error: console.error,
+        warn: console.warn,
+        task: () => {},
+        exit: () => {},
+      } as LoggerApi);
+    return logger[prop].bind(logger);
+  },
 });


### PR DESCRIPTION
Use normal console if no scope is available
also export `logger` for users to use