### PR TITLE
fix: move CLI dependencies from devDependencies to dependencies

### DIFF
--- a/alchemy/package.json
+++ b/alchemy/package.json
@@ -108,6 +108,9 @@
     }
   },
   "dependencies": {
+    "ink": "^6.0.0",
+    "ink-spinner": "^5.0.0",
+    "react": "^19.1.0",
     "unenv": "2.0.0-rc.15"
   },
   "peerDependencies": {
@@ -170,12 +173,9 @@
     "change-case": "^5.4.4",
     "cloudflare": "^4.2.0",
     "cpx": "^1.5.0",
-    "ink": "^6.0.0",
-    "ink-spinner": "^5.0.0",
     "libsodium-wrappers": "^0.7.15",
     "openpgp": "^6.1.0",
     "prettier": "^3.5.3",
-    "react": "^19.1.0",
     "turndown": "^7.2.0",
     "typedoc": "^0.28.1",
     "typedoc-plugin-markdown": "^4.6.0",


### PR DESCRIPTION
Fixes module resolution error where ink, ink-spinner, and react were not available when alchemy was installed as a dependency. These packages are imported by the CLI code at runtime, so they need to be regular dependencies.

Fixes #353

Generated with [Claude Code](https://claude.ai/code)