### PR TITLE
fix(cloudflare): use logical OR operator for BRANCH_PREFIX fallback

### DIFF
--- a/stacks/env.ts
+++ b/stacks/env.ts
@@ -17,7 +17,7 @@ export const NEON_API_KEY = await alchemy.secret.env.NEON_API_KEY;
 export const UPSTASH_API_KEY = await alchemy.secret.env.UPSTASH_API_KEY;
 
 export default {
-  stage: process.env.BRANCH_PREFIX ?? "prod",
+  stage: process.env.BRANCH_PREFIX || "prod",
   phase:
     (process.env.ALCHEMY_PHASE as Phase) ??
     (process.argv.includes("--destroy")


### PR DESCRIPTION
Change `??` to `||` for BRANCH_PREFIX in env.ts to handle empty
string values properly. This prevents the "Missing app or stage"
error in DO State Store when BRANCH_PREFIX is an empty string.

Fixes #326

Generated with [Claude Code](https://claude.ai/code)