### PR TITLE
feat(cloudflare): add SecretKey binding support for Cloudflare Workers

### DIFF
--- a/alchemy-web/docs/providers/cloudflare/secret-key.md
+++ b/alchemy-web/docs/providers/cloudflare/secret-key.md
@@ -1,0 +1,204 @@
+# SecretKey
+
+A data class that represents a secret key binding for Cloudflare Workers, enabling secure cryptographic operations using the Web Crypto API.
+
+## Overview
+
+The `SecretKey` binding allows you to securely store and use cryptographic keys in your Cloudflare Workers. Keys are stored as bindings and exposed as `CryptoKey` objects that can be used with the [SubtleCrypto API](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto).
+
+## Key Formats
+
+SecretKey supports multiple key formats:
+
+- **`raw`** - Raw binary key data
+- **`pkcs8`** - PKCS #8 format for private keys
+- **`spki`** - SubjectPublicKeyInfo format for public keys
+- **`jwk`** - JSON Web Key format
+
+## Key Usages
+
+Keys can be configured with specific [usage permissions](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/importKey#keyusages):
+
+- **`encrypt`** / **`decrypt`** - For encryption/decryption operations
+- **`sign`** / **`verify`** - For digital signatures
+- **`deriveKey`** / **`deriveBits`** - For key derivation
+- **`wrapKey`** / **`unwrapKey`** - For key wrapping
+
+## Examples
+
+### RSA Signing Key (JWK Format)
+
+```typescript
+import { SecretKey } from "alchemy/cloudflare";
+import { Worker } from "alchemy/cloudflare";
+import { secret } from "alchemy";
+
+// Generate an RSA key pair
+const keyPair = await crypto.subtle.generateKey(
+  {
+    name: "RSA-PSS",
+    modulusLength: 2048,
+    publicExponent: new Uint8Array([1, 0, 1]),
+    hash: "SHA-256",
+  },
+  true, // extractable
+  ["sign", "verify"]
+);
+
+// Export the private key as JWK
+const privateKeyJwk = await crypto.subtle.exportKey("jwk", keyPair.privateKey);
+
+const signingKey = new SecretKey({
+  algorithm: { name: "RSA-PSS", hash: "SHA-256" },
+  format: "jwk",
+  usages: ["sign"],
+  key_jwk: secret(privateKeyJwk),
+});
+
+const worker = await Worker("my-worker", {
+  entrypoint: "./worker.ts",
+  bindings: {
+    SIGNING_KEY: signingKey,
+  },
+});
+```
+
+**worker.ts**
+
+```javascript
+export default {
+  async fetch(request, env) {
+    const data = new TextEncoder().encode("Hello, World!");
+
+    const signature = await crypto.subtle.sign(
+      { name: "RSA-PSS", saltLength: 32 },
+      env.SIGNING_KEY,
+      data
+    );
+
+    return Response.json({
+      signed: Array.from(new Uint8Array(signature)),
+    });
+  },
+};
+```
+
+### AES Encryption Key (Raw Format)
+
+```typescript
+import { SecretKey } from "alchemy/cloudflare";
+import { Worker } from "alchemy/cloudflare";
+import { secret } from "alchemy";
+
+// Generate a 256-bit AES key
+const aesKey = await crypto.subtle.generateKey(
+  { name: "AES-GCM", length: 256 },
+  true,
+  ["encrypt", "decrypt"]
+);
+
+// Export as raw bytes
+const keyData = await crypto.subtle.exportKey("raw", aesKey);
+const keyBase64 = btoa(String.fromCharCode(...new Uint8Array(keyData)));
+
+const encryptionKey = new SecretKey({
+  algorithm: { name: "AES-GCM" },
+  format: "raw",
+  usages: ["encrypt", "decrypt"],
+  key_base64: secret(keyBase64),
+});
+
+const worker = await Worker("encryption-worker", {
+  bindings: {
+    ENCRYPTION_KEY: encryptionKey,
+  },
+  entrypoint: "./encryption-worker.js",
+});
+```
+
+**encryption-worker.js**
+
+```javascript
+export default {
+  async fetch(request, env) {
+    const plaintext = new TextEncoder().encode("secret message");
+    const iv = crypto.getRandomValues(new Uint8Array(12));
+
+    const ciphertext = await crypto.subtle.encrypt(
+      { name: "AES-GCM", iv },
+      env.ENCRYPTION_KEY,
+      plaintext
+    );
+
+    return Response.json({
+      ciphertext: Array.from(new Uint8Array(ciphertext)),
+      iv: Array.from(iv),
+    });
+  },
+};
+```
+
+### ECDSA Key from PKCS#8
+
+```typescript
+import { SecretKey } from "alchemy/cloudflare";
+import { secret } from "alchemy";
+
+// Assuming you have a PKCS#8 encoded private key
+const pkcs8Key = "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQg...";
+
+const ecdsaKey = new SecretKey({
+  algorithm: { name: "ECDSA", namedCurve: "P-256" },
+  format: "pkcs8",
+  usages: ["sign"],
+  key_base64: secret(pkcs8Key),
+});
+```
+
+### HMAC Key for Message Authentication
+
+```typescript
+import { SecretKey } from "alchemy/cloudflare";
+import { secret } from "alchemy";
+
+// Generate HMAC key
+const hmacKey = await crypto.subtle.generateKey(
+  { name: "HMAC", hash: "SHA-256" },
+  true,
+  ["sign", "verify"]
+);
+
+const keyData = await crypto.subtle.exportKey("raw", hmacKey);
+const keyBase64 = btoa(String.fromCharCode(...new Uint8Array(keyData)));
+
+const macKey = new SecretKey({
+  algorithm: { name: "HMAC", hash: "SHA-256" },
+  format: "raw",
+  usages: ["sign", "verify"],
+  key_base64: secret(keyBase64),
+});
+```
+
+## Security Considerations
+
+- **Key Storage**: Keys are securely stored by Cloudflare and never exposed in plain text
+- **Access Control**: Keys are only accessible to the specific Worker they're bound to
+- **Usage Restrictions**: The `usages` array strictly controls what operations can be performed
+- **Non-extractable**: Keys imported into Workers are typically non-extractable for security
+
+## Algorithm Support
+
+SecretKey works with all algorithms supported by the [Web Crypto API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API/Supported_algorithms):
+
+- **RSA** (RSA-OAEP, RSA-PSS, RSASSA-PKCS1-v1_5)
+- **ECDSA** / **ECDH** (P-256, P-384, P-521)
+- **AES** (AES-CBC, AES-CTR, AES-GCM, AES-KW)
+- **HMAC** (SHA-1, SHA-256, SHA-384, SHA-512)
+- **PBKDF2**, **HKDF**
+- **Ed25519**, **X25519**
+
+## See Also
+
+- [SubtleCrypto.importKey() - MDN](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/importKey)
+- [Web Crypto API - MDN](https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API)
+- [Cloudflare Workers Bindings](https://developers.cloudflare.com/workers/configuration/bindings/)

--- a/alchemy/src/cloudflare/bindings.ts
+++ b/alchemy/src/cloudflare/bindings.ts
@@ -15,16 +15,17 @@ import type { D1DatabaseResource } from "./d1-database.ts";
 import type { DispatchNamespaceResource } from "./dispatch-namespace.ts";
 import type { DurableObjectNamespace } from "./durable-object-namespace.ts";
 import type { HyperdriveResource } from "./hyperdrive.ts";
+import type { Images } from "./images.ts";
 import type { KVNamespaceResource } from "./kv-namespace.ts";
 import type { PipelineResource } from "./pipeline.ts";
 import type { QueueResource } from "./queue.ts";
+import type { SecretKey } from "./secret-key.ts";
+import type { Secret as CloudflareSecret } from "./secret.ts";
 import type { VectorizeIndexResource } from "./vectorize-index.ts";
 import type { VersionMetadata } from "./version-metadata.ts";
 import type { WorkerStub } from "./worker-stub.ts";
 import type { Worker, WorkerRef } from "./worker.ts";
 import type { Workflow } from "./workflow.ts";
-import type { Images } from "./images.ts";
-import type { Secret as CloudflareSecret } from "./secret.ts";
 
 export type Bindings = {
   [bindingName: string]: Binding;
@@ -59,6 +60,7 @@ export type Binding =
       id: string;
     }
   | Secret
+  | SecretKey
   | string
   | VectorizeIndexResource
   | Worker
@@ -105,6 +107,7 @@ export type WorkerBindingSpec =
   | WorkerBindingPlainText
   | WorkerBindingQueue
   | WorkerBindingR2Bucket
+  | WorkerBindingSecretKey
   | WorkerBindingSecretText
   | WorkerBindingSecretsStore
   | WorkerBindingSecretsStoreSecret
@@ -289,6 +292,35 @@ export interface WorkerBindingR2Bucket {
   type: "r2_bucket";
   /** Bucket name */
   bucket_name: string;
+}
+
+/**
+ * Secret Key binding type
+ */
+export interface WorkerBindingSecretKey {
+  /** The name of the binding */
+  name: string;
+  /** Type identifier for Secret Key binding */
+  type: "secret_key";
+  /** Algorithm-specific key parameters */
+  algorithm: unknown;
+  /** Data format of the key */
+  format: "raw" | "pkcs8" | "spki" | "jwk";
+  /** Allowed operations with the key */
+  usages: Array<
+    | "encrypt"
+    | "decrypt"
+    | "sign"
+    | "verify"
+    | "deriveKey"
+    | "deriveBits"
+    | "wrapKey"
+    | "unwrapKey"
+  >;
+  /** Base64-encoded key data. Required if format is "raw", "pkcs8", or "spki" */
+  key_base64?: string;
+  /** Key data in JSON Web Key format. Required if format is "jwk" */
+  key_jwk?: unknown;
 }
 
 /**

--- a/alchemy/src/cloudflare/bound.ts
+++ b/alchemy/src/cloudflare/bound.ts
@@ -1,6 +1,5 @@
 import type { Pipeline } from "cloudflare:pipelines";
 import type { Secret } from "../secret.ts";
-import type { Secret as CloudflareSecret } from "./secret.ts";
 import type { AiGatewayResource as _AiGateway } from "./ai-gateway.ts";
 import type { Ai as _Ai } from "./ai.ts";
 import type { AnalyticsEngineDataset as _AnalyticsEngineDataset } from "./analytics-engine.ts";
@@ -15,6 +14,8 @@ import type { HyperdriveResource as _Hyperdrive } from "./hyperdrive.ts";
 import type { Images as _Images } from "./images.ts";
 import type { PipelineResource as _Pipeline } from "./pipeline.ts";
 import type { QueueResource as _Queue } from "./queue.ts";
+import type { SecretKey } from "./secret-key.ts";
+import type { Secret as CloudflareSecret } from "./secret.ts";
 import type { VectorizeIndexResource as _VectorizeIndex } from "./vectorize-index.ts";
 import type { VersionMetadata as _VersionMetadata } from "./version-metadata.ts";
 import type { Worker as _Worker, WorkerRef } from "./worker.ts";
@@ -47,34 +48,36 @@ export type Bound<T extends Binding> = T extends _DurableObjectNamespace<
                 ? string
                 : T extends CloudflareSecret
                   ? string
-                  : T extends Assets
-                    ? Service
-                    : T extends _Workflow<infer P>
-                      ? Workflow<P>
-                      : T extends D1DatabaseResource
-                        ? D1Database
-                        : T extends DispatchNamespaceResource
-                          ? { get(name: string): Fetcher }
-                          : T extends _VectorizeIndex
-                            ? VectorizeIndex
-                            : T extends _Queue<infer Body>
-                              ? Queue<Body>
-                              : T extends _AnalyticsEngineDataset
-                                ? AnalyticsEngineDataset
-                                : T extends _Pipeline<infer R>
-                                  ? Pipeline<R>
-                                  : T extends string
-                                    ? string
-                                    : T extends BrowserRendering
-                                      ? Fetcher
-                                      : T extends _Ai<infer M>
-                                        ? Ai<M>
-                                        : T extends _Images
-                                          ? ImagesBinding
-                                          : T extends _VersionMetadata
-                                            ? WorkerVersionMetadata
-                                            : T extends Self
-                                              ? Service
-                                              : T extends Json<infer T>
-                                                ? T
-                                                : Service;
+                  : T extends SecretKey
+                    ? any // TODO(sam): what is this type
+                    : T extends Assets
+                      ? Service
+                      : T extends _Workflow<infer P>
+                        ? Workflow<P>
+                        : T extends D1DatabaseResource
+                          ? D1Database
+                          : T extends DispatchNamespaceResource
+                            ? { get(name: string): Fetcher }
+                            : T extends _VectorizeIndex
+                              ? VectorizeIndex
+                              : T extends _Queue<infer Body>
+                                ? Queue<Body>
+                                : T extends _AnalyticsEngineDataset
+                                  ? AnalyticsEngineDataset
+                                  : T extends _Pipeline<infer R>
+                                    ? Pipeline<R>
+                                    : T extends string
+                                      ? string
+                                      : T extends BrowserRendering
+                                        ? Fetcher
+                                        : T extends _Ai<infer M>
+                                          ? Ai<M>
+                                          : T extends _Images
+                                            ? ImagesBinding
+                                            : T extends _VersionMetadata
+                                              ? WorkerVersionMetadata
+                                              : T extends Self
+                                                ? Service
+                                                : T extends Json<infer T>
+                                                  ? T
+                                                  : Service;

--- a/alchemy/src/cloudflare/bound.ts
+++ b/alchemy/src/cloudflare/bound.ts
@@ -49,7 +49,7 @@ export type Bound<T extends Binding> = T extends _DurableObjectNamespace<
                 : T extends CloudflareSecret
                   ? string
                   : T extends SecretKey
-                    ? any // TODO(sam): what is this type
+                    ? CryptoKey
                     : T extends Assets
                       ? Service
                       : T extends _Workflow<infer P>

--- a/alchemy/src/cloudflare/index.ts
+++ b/alchemy/src/cloudflare/index.ts
@@ -39,6 +39,7 @@ export * from "./react-router.ts";
 export * from "./redwood.ts";
 export * from "./route.ts";
 export * from "./secret.ts";
+export * from "./secret-key.ts";
 export * from "./secrets-store.ts";
 export * from "./sveltekit.ts";
 export * from "./tanstack-start.ts";

--- a/alchemy/src/cloudflare/secret-key.ts
+++ b/alchemy/src/cloudflare/secret-key.ts
@@ -2,10 +2,80 @@
  * SecretKey binding for Cloudflare Workers
  *
  * A data class that represents a secret key binding with cryptographic properties.
- * Based on the Cloudflare Workers API specification for secret keys.
+ * Keys are securely stored and exposed as CryptoKey objects for use with the Web Crypto API.
+ *
+ * @example
+ * // Create an RSA signing key from a JWK format:
+ * const keyPair = await crypto.subtle.generateKey(
+ *   {
+ *     name: "RSA-PSS",
+ *     modulusLength: 2048,
+ *     publicExponent: new Uint8Array([1, 0, 1]),
+ *     hash: "SHA-256",
+ *   },
+ *   true,
+ *   ["sign", "verify"]
+ * );
+ *
+ * const privateKeyJwk = await crypto.subtle.exportKey("jwk", keyPair.privateKey);
+ *
+ * const signingKey = new SecretKey({
+ *   algorithm: { name: "RSA-PSS", hash: "SHA-256" },
+ *   format: "jwk",
+ *   usages: ["sign"],
+ *   key_jwk: secret(privateKeyJwk),
+ * });
+ *
+ * @example
+ * // Create an AES encryption key from raw bytes:
+ * const aesKey = await crypto.subtle.generateKey(
+ *   { name: "AES-GCM", length: 256 },
+ *   true,
+ *   ["encrypt", "decrypt"]
+ * );
+ *
+ * const keyData = await crypto.subtle.exportKey("raw", aesKey);
+ * const keyBase64 = btoa(String.fromCharCode(...new Uint8Array(keyData)));
+ *
+ * const encryptionKey = new SecretKey({
+ *   algorithm: { name: "AES-GCM" },
+ *   format: "raw",
+ *   usages: ["encrypt", "decrypt"],
+ *   key_base64: secret(keyBase64),
+ * });
+ *
+ * @example
+ * // Create an ECDSA key from PKCS#8 format:
+ * const ecdsaKey = new SecretKey({
+ *   algorithm: { name: "ECDSA", namedCurve: "P-256" },
+ *   format: "pkcs8",
+ *   usages: ["sign"],
+ *   key_base64: secret("MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQg..."),
+ * });
+ *
+ * @example
+ * // Create an HMAC key for message authentication:
+ * const hmacKey = await crypto.subtle.generateKey(
+ *   { name: "HMAC", hash: "SHA-256" },
+ *   true,
+ *   ["sign", "verify"]
+ * );
+ *
+ * const keyData = await crypto.subtle.exportKey("raw", hmacKey);
+ * const keyBase64 = btoa(String.fromCharCode(...new Uint8Array(keyData)));
+ *
+ * const macKey = new SecretKey({
+ *   algorithm: { name: "HMAC", hash: "SHA-256" },
+ *   format: "raw",
+ *   usages: ["sign", "verify"],
+ *   key_base64: secret(keyBase64),
+ * });
  *
  * @see https://developers.cloudflare.com/api/resources/workers/subresources/scripts/methods/update/
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/importKey#keyusages
  */
+
+import type { Secret } from "../secret.ts";
 
 /**
  * Data format of the key
@@ -47,54 +117,27 @@ export interface SecretKeyProps {
   /**
    * Base64-encoded key data. Required if format is "raw", "pkcs8", or "spki"
    */
-  key_base64?: string;
+  key_base64?: Secret;
 
   /**
    * Key data in JSON Web Key format. Required if format is "jwk"
    */
-  key_jwk?: unknown;
+  key_jwk?: Secret<JsonWebKey>;
 }
 
-/**
- * SecretKey binding type
- */
-export type SecretKey = SecretKeyProps & {
-  /**
-   * The kind of resource that the binding provides
-   */
-  type: "secret_key";
-};
+export class SecretKey {
+  readonly type = "secret_key";
+  readonly algorithm: unknown;
+  readonly format: SecretKeyFormat;
+  readonly usages: SecretKeyUsage[];
+  readonly key_base64?: Secret;
+  readonly key_jwk?: Secret<JsonWebKey>;
 
-/**
- * Create a SecretKey binding
- *
- * @example
- * ```ts
- * const secretKey = SecretKey({
- *   algorithm: { name: "HMAC", hash: "SHA-256" },
- *   format: "raw",
- *   usages: ["sign", "verify"],
- *   key_base64: "dGVzdC1rZXk="
- * });
- * ```
- *
- * @example
- * ```ts
- * const jwkKey = SecretKey({
- *   algorithm: { name: "RSA-PSS", hash: "SHA-256" },
- *   format: "jwk",
- *   usages: ["sign"],
- *   key_jwk: {
- *     kty: "RSA",
- *     n: "...",
- *     e: "AQAB"
- *   }
- * });
- * ```
- */
-export function SecretKey(props: SecretKeyProps): SecretKey {
-  return {
-    type: "secret_key",
-    ...props,
-  };
+  constructor(props: SecretKeyProps) {
+    this.algorithm = props.algorithm;
+    this.format = props.format;
+    this.usages = props.usages;
+    this.key_base64 = props.key_base64;
+    this.key_jwk = props.key_jwk;
+  }
 }

--- a/alchemy/src/cloudflare/secret-key.ts
+++ b/alchemy/src/cloudflare/secret-key.ts
@@ -1,0 +1,100 @@
+/**
+ * SecretKey binding for Cloudflare Workers
+ *
+ * A data class that represents a secret key binding with cryptographic properties.
+ * Based on the Cloudflare Workers API specification for secret keys.
+ *
+ * @see https://developers.cloudflare.com/api/resources/workers/subresources/scripts/methods/update/
+ */
+
+/**
+ * Data format of the key
+ */
+export type SecretKeyFormat = "raw" | "pkcs8" | "spki" | "jwk";
+
+/**
+ * Allowed operations with the key
+ */
+export type SecretKeyUsage =
+  | "encrypt"
+  | "decrypt"
+  | "sign"
+  | "verify"
+  | "deriveKey"
+  | "deriveBits"
+  | "wrapKey"
+  | "unwrapKey";
+
+/**
+ * SecretKey binding properties
+ */
+export interface SecretKeyProps {
+  /**
+   * Algorithm-specific key parameters
+   */
+  algorithm: unknown;
+
+  /**
+   * Data format of the key
+   */
+  format: SecretKeyFormat;
+
+  /**
+   * Allowed operations with the key
+   */
+  usages: SecretKeyUsage[];
+
+  /**
+   * Base64-encoded key data. Required if format is "raw", "pkcs8", or "spki"
+   */
+  key_base64?: string;
+
+  /**
+   * Key data in JSON Web Key format. Required if format is "jwk"
+   */
+  key_jwk?: unknown;
+}
+
+/**
+ * SecretKey binding type
+ */
+export type SecretKey = SecretKeyProps & {
+  /**
+   * The kind of resource that the binding provides
+   */
+  type: "secret_key";
+};
+
+/**
+ * Create a SecretKey binding
+ *
+ * @example
+ * ```ts
+ * const secretKey = SecretKey({
+ *   algorithm: { name: "HMAC", hash: "SHA-256" },
+ *   format: "raw",
+ *   usages: ["sign", "verify"],
+ *   key_base64: "dGVzdC1rZXk="
+ * });
+ * ```
+ *
+ * @example
+ * ```ts
+ * const jwkKey = SecretKey({
+ *   algorithm: { name: "RSA-PSS", hash: "SHA-256" },
+ *   format: "jwk",
+ *   usages: ["sign"],
+ *   key_jwk: {
+ *     kty: "RSA",
+ *     n: "...",
+ *     e: "AQAB"
+ *   }
+ * });
+ * ```
+ */
+export function SecretKey(props: SecretKeyProps): SecretKey {
+  return {
+    type: "secret_key",
+    ...props,
+  };
+}

--- a/alchemy/src/cloudflare/worker-metadata.ts
+++ b/alchemy/src/cloudflare/worker-metadata.ts
@@ -491,8 +491,8 @@ export async function prepareWorkerMetadata<B extends Bindings>(
         algorithm: binding.algorithm,
         format: binding.format,
         usages: binding.usages,
-        key_base64: binding.key_base64,
-        key_jwk: binding.key_jwk,
+        key_base64: binding.key_base64?.unencrypted,
+        key_jwk: binding.key_jwk?.unencrypted,
       });
     } else {
       // @ts-expect-error - we should never reach here

--- a/alchemy/src/cloudflare/worker-metadata.ts
+++ b/alchemy/src/cloudflare/worker-metadata.ts
@@ -484,6 +484,16 @@ export async function prepareWorkerMetadata<B extends Bindings>(
         name: bindingName,
         namespace: binding.namespaceName,
       });
+    } else if (binding.type === "secret_key") {
+      meta.bindings.push({
+        type: "secret_key",
+        name: bindingName,
+        algorithm: binding.algorithm,
+        format: binding.format,
+        usages: binding.usages,
+        key_base64: binding.key_base64,
+        key_jwk: binding.key_jwk,
+      });
     } else {
       // @ts-expect-error - we should never reach here
       throw new Error(`Unsupported binding type: ${binding.type}`);

--- a/alchemy/src/cloudflare/worker.ts
+++ b/alchemy/src/cloudflare/worker.ts
@@ -604,7 +604,7 @@ export function WorkerRef<
  * const taskQueue = await Queue("task-queue", {
  *   name: "task-queue"
  * });
- * 
+ *
  * const dlq = await Queue("failed-tasks", {
  *   name: "failed-tasks"
  * });
@@ -628,8 +628,7 @@ export function WorkerRef<
  *   }]
  * });
  *
- * @see
- * https://developers.cloudflare.com/workers/
+ * @see https://developers.cloudflare.com/workers/
  */
 export function Worker<
   const B extends Bindings,

--- a/alchemy/src/cloudflare/wrangler.json.ts
+++ b/alchemy/src/cloudflare/wrangler.json.ts
@@ -607,6 +607,8 @@ function processBindings(
         binding: bindingName,
         namespace: binding.namespaceName,
       });
+    } else if (binding.type === "secret_key") {
+      // no-op
     } else {
       // biome-ignore lint/correctness/noVoidTypeReturn: it returns never
       return assertNever(binding);

--- a/alchemy/src/secret.ts
+++ b/alchemy/src/secret.ts
@@ -8,7 +8,7 @@ declare global {
 
 // a global registry of all secrets that we will use when serializing an application
 const globalSecrets: {
-  [name: string]: Secret;
+  [name: string]: Secret<any>;
 } = (globalThis.__ALCHEMY_SECRETS__ ??= {});
 
 let i = 0;
@@ -53,19 +53,19 @@ const SecretSymbol = Symbol.for("alchemy::Secret");
  *   }
  * }
  */
-export class Secret {
+export class Secret<T = string> {
   [SecretSymbol] = true;
 
   /**
    * @internal
    */
-  public static all(): Secret[] {
+  public static all(): Secret<any>[] {
     return Object.values(globalSecrets);
   }
 
   public readonly type = "secret";
   constructor(
-    readonly unencrypted: string,
+    readonly unencrypted: T,
     readonly name: string = nextName(),
   ) {
     globalSecrets[name] = this;
@@ -111,10 +111,10 @@ export function isSecret(binding: any): binding is Secret {
  * @throws {Error} If the value is undefined
  * @throws {Error} If no password is set in the alchemy application options or current scope
  */
-export function secret<S extends string | undefined>(
-  unencrypted: S,
+export function secret<S = string>(
+  unencrypted: S | undefined,
   name?: string,
-): Secret {
+): Secret<S> {
   if (unencrypted === undefined) {
     throw new Error("Secret cannot be undefined");
   }

--- a/alchemy/test/cloudflare/secret-key.test.ts
+++ b/alchemy/test/cloudflare/secret-key.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect } from "vitest";
+import { alchemy } from "../../src/alchemy.ts";
+import { SecretKey } from "../../src/cloudflare/secret-key.ts";
+import { Worker } from "../../src/cloudflare/worker.ts";
+import { destroy } from "../../src/destroy.ts";
+import { secret } from "../../src/secret.ts";
+import "../../src/test/vitest.ts";
+import { BRANCH_PREFIX } from "../util.ts";
+import { fetchAndExpectOK } from "./fetch-utils.ts";
+
+const test = alchemy.test(import.meta, {
+  prefix: BRANCH_PREFIX,
+});
+
+describe("SecretKey Binding", () => {
+  test("create worker with programmatically generated JWK SecretKey", async (scope) => {
+    const workerName = `${BRANCH_PREFIX}-secret-key-jwk-worker`;
+
+    let worker: Worker | undefined;
+
+    try {
+      // Generate an RSA key pair programmatically using Web Crypto API
+      const keyPair = await crypto.subtle.generateKey(
+        {
+          name: "RSA-PSS",
+          modulusLength: 2048,
+          publicExponent: new Uint8Array([1, 0, 1]),
+          hash: "SHA-256",
+        },
+        true, // extractable
+        ["sign", "verify"],
+      );
+
+      // Export the private key as JWK
+      const privateKeyJwk = await crypto.subtle.exportKey(
+        "jwk",
+        keyPair.privateKey,
+      );
+
+      const secretKey = new SecretKey({
+        algorithm: { name: "RSA-PSS", hash: "SHA-256" },
+        format: "jwk",
+        usages: ["sign"],
+        key_jwk: secret(privateKeyJwk),
+      });
+
+      // Create a worker that accesses the JWK SecretKey properties and can sign data
+      worker = await Worker(workerName, {
+        name: workerName,
+        format: "esm",
+        url: true,
+        bindings: {
+          RSA_KEY: secretKey,
+        },
+        script: `
+          export default {
+            async fetch(request, env, ctx) {
+              const url = new URL(request.url);
+
+              if (url.pathname === '/jwk-key-info') {
+                try {
+                  return Response.json({
+                    success: true,
+                    keyType: typeof env.RSA_KEY,
+                    algorithm: env.RSA_KEY.algorithm,
+                    usages: env.RSA_KEY.usages,
+                    extractable: env.RSA_KEY.extractable,
+                    keyFormat: env.RSA_KEY.type // should be "private" for signing keys
+                  });
+                } catch (error) {
+                  return Response.json({
+                    success: false,
+                    error: error.message
+                  }, { status: 500 });
+                }
+              }
+
+              if (url.pathname === '/sign-with-rsa') {
+                try {
+                  const dataToSign = url.searchParams.get('data') || 'test-rsa-data';
+                  const encoder = new TextEncoder();
+                  const data = encoder.encode(dataToSign);
+
+                  // Use the RSA SecretKey binding to sign the data
+                  const signature = await crypto.subtle.sign(
+                    { name: "RSA-PSS", saltLength: 32 },
+                    env.RSA_KEY,
+                    data
+                  );
+
+                  // Convert signature to hex string for response
+                  const signatureArray = new Uint8Array(signature);
+                  const signatureHex = Array.from(signatureArray)
+                    .map(b => b.toString(16).padStart(2, '0'))
+                    .join('');
+
+                  return Response.json({
+                    success: true,
+                    data: dataToSign,
+                    signature: signatureHex,
+                    algorithm: env.RSA_KEY.algorithm.name
+                  });
+                } catch (error) {
+                  return Response.json({
+                    success: false,
+                    error: error.message
+                  }, { status: 500 });
+                }
+              }
+
+              return new Response('JWK SecretKey Worker is running!', {
+                status: 200,
+                headers: { 'Content-Type': 'text/plain' }
+              });
+            }
+          };
+        `,
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+
+      expect(worker.id).toBeTruthy();
+      expect(worker.name).toEqual(workerName);
+      expect(worker.bindings).toBeDefined();
+      expect(worker.bindings!.RSA_KEY).toBeDefined();
+      expect(worker.url).toBeTruthy();
+
+      // Test that the JWK SecretKey binding provides proper CryptoKey information
+      const keyInfoResponse = await fetchAndExpectOK(
+        `${worker.url}/jwk-key-info`,
+      );
+      const keyInfo: any = await keyInfoResponse.json();
+
+      expect(keyInfo.success).toEqual(true);
+      expect(keyInfo.keyType).toEqual("object"); // CryptoKey is an object
+      expect(keyInfo.algorithm.name).toEqual("RSA-PSS");
+      expect(keyInfo.algorithm.hash.name).toEqual("SHA-256");
+      expect(keyInfo.usages).toContain("sign");
+      expect(keyInfo.extractable).toEqual(false); // SecretKeys are typically non-extractable
+      expect(keyInfo.keyFormat).toEqual("private"); // RSA signing keys are private keys
+
+      // Test signing data with the programmatically generated RSA key
+      const testData = "rsa-test-data";
+      const signResponse = await fetchAndExpectOK(
+        `${worker.url}/sign-with-rsa?data=${encodeURIComponent(testData)}`,
+      );
+      const signResult: any = await signResponse.json();
+
+      expect(signResult.success).toEqual(true);
+      expect(signResult.data).toEqual(testData);
+      expect(signResult.signature).toBeTruthy();
+      expect(typeof signResult.signature).toEqual("string");
+      expect(signResult.algorithm).toEqual("RSA-PSS");
+
+      // Verify the signature is valid by using the public key we generated
+      const signatureArray = new Uint8Array(
+        signResult.signature
+          .match(/.{1,2}/g)
+          .map((byte: string) => Number.parseInt(byte, 16)),
+      );
+      const encoder = new TextEncoder();
+      const data = encoder.encode(testData);
+
+      const isValid = await crypto.subtle.verify(
+        { name: "RSA-PSS", saltLength: 32 },
+        keyPair.publicKey,
+        signatureArray,
+        data,
+      );
+
+      expect(isValid).toEqual(true);
+    } finally {
+      await destroy(scope);
+    }
+  });
+});


### PR DESCRIPTION
Closes #384
```typescript
import { SecretKey } from "alchemy/cloudflare";
import { Worker } from "alchemy/cloudflare";
import { secret } from "alchemy";

// Generate an RSA key pair
const keyPair = await crypto.subtle.generateKey(
  {
    name: "RSA-PSS",
    modulusLength: 2048,
    publicExponent: new Uint8Array([1, 0, 1]),
    hash: "SHA-256",
  },
  true, // extractable
  ["sign", "verify"]
);

// Export the private key as JWK
const privateKeyJwk = await crypto.subtle.exportKey("jwk", keyPair.privateKey);

const signingKey = new SecretKey({
  algorithm: { name: "RSA-PSS", hash: "SHA-256" },
  format: "jwk",
  usages: ["sign"],
  key_jwk: secret(privateKeyJwk),
});

const worker = await Worker("my-worker", {
  entrypoint: "./worker.ts",
  bindings: {
    SIGNING_KEY: signingKey,
  },
});
```

**worker.ts**

```javascript
export default {
  async fetch(request, env) {
    const data = new TextEncoder().encode("Hello, World!");

    const signature = await crypto.subtle.sign(
      { name: "RSA-PSS", saltLength: 32 },
      env.SIGNING_KEY,
      data
    );

    return Response.json({
      signed: Array.from(new Uint8Array(signature)),
    });
  },
};
```

Generated with [Claude Code](https://claude.ai/code)