### PR TITLE
revert: restore larger hero text sizes

### DIFF
--- a/alchemy-web/.vitepress/theme/components/CodeSnippetHero.vue
+++ b/alchemy-web/.vitepress/theme/components/CodeSnippetHero.vue
@@ -175,7 +175,7 @@ function copyCode() {
 }
 
 .name {
-  font-size: 3.6rem;
+  font-size: 4rem;
   font-weight: 700;
   line-height: 1;
   background: var(--vp-home-hero-name-background);
@@ -189,7 +189,7 @@ function copyCode() {
 }
 
 .text {
-  font-size: 2.8rem;
+  font-size: 3.2rem;
   font-weight: 700;
   line-height: 1.1;
   margin-top: 0.625rem;
@@ -483,11 +483,11 @@ function copyCode() {
   }
 
   .name {
-    font-size: 3.2rem;
+    font-size: 3.6rem;
   }
 
   .text {
-    font-size: 2.5rem;
+    font-size: 2.8rem;
   }
 }
 
@@ -510,11 +510,11 @@ function copyCode() {
   }
 
   .name {
-    font-size: 2.8rem;
+    font-size: 3.2rem;
   }
 
   .text {
-    font-size: 2.2rem;
+    font-size: 2.5rem;
     white-space: normal;
   }
 
@@ -543,11 +543,11 @@ function copyCode() {
   }
 
   .name {
-    font-size: 2.4rem;
+    font-size: 2.8rem;
   }
 
   .text {
-    font-size: 1.8rem;
+    font-size: 2.2rem;
     white-space: normal;
   }
 
@@ -584,11 +584,11 @@ function copyCode() {
   }
 
   .name {
-    font-size: 2rem;
+    font-size: 2.4rem;
   }
 
   .text {
-    font-size: 1.5rem;
+    font-size: 1.8rem;
     white-space: normal;
   }
 
@@ -640,11 +640,11 @@ function copyCode() {
   }
 
   .name {
-    font-size: 1.6rem;
+    font-size: 2rem;
   }
 
   .text {
-    font-size: 1.2rem;
+    font-size: 1.5rem;
     margin-top: 0.5rem;
     white-space: normal;
   }

--- a/alchemy-web/index.md
+++ b/alchemy-web/index.md
@@ -1,13 +1,13 @@
 ---
 layout: home
 title: Alchemy
-description: Wrangle the Cloud with pure TypeScript
+description: Control the Cloud with pure TypeScript
 # Custom hero component instead of the default hero
 ---
 
 <CodeSnippetHero 
   name="Alchemy 🪄" 
-  text="Wrangle the Cloud with pure TypeScript" 
+  text="Control the Cloud with pure TypeScript" 
   tagline="Built-in support for Cloudflare, AWS, Stripe and more — or generate your own in minutes with AI"
   :actions="[
     { theme: 'brand', text: 'Get Started', link: '/docs/getting-started' },


### PR DESCRIPTION
Reverts the hero text size reductions from PR #329.

Increases font sizes across all responsive breakpoints to restore the original larger hero text appearance.

Generated with [Claude Code](https://claude.ai/code)