### PR TITLE
chore: add pre-commit hook to run check --fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ lib/
 
 .repomix-output.txt
 wrangler.jsonc
+
+# Husky - ignore generated files but keep hooks
+.husky/_
+!.husky/pre-commit

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+bun lint-staged

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "publish:npm": "bun run --filter alchemy publish:npm",
     "test": "bun ./alchemy/test/run.ts",
     "test:force": "vitest run",
-    "bump": "bun ./scripts/bump.ts"
+    "bump": "bun ./scripts/bump.ts",
+    "prepare": "husky"
   },
   "workspaces": [
     "alchemy",
@@ -37,6 +38,8 @@
     "aws4fetch": "^1.0.20",
     "braintrust": "*",
     "changelogithub": "^13.15.0",
+    "husky": "^9.1.7",
+    "lint-staged": "^15.3.0",
     "openai": "^4.103.0",
     "typescript": "latest",
     "vitest": "^3.1.4",
@@ -44,5 +47,11 @@
   },
   "dependencies": {
     "alchemy-mono": "."
+  },
+  "lint-staged": {
+    "*.{ts,tsx,js,jsx,mjs}": [
+      "biome check --write --no-errors-on-unmatched",
+      "biome check --no-errors-on-unmatched"
+    ]
   }
 }


### PR DESCRIPTION
Sets up husky + lint-staged to automatically run biome check --fix on staged files before commits to prevent linting/formatting issues.

- Add husky and lint-staged dependencies
- Create .husky/pre-commit hook
- Configure lint-staged to run biome check --write and verify
- Update .gitignore to track pre-commit hook
- Add prepare script for automatic husky setup

Closes #337

Generated with [Claude Code](https://claude.ai/code)