### PR TITLE
fix: move @cloudflare/workers-types to dependencies

### DIFF
--- a/alchemy/package.json
+++ b/alchemy/package.json
@@ -108,6 +108,7 @@
     }
   },
   "dependencies": {
+    "@cloudflare/workers-types": "^4.20250303.0",
     "unenv": "2.0.0-rc.15"
   },
   "peerDependencies": {
@@ -155,7 +156,6 @@
     "@aws-sdk/client-s3": "3.726.1",
     "@biomejs/biome": "^1.9.4",
     "@cloudflare/puppeteer": "^1.0.2",
-    "@cloudflare/workers-types": "^4.20250303.0",
     "@iarna/toml": "^2.2.5",
     "@octokit/rest": "^21.1.1",
     "@types/bun": "latest",


### PR DESCRIPTION
Fixes implicit dependency issue in `bound.ts` where @cloudflare/workers-types was only in devDependencies, causing types to become 'any' for consumers.

Now consumers of the alchemy package will automatically get the required Cloudflare types when they install it.

Generated with [Claude Code](https://claude.ai/code)