### PR TITLE
chore: add miniflare ^4.0.0 as dev dependency

### DIFF
--- a/alchemy/package.json
+++ b/alchemy/package.json
@@ -170,6 +170,7 @@
     "cloudflare": "^4.2.0",
     "cpx": "^1.5.0",
     "libsodium-wrappers": "^0.7.15",
+    "miniflare": "^4.0.0",
     "openpgp": "^6.1.0",
     "prettier": "^3.5.3",
     "turndown": "^7.2.0",


### PR DESCRIPTION
Adds miniflare ^4.0.0 as a development dependency to the alchemy package.

Closes #363

Generated with [Claude Code](https://claude.ai/code)