### PR TITLE
feat(cloudflare): add Worker version/preview support with labels

### DIFF
--- a/alchemy-web/docs/guides/cloudflare-worker.md
+++ b/alchemy-web/docs/guides/cloudflare-worker.md
@@ -366,9 +366,12 @@ const previewWorker = await Worker("my-worker", {
 });
 
 // Access the preview URL for testing
-console.log(`Preview URL: ${previewWorker.previewUrl}`);
+console.log(`Preview URL: ${previewWorker.url}`);
 // Output: https://{version-hash}-my-worker.subdomain.workers.dev
 ```
+
+> [!CAUTION]
+> Preview URLs cannot be generated for Workers with Durable Objects, see the [Preview URL](https://developers.cloudflare.com/workers/configuration/previews/#limitations) documentation to learn more.
 
 ## Reference Worker by Name
 

--- a/alchemy-web/docs/guides/cloudflare-worker.md
+++ b/alchemy-web/docs/guides/cloudflare-worker.md
@@ -351,6 +351,25 @@ export default {
 > [!TIP]
 > See the [Dispatch Namespace](../providers/cloudflare/dispatch-namespace.md) documentation for more details on Workers for Platforms.
 
+## Worker Versions
+
+Deploy worker versions for testing and staging before promoting to production. Worker versions create isolated deployments with preview URLs that don't affect your live worker.
+
+```ts
+import { Worker } from "alchemy/cloudflare";
+
+// Create a versioned worker for testing
+const previewWorker = await Worker("my-worker", {
+  name: "my-worker",
+  entrypoint: "./src/worker.ts",
+  version: "pr-123", // Version label for display in the console
+});
+
+// Access the preview URL for testing
+console.log(`Preview URL: ${previewWorker.previewUrl}`);
+// Output: https://{version-hash}-my-worker.subdomain.workers.dev
+```
+
 ## Reference Worker by Name
 
 Use `WorkerRef` to reference an existing worker by its service name rather than by resource instance. This is useful for worker-to-worker bindings when you need to reference a worker that already exists.

--- a/alchemy-web/docs/providers/cloudflare/worker.md
+++ b/alchemy-web/docs/providers/cloudflare/worker.md
@@ -365,9 +365,12 @@ const previewWorker = await Worker("my-worker", {
 });
 
 // Access the preview URL for testing
-console.log(`Preview URL: ${previewWorker.previewUrl}`);
+console.log(`Preview URL: ${previewWorker.url}`);
 // Output: https://{version-hash}-my-worker.subdomain.workers.dev
 ```
+
+> [!CAUTION]
+> Preview URLs cannot be generated for Workers with Durable Objects, see the [Preview URL](https://developers.cloudflare.com/workers/configuration/previews/#limitations) documentation to learn more.
 
 ## Reference Worker by Name
 

--- a/alchemy-web/docs/providers/cloudflare/worker.md
+++ b/alchemy-web/docs/providers/cloudflare/worker.md
@@ -350,6 +350,25 @@ export default {
 > [!TIP]
 > See the [Dispatch Namespace](./dispatch-namespace.md) documentation for more details on Workers for Platforms.
 
+## Worker Versions
+
+Deploy worker versions for testing and staging before promoting to production. Worker versions create isolated deployments with preview URLs that don't affect your live worker.
+
+```ts
+import { Worker } from "alchemy/cloudflare";
+
+// Create a versioned worker for testing
+const previewWorker = await Worker("my-worker", {
+  name: "my-worker",
+  entrypoint: "./src/worker.ts",
+  version: "pr-123", // Version label for display in the console
+});
+
+// Access the preview URL for testing
+console.log(`Preview URL: ${previewWorker.previewUrl}`);
+// Output: https://{version-hash}-my-worker.subdomain.workers.dev
+```
+
 ## Reference Worker by Name
 
 Use `WorkerRef` to reference an existing worker by its service name rather than by resource instance. This is useful for worker-to-worker bindings when you need to reference a worker that already exists.

--- a/alchemy/src/cloudflare/api.ts
+++ b/alchemy/src/cloudflare/api.ts
@@ -141,7 +141,7 @@ export class CloudflareApi {
    * @param init Fetch init options
    * @returns Raw Response object from fetch
    */
-  async fetch(path: string, init: RequestInit = {}): Promise<Response> {
+  public async fetch(path: string, init: RequestInit = {}): Promise<Response> {
     let headers: Record<string, string> = {
       "Content-Type": "application/json",
     };

--- a/alchemy/src/util/safe-fetch.ts
+++ b/alchemy/src/util/safe-fetch.ts
@@ -15,6 +15,7 @@ export async function safeFetch(
         dispatcher: await dispatcher(),
       } as RequestInit);
     } catch (err: any) {
+      console.log(url, err);
       latestErr = err;
       const shouldRetry =
         err?.code === "UND_ERR_SOCKET" ||

--- a/alchemy/test/cloudflare/fetch-utils.ts
+++ b/alchemy/test/cloudflare/fetch-utils.ts
@@ -3,7 +3,14 @@
  * eventually consistent control plane.
  */
 
+import { expect } from "vitest";
 import { safeFetch } from "../../src/util/safe-fetch.ts";
+
+export async function fetchAndExpect(url: string, expected: string) {
+  const response = await fetchAndExpectOK(url);
+  const text = await response.text();
+  expect(text).toEqual(expected);
+}
 
 /**
  * Fetch with exponential backoff retry logic for 404 responses, expecting 200 OK.

--- a/alchemy/test/cloudflare/worker.test.ts
+++ b/alchemy/test/cloudflare/worker.test.ts
@@ -1410,9 +1410,11 @@ describe("Worker Resource", () => {
       });
 
       // Verify the version worker properties
+      expect(versionWorker).toMatchObject({
+        name: workerName,
+        version: versionLabel,
+      });
       expect(versionWorker.id).toBeTruthy();
-      expect(versionWorker.name).toEqual(workerName);
-      expect(versionWorker.version).toEqual(versionLabel);
       expect(versionWorker.previewUrl).toBeTruthy();
       expect(versionWorker.previewUrl).toContain(versionLabel);
       expect(versionWorker.previewUrl).toContain(workerName);

--- a/alchemy/test/cloudflare/worker.test.ts
+++ b/alchemy/test/cloudflare/worker.test.ts
@@ -1403,7 +1403,6 @@ describe("Worker Resource", () => {
       expect(baseWorker.id).toBeTruthy();
       expect(baseWorker.name).toEqual(workerName);
       expect(baseWorker.version).toBeUndefined();
-      expect(baseWorker.previewUrl).toBeUndefined();
       expect(baseWorker.url).toBeTruthy();
 
       // Test that the base worker URL works
@@ -1454,7 +1453,7 @@ describe("Worker Resource", () => {
       });
       expect(versionWorker.id).toBeTruthy();
 
-      expect(versionWorker.previewUrl).toBeTruthy();
+      expect(versionWorker.url).toBeTruthy();
       expect(versionWorker.bindings?.ASSETS).toBeDefined();
 
       // the live worker should not have the new content
@@ -1464,10 +1463,7 @@ describe("Worker Resource", () => {
       );
 
       // the versioned worker should have the new content
-      await fetchAndExpect(
-        `${versionWorker.previewUrl!}/test.txt`,
-        testContent,
-      );
+      await fetchAndExpect(`${versionWorker.url!}/test.txt`, testContent);
     } finally {
       // Clean up temporary directory
       if (tempDir) {


### PR DESCRIPTION
Closes #350.

## Worker Versions

Deploy worker versions for testing and staging before promoting to production. Worker versions create isolated deployments with preview URLs that don't affect your live worker.

```ts
import { Worker } from "alchemy/cloudflare";

// Create a versioned worker for testing
const previewWorker = await Worker("my-worker", {
  name: "my-worker",
  entrypoint: "./src/worker.ts",
  version: "pr-123", // Version label for display in the console
});

// Access the preview URL for testing
console.log(`Preview URL: ${previewWorker.url}`);
// Output: https://{version-hash}-my-worker.subdomain.workers.dev
```
