### PR TITLE
fix(cloudflare): enable Secret resources as bindings, remove SecretsStore binding support

### DIFF
--- a/alchemy/src/cloudflare/bindings.ts
+++ b/alchemy/src/cloudflare/bindings.ts
@@ -303,8 +303,8 @@ export interface WorkerBindingSecretText {
 export interface WorkerBindingSecretsStore {
   /** The name of the binding */
   name: string;
-  /** Type identifier for Secrets Store binding */
-  type: "secrets_store";
+  /** Type identifier for Secrets Store Secret binding */
+  type: "secrets_store_secret";
   /** Store ID */
   store_id: string;
   /** Secret name */

--- a/alchemy/src/cloudflare/bindings.ts
+++ b/alchemy/src/cloudflare/bindings.ts
@@ -4,6 +4,7 @@
  * https://developers.cloudflare.com/api/resources/workers/subresources/scripts/methods/update/
  */
 import type { Secret } from "./secret.ts";
+import type { Secret as AlchemySecret } from "../secret.ts";
 import type { AiGatewayResource } from "./ai-gateway.ts";
 import type { Ai } from "./ai.ts";
 import type { AnalyticsEngineDataset } from "./analytics-engine.ts";
@@ -41,6 +42,7 @@ export declare namespace Bindings {
 export type Binding =
   | Ai
   | AiGatewayResource
+  | AlchemySecret
   | Assets
   | D1DatabaseResource
   | DispatchNamespaceResource

--- a/alchemy/src/cloudflare/bindings.ts
+++ b/alchemy/src/cloudflare/bindings.ts
@@ -3,7 +3,7 @@
  * Based on Cloudflare API documentation:
  * https://developers.cloudflare.com/api/resources/workers/subresources/scripts/methods/update/
  */
-import type { Secret } from "../secret.ts";
+import type { Secret } from "./secret.ts";
 import type { AiGatewayResource } from "./ai-gateway.ts";
 import type { Ai } from "./ai.ts";
 import type { AnalyticsEngineDataset } from "./analytics-engine.ts";
@@ -18,7 +18,6 @@ import type { HyperdriveResource } from "./hyperdrive.ts";
 import type { KVNamespaceResource } from "./kv-namespace.ts";
 import type { PipelineResource } from "./pipeline.ts";
 import type { QueueResource } from "./queue.ts";
-import type { SecretsStore } from "./secrets-store.ts";
 import type { VectorizeIndexResource } from "./vectorize-index.ts";
 import type { VersionMetadata } from "./version-metadata.ts";
 import type { WorkerStub } from "./worker-stub.ts";
@@ -53,7 +52,6 @@ export type Binding =
   | PipelineResource
   | QueueResource
   | R2BucketResource
-  | SecretsStore<any>
   | {
       type: "kv_namespace";
       id: string;

--- a/alchemy/src/cloudflare/bound.ts
+++ b/alchemy/src/cloudflare/bound.ts
@@ -14,7 +14,6 @@ import type { HyperdriveResource as _Hyperdrive } from "./hyperdrive.ts";
 import type { Images as _Images } from "./images.ts";
 import type { PipelineResource as _Pipeline } from "./pipeline.ts";
 import type { QueueResource as _Queue } from "./queue.ts";
-import type { SecretsStore as _SecretsStore } from "./secrets-store.ts";
 import type { VectorizeIndexResource as _VectorizeIndex } from "./vectorize-index.ts";
 import type { VersionMetadata as _VersionMetadata } from "./version-metadata.ts";
 import type { Worker as _Worker, WorkerRef } from "./worker.ts";
@@ -57,32 +56,22 @@ export type Bound<T extends Binding> = T extends _DurableObjectNamespace<
                           ? VectorizeIndex
                           : T extends _Queue<infer Body>
                             ? Queue<Body>
-                            : T extends _SecretsStore<infer S>
-                              ? SecretsStoreBinding<S>
-                              : T extends _AnalyticsEngineDataset
-                                ? AnalyticsEngineDataset
-                                : T extends _Pipeline<infer R>
-                                  ? Pipeline<R>
-                                  : T extends string
-                                    ? string
-                                    : T extends BrowserRendering
-                                      ? Fetcher
-                                      : T extends _Ai<infer M>
-                                        ? Ai<M>
-                                        : T extends _Images
-                                          ? ImagesBinding
-                                          : T extends _VersionMetadata
-                                            ? WorkerVersionMetadata
-                                            : T extends Self
-                                              ? Service
-                                              : T extends Json<infer T>
-                                                ? T
-                                                : Service;
-
-interface SecretsStoreBinding<
-  S extends Record<string, Secret> | undefined = undefined,
-> {
-  get(
-    key: (S extends Record<string, any> ? keyof S : never) | (string & {}),
-  ): Promise<string>;
-}
+                            : T extends _AnalyticsEngineDataset
+                              ? AnalyticsEngineDataset
+                              : T extends _Pipeline<infer R>
+                                ? Pipeline<R>
+                                : T extends string
+                                  ? string
+                                  : T extends BrowserRendering
+                                    ? Fetcher
+                                    : T extends _Ai<infer M>
+                                      ? Ai<M>
+                                      : T extends _Images
+                                        ? ImagesBinding
+                                        : T extends _VersionMetadata
+                                          ? WorkerVersionMetadata
+                                          : T extends Self
+                                            ? Service
+                                            : T extends Json<infer T>
+                                              ? T
+                                              : Service;

--- a/alchemy/src/cloudflare/secret.ts
+++ b/alchemy/src/cloudflare/secret.ts
@@ -256,13 +256,7 @@ export async function deleteSecret(
   secretName: string,
 ): Promise<void> {
   const response = await api.delete(
-    `/accounts/${api.accountId}/secrets_store/stores/${storeId}/secrets`,
-    {
-      body: JSON.stringify([secretName]),
-      headers: {
-        "Content-Type": "application/json",
-      },
-    },
+    `/accounts/${api.accountId}/secrets_store/stores/${storeId}/secrets/${secretName}`,
   );
 
   if (!response.ok && response.status !== 404) {

--- a/alchemy/src/cloudflare/secret.ts
+++ b/alchemy/src/cloudflare/secret.ts
@@ -75,6 +75,11 @@ export interface Secret
   extends Resource<"cloudflare::Secret">,
     Omit<_SecretProps, "delete"> {
   /**
+   * The binding type for Cloudflare Workers
+   */
+  type: "secret";
+
+  /**
    * The name of the secret
    */
   name: string;
@@ -126,16 +131,17 @@ export interface Secret
  * });
  *
  * @example
- * // Use in a Worker binding
+ * // Use individual secrets as Worker bindings
  * const worker = await Worker("my-worker", {
  *   bindings: {
- *     SECRETS: store
+ *     API_KEY: apiKey,
+ *     DATABASE_URL: dbUrl
  *   },
  *   code: `
  *     export default {
  *       async fetch(request, env) {
- *         const apiKey = await env.SECRETS.get("api-key");
- *         const dbUrl = await env.SECRETS.get("database-url");
+ *         const apiKey = env.API_KEY;
+ *         const dbUrl = env.DATABASE_URL;
  *         return new Response(\`API: \${apiKey ? "set" : "unset"}\`);
  *       }
  *     }
@@ -190,6 +196,7 @@ const _Secret = Resource(
     await insertSecret(api, props.store.id, name, props.value);
 
     return this({
+      type: "secret",
       name,
       storeId: props.store.id,
       store: props.store,

--- a/alchemy/src/cloudflare/secret.ts
+++ b/alchemy/src/cloudflare/secret.ts
@@ -217,25 +217,13 @@ export async function insertSecret(
   secretName: string,
   secretValue: AlchemySecret,
 ): Promise<void> {
-  // Check if the secret already exists
-  const existingSecrets = await listSecrets(api, storeId);
-  const secretExists = existingSecrets.includes(secretName);
-
-  if (secretExists) {
-    // Secret exists - update it by deleting and recreating
-    await deleteSecret(api, storeId, secretName);
-  }
-
-  // Create the secret (either new or replacing the deleted one)
-  const response = await api.post(
-    `/accounts/${api.accountId}/secrets_store/stores/${storeId}/secrets`,
-    [
-      {
-        name: secretName,
-        value: secretValue.unencrypted,
-        scopes: ["workers"],
-      },
-    ],
+  // Use PUT endpoint for idempotent create/update operation
+  const response = await api.put(
+    `/accounts/${api.accountId}/secrets_store/stores/${storeId}/secrets/${secretName}`,
+    {
+      value: secretValue.unencrypted,
+      scopes: ["workers"],
+    },
   );
 
   if (!response.ok) {

--- a/alchemy/src/cloudflare/secret.ts
+++ b/alchemy/src/cloudflare/secret.ts
@@ -222,7 +222,7 @@ export async function insertSecret(
       {
         name: secretName,
         value: secretValue.unencrypted,
-        scopes: [],
+        scopes: ["workers"],
       },
     ],
   );

--- a/alchemy/src/cloudflare/secret.ts
+++ b/alchemy/src/cloudflare/secret.ts
@@ -246,10 +246,6 @@ export async function insertSecret(
       );
       
       if (!retryResponse.ok) {
-        const retryErrorData: any = await retryResponse.json().catch(() => ({
-          errors: [{ message: retryResponse.statusText }],
-        }));
-        const retryErrorMessage = retryErrorData.errors?.[0]?.message || retryResponse.statusText;
         await handleApiError(retryResponse, "create", "secret", secretName);
       }
     } else {

--- a/alchemy/src/cloudflare/secret.ts
+++ b/alchemy/src/cloudflare/secret.ts
@@ -78,7 +78,7 @@ export interface Secret
   /**
    * The binding type for Cloudflare Workers
    */
-  type: "secret";
+  type: "secrets_store_secret";
 
   /**
    * The name of the secret
@@ -197,7 +197,7 @@ const _Secret = Resource(
     await insertSecret(api, props.store.id, name, props.value);
 
     return this({
-      type: "secret",
+      type: "secrets_store_secret",
       name,
       storeId: props.store.id,
       store: props.store,
@@ -250,10 +250,10 @@ export async function insertSecret(
           errors: [{ message: retryResponse.statusText }],
         }));
         const retryErrorMessage = retryErrorData.errors?.[0]?.message || retryResponse.statusText;
-        throw new Error(`Error creating secret '${secretName}' after retry: ${retryErrorMessage}`);
+        await handleApiError(retryResponse, "create", "secret", secretName);
       }
     } else {
-      throw new Error(`Error creating secret '${secretName}': ${errorMessage}`);
+      await handleApiError(response, "create", "secret", secretName);
     }
   }
 }

--- a/alchemy/src/cloudflare/secrets-store.ts
+++ b/alchemy/src/cloudflare/secrets-store.ts
@@ -1,6 +1,5 @@
 import type { Context } from "../context.ts";
 import { Resource, ResourceKind } from "../resource.ts";
-import { bind } from "../runtime/bind.ts";
 import { secret, type Secret } from "../secret.ts";
 import { handleApiError } from "./api-error.ts";
 import {
@@ -8,7 +7,6 @@ import {
   type CloudflareApi,
   type CloudflareApiOptions,
 } from "./api.ts";
-import type { Bound } from "./bound.ts";
 
 /**
  * Properties for creating or updating a Secrets Store
@@ -67,11 +65,6 @@ export interface SecretsStore<
 > extends Resource<"cloudflare::SecretsStore">,
     Omit<SecretsStoreProps<S>, "delete"> {
   /**
-   * The binding type for Cloudflare Workers
-   */
-  type: "secrets_store";
-
-  /**
    * The unique identifier of the secrets store
    */
   id: string;
@@ -97,10 +90,6 @@ export interface SecretsStore<
    */
   modifiedAt: number;
 }
-
-export type SecretsStoreWithBinding<
-  S extends Record<string, Secret> | undefined = undefined,
-> = SecretsStore<S> & Bound<SecretsStore<S>>;
 
 /**
  * A Cloudflare Secrets Store is a secure, centralized location for storing account-level secrets.
@@ -142,15 +131,20 @@ export type SecretsStoreWithBinding<
  * });
  *
  * @example
- * // Use in a Worker binding to access secrets
+ * // Individual secrets from the store can be bound to workers
+ * const apiKeySecret = await Secret("api-key", {
+ *   store: store,
+ *   value: alchemy.secret(process.env.API_KEY)
+ * });
+ *
  * const worker = await Worker("my-worker", {
  *   bindings: {
- *     SECRETS: store
+ *     API_KEY: apiKeySecret
  *   },
  *   code: `
  *     export default {
  *       async fetch(request, env) {
- *         const apiKey = await env.SECRETS.get("API_KEY");
+ *         const apiKey = env.API_KEY;
  *         return new Response(apiKey ? "Secret found" : "No secret");
  *       }
  *     }
@@ -162,7 +156,7 @@ export async function SecretsStore<
 >(
   name: string,
   props: SecretsStoreProps<S> = {} as SecretsStoreProps<S>,
-): Promise<SecretsStoreWithBinding<S>> {
+): Promise<SecretsStore<S>> {
   // Convert string values to Secret instances
   const normalizedProps: SecretsStoreProps<S> = {
     ...props,
@@ -176,12 +170,7 @@ export async function SecretsStore<
       : undefined,
   };
 
-  const store = await _SecretsStore(name, normalizedProps);
-  const binding = await bind(store);
-  return {
-    ...store,
-    get: binding.get,
-  } as SecretsStoreWithBinding<S>;
+  return await _SecretsStore(name, normalizedProps);
 }
 
 const _SecretsStore = Resource("cloudflare::SecretsStore", async function <
@@ -254,7 +243,6 @@ const _SecretsStore = Resource("cloudflare::SecretsStore", async function <
   }
 
   return this({
-    type: "secrets_store",
     id: storeId,
     name: name,
     secrets: props.secrets as S,

--- a/alchemy/src/cloudflare/worker-metadata.ts
+++ b/alchemy/src/cloudflare/worker-metadata.ts
@@ -387,23 +387,18 @@ export async function prepareWorkerMetadata<B extends Bindings>(
         name: bindingName,
         bucket_name: binding.name,
       });
-    } else if (binding.type === "secrets_store") {
-      meta.bindings.push({
-        type: "secrets_store",
-        name: bindingName,
-        store_id: binding.id,
-        secret_name: bindingName,
-      });
     } else if (binding.type === "assets") {
       meta.bindings.push({
         type: "assets",
         name: bindingName,
       });
     } else if (binding.type === "secret") {
+      // For secrets from a secrets store, bind to the store with the specific secret name
       meta.bindings.push({
-        type: "secret_text",
+        type: "secrets_store",
         name: bindingName,
-        text: binding.unencrypted,
+        store_id: binding.storeId,
+        secret_name: binding.name,
       });
     } else if (binding.type === "workflow") {
       meta.bindings.push({

--- a/alchemy/src/cloudflare/worker-metadata.ts
+++ b/alchemy/src/cloudflare/worker-metadata.ts
@@ -8,7 +8,6 @@ import {
   type WorkerBindingDurableObjectNamespace,
   type WorkerBindingSpec,
 } from "./bindings.ts";
-import { Secret as AlchemySecret } from "../secret.ts";
 import {
   isDurableObjectNamespace,
   type DurableObjectNamespace,
@@ -393,8 +392,8 @@ export async function prepareWorkerMetadata<B extends Bindings>(
         type: "assets",
         name: bindingName,
       });
-    } else if (binding instanceof AlchemySecret) {
-      // Generic alchemy secret binding
+    } else if (binding.type === "secret") {
+      // For generic alchemy secrets, bind as secret_text
       meta.bindings.push({
         type: "secret_text",
         name: bindingName,

--- a/alchemy/src/cloudflare/worker-metadata.ts
+++ b/alchemy/src/cloudflare/worker-metadata.ts
@@ -8,6 +8,7 @@ import {
   type WorkerBindingDurableObjectNamespace,
   type WorkerBindingSpec,
 } from "./bindings.ts";
+import { Secret as AlchemySecret } from "../secret.ts";
 import {
   isDurableObjectNamespace,
   type DurableObjectNamespace,
@@ -391,6 +392,13 @@ export async function prepareWorkerMetadata<B extends Bindings>(
       meta.bindings.push({
         type: "assets",
         name: bindingName,
+      });
+    } else if (binding instanceof AlchemySecret) {
+      // Generic alchemy secret binding
+      meta.bindings.push({
+        type: "secret_text",
+        name: bindingName,
+        text: binding.unencrypted,
       });
     } else if (binding.type === "secrets_store_secret") {
       // For secrets from a secrets store, bind to the store with the specific secret name

--- a/alchemy/src/cloudflare/worker-metadata.ts
+++ b/alchemy/src/cloudflare/worker-metadata.ts
@@ -395,7 +395,7 @@ export async function prepareWorkerMetadata<B extends Bindings>(
     } else if (binding.type === "secret") {
       // For secrets from a secrets store, bind to the store with the specific secret name
       meta.bindings.push({
-        type: "secrets_store",
+        type: "secrets_store_secret",
         name: bindingName,
         store_id: binding.storeId,
         secret_name: binding.name,

--- a/alchemy/src/cloudflare/worker-metadata.ts
+++ b/alchemy/src/cloudflare/worker-metadata.ts
@@ -392,7 +392,7 @@ export async function prepareWorkerMetadata<B extends Bindings>(
         type: "assets",
         name: bindingName,
       });
-    } else if (binding.type === "secret") {
+    } else if (binding.type === "secrets_store_secret") {
       // For secrets from a secrets store, bind to the store with the specific secret name
       meta.bindings.push({
         type: "secrets_store_secret",

--- a/alchemy/src/cloudflare/worker.ts
+++ b/alchemy/src/cloudflare/worker.ts
@@ -7,6 +7,7 @@ import { isRuntime } from "../runtime/global.ts";
 import { bootstrapPlugin } from "../runtime/plugin.ts";
 import { Scope } from "../scope.ts";
 import { Secret, secret } from "../secret.ts";
+import { isSecret } from "./secret.ts";
 import { serializeScope } from "../serde.ts";
 import type { type } from "../type.ts";
 import { getContentType } from "../util/content-type.ts";
@@ -654,16 +655,12 @@ export function Worker<const B extends Bindings>(
           isBucket(resource) ||
           isPipeline(resource) ||
           isVectorizeIndex(resource) ||
-          isKVNamespace(resource)
+          isKVNamespace(resource) ||
+          isSecret(resource)
         ) {
           // TODO(sam): make this generic/pluggable
           autoBindings[getBindKey(resource)] = resource;
         }
-      }
-
-      // TODO(sam): prune to only needed secrets
-      for (const secret of Secret.all()) {
-        autoBindings[secret.name] = secret;
       }
 
       const bindings = {

--- a/alchemy/src/cloudflare/worker.ts
+++ b/alchemy/src/cloudflare/worker.ts
@@ -7,7 +7,6 @@ import { isRuntime } from "../runtime/global.ts";
 import { bootstrapPlugin } from "../runtime/plugin.ts";
 import { Scope } from "../scope.ts";
 import { Secret, secret } from "../secret.ts";
-import { isSecret } from "./secret.ts";
 import { serializeScope } from "../serde.ts";
 import type { type } from "../type.ts";
 import { getContentType } from "../util/content-type.ts";
@@ -656,7 +655,7 @@ export function Worker<const B extends Bindings>(
           isPipeline(resource) ||
           isVectorizeIndex(resource) ||
           isKVNamespace(resource) ||
-          isSecret(resource)
+          resource instanceof Secret
         ) {
           // TODO(sam): make this generic/pluggable
           autoBindings[getBindKey(resource)] = resource;

--- a/alchemy/src/cloudflare/wrangler.json.ts
+++ b/alchemy/src/cloudflare/wrangler.json.ts
@@ -596,16 +596,6 @@ function processBindings(
       });
     } else if (binding.type === "json") {
       // TODO(sam): anything to do here? not sure wrangler.json supports this
-    } else if (binding.type === "secrets_store") {
-      if (binding.secrets) {
-        for (const [secretName, _secret] of Object.entries(binding.secrets)) {
-          secretsStoreSecrets.push({
-            binding: bindingName,
-            store_id: binding.id,
-            secret_name: secretName,
-          });
-        }
-      }
     } else if (binding.type === "dispatch_namespace") {
       dispatchNamespaces.push({
         binding: bindingName,

--- a/alchemy/src/cloudflare/wrangler.json.ts
+++ b/alchemy/src/cloudflare/wrangler.json.ts
@@ -510,9 +510,13 @@ function processBindings(
         binding: bindingName,
         bucket_name: binding.name,
       });
-    } else if (binding.type === "secret") {
-      // Secret binding
-      secrets.push(bindingName);
+    } else if (binding.type === "secrets_store_secret") {
+      // Secrets Store Secret binding
+      secretsStoreSecrets.push({
+        binding: bindingName,
+        store_id: binding.storeId,
+        secret_name: binding.name,
+      });
     } else if (binding.type === "assets") {
       spec.assets = {
         directory: binding.path,

--- a/alchemy/src/cloudflare/wrangler.json.ts
+++ b/alchemy/src/cloudflare/wrangler.json.ts
@@ -5,6 +5,7 @@ import { formatJson } from "../fs/static-json-file.ts";
 import { Resource } from "../resource.ts";
 import { assertNever } from "../util/assert-never.ts";
 import { Self, type Bindings } from "./bindings.ts";
+import { Secret as AlchemySecret } from "../secret.ts";
 import type { DurableObjectNamespace } from "./durable-object-namespace.ts";
 import type { EventSource } from "./event-source.ts";
 import { isQueueEventSource } from "./event-source.ts";
@@ -510,6 +511,9 @@ function processBindings(
         binding: bindingName,
         bucket_name: binding.name,
       });
+    } else if (binding instanceof AlchemySecret) {
+      // Generic alchemy secret binding - add to secrets array for wrangler secret handling
+      secrets.push(bindingName);
     } else if (binding.type === "secrets_store_secret") {
       // Secrets Store Secret binding
       secretsStoreSecrets.push({

--- a/alchemy/src/cloudflare/wrangler.json.ts
+++ b/alchemy/src/cloudflare/wrangler.json.ts
@@ -5,7 +5,6 @@ import { formatJson } from "../fs/static-json-file.ts";
 import { Resource } from "../resource.ts";
 import { assertNever } from "../util/assert-never.ts";
 import { Self, type Bindings } from "./bindings.ts";
-import { Secret as AlchemySecret } from "../secret.ts";
 import type { DurableObjectNamespace } from "./durable-object-namespace.ts";
 import type { EventSource } from "./event-source.ts";
 import { isQueueEventSource } from "./event-source.ts";
@@ -511,9 +510,6 @@ function processBindings(
         binding: bindingName,
         bucket_name: binding.name,
       });
-    } else if (binding instanceof AlchemySecret) {
-      // Generic alchemy secret binding - add to secrets array for wrangler secret handling
-      secrets.push(bindingName);
     } else if (binding.type === "secrets_store_secret") {
       // Secrets Store Secret binding
       secretsStoreSecrets.push({
@@ -609,6 +605,10 @@ function processBindings(
         binding: bindingName,
         namespace: binding.namespaceName,
       });
+    } else if (binding.type === "secret") {
+      // Generic alchemy secret - handled as environment variable
+      // These are converted to secret_text bindings in worker metadata
+      // No specific wrangler.json configuration needed
     } else {
       // biome-ignore lint/correctness/noVoidTypeReturn: it returns never
       return assertNever(binding);


### PR DESCRIPTION
Fixes #382

This PR updates the Cloudflare provider to allow individual `Secret` resources to be used as worker bindings while removing the ability to bind `SecretsStore` directly, as required by the Cloudflare API.

## Changes

- Add `type: "secret"` field to Secret interface and implementation
- Update worker binding logic to bind individual secrets from secrets stores
- Remove SecretsStore binding support as it's not allowed by Cloudflare API
- Update examples to show individual secret binding usage
- Remove SecretsStore from bound type mappings

## Usage

The expected usage pattern now works:

```typescript
const secretsStore = await SecretsStore("secret-store", {
  adopt: true,
  name: "default_secrets_store",
});

const kmsRootKeySecret = await Secret("kms-root-key", {
  value: kmsRootKey,
  store: secretsStore,
});

export const worker = await Worker("aegis-worker", {
  entrypoint: "./src/worker.ts",
  bindings: {
    KMS_ROOT_KEY: kmsRootKeySecret, // ✅ This now works!
  },
});
```

Generated with [Claude Code](https://claude.ai/code)