### PR TITLE
fix(cloudflare): 404 error when deploying dofs state store

### DIFF
--- a/alchemy/src/cloudflare/do-state-store/internal.ts
+++ b/alchemy/src/cloudflare/do-state-store/internal.ts
@@ -104,6 +104,7 @@ export async function upsertStateStoreWorker(
   api: CloudflareApi,
   workerName: string,
   token: string,
+  force: boolean,
 ) {
   const key = `worker:${workerName}`;
   const cached = cache.get(key);
@@ -111,7 +112,7 @@ export async function upsertStateStoreWorker(
     return;
   }
   const { found, tag } = await getWorkerStatus(api, workerName);
-  if (found && tag === TAG) {
+  if (found && tag === TAG && !force) {
     cache.set(key, TAG);
     return;
   }

--- a/alchemy/src/cloudflare/do-state-store/store.ts
+++ b/alchemy/src/cloudflare/do-state-store/store.ts
@@ -88,7 +88,12 @@ export class DOStateStore implements StateStore {
     const api = await createCloudflareApi(this.options);
     const [subdomain, _] = await Promise.all([
       getAccountSubdomain(api),
-      upsertStateStoreWorker(api, workerName, token),
+      upsertStateStoreWorker(
+        api,
+        workerName,
+        token,
+        this.options.worker?.force ?? false,
+      ),
     ]);
     const client = new DOStateStoreClient({
       app: this.scope.appName ?? "alchemy",

--- a/alchemy/src/cloudflare/do-state-store/store.ts
+++ b/alchemy/src/cloudflare/do-state-store/store.ts
@@ -102,9 +102,26 @@ export class DOStateStore implements StateStore {
       token,
     });
     // This ensures the token is correct and the worker is ready to use.
-    // RPC methods are retried, which is what we want here in case the worker is not ready yet.
-    await client.rpc("validate", null);
-    return client;
+    let last: Response | undefined;
+    let delay = 1000;
+    for (let i = 0; i < 20; i++) {
+      const res = await client.validate();
+      if (res.ok) {
+        return client;
+      }
+      if (!last) {
+        console.log("Waiting for state store deployment...");
+      }
+      last = res;
+      // Exponential backoff with jitter
+      const jitter = Math.random() * 0.1 * delay;
+      await new Promise((resolve) => setTimeout(resolve, delay + jitter));
+      delay *= 1.5; // Increase the delay for next attempt
+      delay = Math.min(delay, 10000); // Cap at 10 seconds
+    }
+    throw new Error(
+      `Failed to access state store: ${last?.status} ${last?.statusText}`,
+    );
   }
 
   private async getClient() {

--- a/alchemy/src/util/telemetry/client.ts
+++ b/alchemy/src/util/telemetry/client.ts
@@ -51,7 +51,7 @@ export class TelemetryClient implements ITelemetryClient {
 
   record(event: Telemetry.EventInput, timestamp = Date.now()) {
     if (!this.context) {
-      throw new Error("Context not initialized");
+      return;
     }
     const payload = {
       ...event,


### PR DESCRIPTION
Before we can use the DOFS state store, we have to wait for DNS to update. We have retry logic already, but it wasn't aggressive enough, and also logged the whole response which was unnecessary.

Anyway, here's a fix.