### PR TITLE
feat(cloudflare): add script to convert wrangler.json to alchemy.run.ts

### DIFF
--- a/alchemy/test/scripts/wrangler-to-alchemy.test.ts
+++ b/alchemy/test/scripts/wrangler-to-alchemy.test.ts
@@ -1,0 +1,495 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import type { WranglerJsonSpec } from "../../src/cloudflare/wrangler.json.ts";
+
+// Import the functions we want to test
+// Note: We need to mock the CLI parts and test the core functions
+const scriptPath = path.resolve(
+  import.meta.dirname,
+  "../../../scripts/wrangler-to-alchemy.ts",
+);
+
+// Create a temporary directory for test files
+const testDir = path.join(process.cwd(), ".test-tmp");
+
+describe("wrangler-to-alchemy conversion script", () => {
+  // Helper function to run conversion script
+  async function runConversion(inputSpec: WranglerJsonSpec, filename = "test") {
+    const testFilePath = path.join(testDir, `${filename}-wrangler.json`);
+    const outputPath = path.join(testDir, `${filename}-alchemy.run.ts`);
+    
+    // Ensure test directory exists
+    await fs.mkdir(testDir, { recursive: true });
+    await fs.writeFile(testFilePath, JSON.stringify(inputSpec, null, 2));
+
+    const { exec } = await import("node:child_process");
+    const { promisify } = await import("node:util");
+    const execAsync = promisify(exec);
+
+    await execAsync(`bun ${scriptPath} ${testFilePath} ${outputPath}`);
+    
+    return await fs.readFile(outputPath, "utf-8");
+  }
+
+  beforeEach(async () => {
+    // Create test directory
+    await fs.mkdir(testDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    // Clean up test directory
+    try {
+      await fs.rm(testDir, { recursive: true, force: true });
+    } catch {
+      // Ignore cleanup errors
+    }
+  });
+
+  describe("parseArgs", () => {
+    it("should parse basic arguments", async () => {
+      // Test argument parsing by running the script with --help
+      const { exec } = await import("node:child_process");
+      const { promisify } = await import("node:util");
+      const execAsync = promisify(exec);
+
+      const { stdout } = await execAsync(`bun ${scriptPath} --help`);
+      expect(stdout).toContain("Usage: bun scripts/wrangler-to-alchemy.ts");
+      expect(stdout).toContain(
+        "Convert a wrangler.json file to an alchemy.run.ts file",
+      );
+    });
+
+    it("should exit with error for missing arguments", async () => {
+      const { exec } = await import("node:child_process");
+      const { promisify } = await import("node:util");
+      const execAsync = promisify(exec);
+
+      try {
+        await execAsync(`bun ${scriptPath}`);
+        expect.fail("Should have thrown an error");
+      } catch (error: any) {
+        expect(error.stderr).toContain("Error: Missing required argument");
+      }
+    });
+  });
+
+  describe("loadWranglerJson", () => {
+    it("should load valid wrangler.json", async () => {
+      const testSpec: WranglerJsonSpec = {
+        name: "test-worker",
+        main: "src/index.ts",
+        compatibility_date: "2023-12-01",
+      };
+
+      const testFilePath = path.join(testDir, "wrangler.json");
+      await fs.writeFile(testFilePath, JSON.stringify(testSpec, null, 2));
+
+      // We need to import and test the function, but since it's in a script file,
+      // we'll test via the CLI interface for now
+      const { exec } = await import("node:child_process");
+      const { promisify } = await import("node:util");
+      const execAsync = promisify(exec);
+      const outputPath = path.join(testDir, "alchemy.run.ts");
+
+      await execAsync(`bun ${scriptPath} ${testFilePath} ${outputPath}`);
+
+      const generatedContent = await fs.readFile(outputPath, "utf-8");
+      expect(generatedContent).toContain('import alchemy from "alchemy"');
+      expect(generatedContent).toContain(
+        'import { Worker } from "alchemy/cloudflare"',
+      );
+      expect(generatedContent).toContain('"test-worker"');
+    });
+
+    it("should handle file not found error", async () => {
+      const { exec } = await import("node:child_process");
+      const { promisify } = await import("node:util");
+      const execAsync = promisify(exec);
+      const nonExistentPath = path.join(testDir, "nonexistent.json");
+
+      try {
+        await execAsync(`bun ${scriptPath} ${nonExistentPath}`);
+        expect.fail("Should have thrown an error");
+      } catch (error: any) {
+        expect(error.code).toBe(1);
+        expect(error.stderr).toContain("File not found");
+      }
+    });
+
+    it("should handle invalid JSON", async () => {
+      const invalidJsonPath = path.join(testDir, "invalid.json");
+      // Ensure directory exists first
+      await fs.mkdir(testDir, { recursive: true });
+      await fs.writeFile(invalidJsonPath, "{ invalid json");
+
+      const { exec } = await import("node:child_process");
+      const { promisify } = await import("node:util");
+      const execAsync = promisify(exec);
+
+      try {
+        await execAsync(`bun ${scriptPath} ${invalidJsonPath}`);
+        expect.fail("Should have thrown an error");
+      } catch (error: any) {
+        expect(error.stderr).toContain("Invalid JSON");
+      }
+    });
+  });
+
+  describe("generateImports", () => {
+    it("should generate basic imports", async () => {
+      const spec: WranglerJsonSpec = {
+        name: "basic-worker",
+      };
+
+      const content = await runConversion(spec, "basic");
+      expect(content).toContain('import alchemy from "alchemy"');
+      expect(content).toContain('import { Worker } from "alchemy/cloudflare"');
+    });
+
+    it("should include KV imports when KV namespaces are present", async () => {
+      const spec: WranglerJsonSpec = {
+        name: "kv-worker",
+        kv_namespaces: [{ binding: "MY_KV", id: "kv-id-123" }],
+      };
+
+      const content = await runConversion(spec, "kv");
+      expect(content).toContain("KVNamespace");
+      expect(content).toContain('await KVNamespace("MY_KV"');
+    });
+
+    it("should include R2 imports when R2 buckets are present", async () => {
+      const spec: WranglerJsonSpec = {
+        name: "r2-worker",
+        r2_buckets: [{ binding: "MY_BUCKET", bucket_name: "my-bucket" }],
+      };
+
+      const content = await runConversion(spec, "r2");
+      expect(content).toContain("R2Bucket");
+      expect(content).toContain('await R2Bucket("my-bucket"');
+    });
+
+    it("should include D1 imports when D1 databases are present", async () => {
+      const spec: WranglerJsonSpec = {
+        name: "d1-worker",
+        d1_databases: [
+          { binding: "DB", database_id: "db-id-123", database_name: "my-db" },
+        ],
+      };
+
+      const content = await runConversion(spec, "d1");
+      expect(content).toContain("D1Database");
+      expect(content).toContain('await D1Database("my-db"');
+    });
+
+    it("should include multiple imports when multiple binding types are present", async () => {
+      const spec: WranglerJsonSpec = {
+        name: "multi-worker",
+        kv_namespaces: [{ binding: "MY_KV", id: "kv-id-123" }],
+        r2_buckets: [{ binding: "MY_BUCKET", bucket_name: "my-bucket" }],
+        d1_databases: [
+          { binding: "DB", database_id: "db-id-123", database_name: "my-db" },
+        ],
+        ai: { binding: "AI" },
+      };
+
+      const content = await runConversion(spec, "multi");
+      expect(content).toContain(
+        "KVNamespace, R2Bucket, D1Database, Ai, Worker",
+      );
+      expect(content).toContain("MY_KV: my_kv");
+      expect(content).toContain("MY_BUCKET: my_bucket");
+      expect(content).toContain("DB: db");
+      expect(content).toContain("AI: ai");
+    });
+  });
+
+  describe("generateBindings", () => {
+    it("should generate durable object bindings correctly", async () => {
+      const spec: WranglerJsonSpec = {
+        name: "do-worker",
+        durable_objects: {
+          bindings: [
+            {
+              name: "MY_DO",
+              class_name: "MyDurableObject",
+              script_name: "do-script",
+              environment: "production",
+            },
+          ],
+        },
+      };
+
+      const content = await runConversion(spec, "do");
+      expect(content).toContain("DurableObjectNamespace");
+      expect(content).toContain('new DurableObjectNamespace("MY_DO"');
+      expect(content).toContain('className: "MyDurableObject"');
+      expect(content).toContain('scriptName: "do-script"');
+      expect(content).toContain('environment: "production"');
+    });
+
+    it("should generate queue bindings and event sources correctly", async () => {
+      const spec: WranglerJsonSpec = {
+        name: "queue-worker",
+        queues: {
+          producers: [{ binding: "MY_QUEUE", queue: "my-queue" }],
+          consumers: [{ queue: "my-queue", max_batch_size: 10 }],
+        },
+      };
+
+      const content = await runConversion(spec, "queue");
+      expect(content).toContain("Queue");
+      expect(content).toContain('await Queue("my-queue"');
+      expect(content).toContain("eventSources: [my_queue]");
+    });
+
+    it("should generate workflow bindings correctly", async () => {
+      const spec: WranglerJsonSpec = {
+        name: "workflow-worker",
+        workflows: [
+          {
+            name: "my-workflow",
+            binding: "MY_WORKFLOW",
+            class_name: "MyWorkflow",
+            script_name: "workflow-script",
+          },
+        ],
+      };
+
+      const content = await runConversion(spec, "workflow");
+      expect(content).toContain("Workflow");
+      expect(content).toContain('new Workflow("my-workflow"');
+      expect(content).toContain('className: "MyWorkflow"');
+      expect(content).toContain('workflowName: "my-workflow"');
+      expect(content).toContain('scriptName: "workflow-script"');
+    });
+  });
+
+  describe("generateWorkerConfig", () => {
+    it("should generate basic worker configuration", async () => {
+      const spec: WranglerJsonSpec = {
+        name: "basic-worker",
+        main: "src/index.ts",
+        compatibility_date: "2023-12-01",
+        compatibility_flags: ["nodejs_compat"],
+        workers_dev: true,
+      };
+
+      const testFilePath = path.join(testDir, "worker-wrangler.json");
+      const outputPath = path.join(testDir, "worker-alchemy.run.ts");
+      await fs.writeFile(testFilePath, JSON.stringify(spec));
+
+      const { exec } = await import("node:child_process");
+      const { promisify } = await import("node:util");
+      const execAsync = promisify(exec);
+
+      await execAsync(`bun ${scriptPath} ${testFilePath} ${outputPath}`);
+
+      const content = await fs.readFile(outputPath, "utf-8");
+      expect(content).toContain('await Worker("basic-worker"');
+      expect(content).toContain('entrypoint: "src/index.ts"');
+      expect(content).toContain('compatibilityDate: "2023-12-01"');
+      expect(content).toContain('compatibilityFlags: ["nodejs_compat"]');
+      expect(content).toContain("url: true");
+      expect(content).toContain("adopt: true");
+    });
+
+    it("should include environment variables", async () => {
+      const spec: WranglerJsonSpec = {
+        name: "env-worker",
+        vars: {
+          API_URL: "https://api.example.com",
+          DEBUG: "true",
+        },
+      };
+
+      const testFilePath = path.join(testDir, "env-wrangler.json");
+      const outputPath = path.join(testDir, "env-alchemy.run.ts");
+      await fs.writeFile(testFilePath, JSON.stringify(spec));
+
+      const { exec } = await import("node:child_process");
+      const { promisify } = await import("node:util");
+      const execAsync = promisify(exec);
+
+      await execAsync(`bun ${scriptPath} ${testFilePath} ${outputPath}`);
+
+      const content = await fs.readFile(outputPath, "utf-8");
+      expect(content).toContain('"API_URL": "https://api.example.com"');
+      expect(content).toContain('"DEBUG": "true"');
+    });
+
+    it("should include cron triggers", async () => {
+      const spec: WranglerJsonSpec = {
+        name: "cron-worker",
+        triggers: {
+          crons: ["0 0 * * *", "0 12 * * *"],
+        },
+      };
+
+      const testFilePath = path.join(testDir, "cron-wrangler.json");
+      const outputPath = path.join(testDir, "cron-alchemy.run.ts");
+      await fs.writeFile(testFilePath, JSON.stringify(spec));
+
+      const { exec } = await import("node:child_process");
+      const { promisify } = await import("node:util");
+      const execAsync = promisify(exec);
+
+      await execAsync(`bun ${scriptPath} ${testFilePath} ${outputPath}`);
+
+      const content = await fs.readFile(outputPath, "utf-8");
+      expect(content).toContain('crons: ["0 0 * * *","0 12 * * *"]');
+    });
+  });
+
+  describe("hyperdrive bindings", () => {
+    it("should generate hyperdrive bindings with secret import", async () => {
+      const spec: WranglerJsonSpec = {
+        name: "hyperdrive-worker",
+        hyperdrive: [
+          {
+            binding: "HYPERDRIVE",
+            id: "hyperdrive-id-123",
+            localConnectionString:
+              "postgres://user:password@localhost:5432/mydb",
+          },
+        ],
+      };
+
+      const testFilePath = path.join(testDir, "hyperdrive-wrangler.json");
+      const outputPath = path.join(testDir, "hyperdrive-alchemy.run.ts");
+      await fs.writeFile(testFilePath, JSON.stringify(spec));
+
+      const { exec } = await import("node:child_process");
+      const { promisify } = await import("node:util");
+      const execAsync = promisify(exec);
+
+      await execAsync(`bun ${scriptPath} ${testFilePath} ${outputPath}`);
+
+      const content = await fs.readFile(outputPath, "utf-8");
+      expect(content).toContain('import { secret } from "alchemy"');
+      expect(content).toContain("Hyperdrive");
+      expect(content).toContain('await Hyperdrive("hyperdrive-id-123"');
+      expect(content).toContain('scheme: "postgres"');
+      expect(content).toContain('host: "localhost"');
+      expect(content).toContain("port: 5432");
+      expect(content).toContain('database: "mydb"');
+      expect(content).toContain('user: "user"');
+      expect(content).toContain('password: secret("USER_PASSWORD")');
+    });
+  });
+
+  describe("routes handling", () => {
+    it("should generate routes when present", async () => {
+      const spec: WranglerJsonSpec = {
+        name: "route-worker",
+        routes: ["example.com/*", "*.example.com/api/*"],
+      };
+
+      const testFilePath = path.join(testDir, "route-wrangler.json");
+      const outputPath = path.join(testDir, "route-alchemy.run.ts");
+      await fs.writeFile(testFilePath, JSON.stringify(spec));
+
+      const { exec } = await import("node:child_process");
+      const { promisify } = await import("node:util");
+      const execAsync = promisify(exec);
+
+      await execAsync(`bun ${scriptPath} ${testFilePath} ${outputPath}`);
+
+      const content = await fs.readFile(outputPath, "utf-8");
+      expect(content).toContain("// Routes");
+      expect(content).toContain('await Route("route-0"');
+      expect(content).toContain('pattern: "example.com/*"');
+      expect(content).toContain('await Route("route-1"');
+      expect(content).toContain('pattern: "*.example.com/api/*"');
+    });
+  });
+
+  describe("complete conversion", () => {
+    it("should generate a complete alchemy.run.ts file", async () => {
+      const spec: WranglerJsonSpec = {
+        name: "complete-worker",
+        main: "src/index.ts",
+        compatibility_date: "2023-12-01",
+        compatibility_flags: ["nodejs_compat"],
+        workers_dev: true,
+        kv_namespaces: [{ binding: "CACHE", id: "kv-cache-123" }],
+        vars: {
+          API_URL: "https://api.example.com",
+        },
+        triggers: {
+          crons: ["0 */6 * * *"],
+        },
+        routes: ["*.example.com/*"],
+      };
+
+      const content = await runConversion(spec, "complete");
+
+      // Check structure
+      expect(content).toContain('import alchemy from "alchemy"');
+      expect(content).toContain(
+        'import { KVNamespace, Worker } from "alchemy/cloudflare"',
+      );
+      expect(content).toContain('const app = await alchemy("complete-worker"');
+      expect(content).toContain("// Resources");
+      expect(content).toContain("// Worker");
+      expect(content).toContain("// Routes");
+      expect(content).toContain("console.log(worker.url)");
+      expect(content).toContain("await app.finalize()");
+
+      // Check specific configurations
+      expect(content).toContain('await KVNamespace("CACHE"');
+      expect(content).toContain("CACHE: cache");
+      expect(content).toContain('"API_URL": "https://api.example.com"');
+      expect(content).toContain('crons: ["0 */6 * * *"]');
+      expect(content).toContain('pattern: "*.example.com/*"');
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle empty wrangler.json", async () => {
+      const spec: WranglerJsonSpec = {
+        name: "empty-worker",
+      };
+
+      const content = await runConversion(spec, "empty");
+      expect(content).toContain('const app = await alchemy("empty-worker"');
+      expect(content).toContain('await Worker("empty-worker"');
+      expect(content).toContain("adopt: true");
+    });
+
+    it("should handle special binding types like AI, Browser, Images", async () => {
+      const spec: WranglerJsonSpec = {
+        name: "special-worker",
+        ai: { binding: "AI" },
+        browser: { binding: "BROWSER" },
+        images: { binding: "IMAGES" },
+        version_metadata: { binding: "VERSION" },
+      };
+
+      const testFilePath = path.join(testDir, "special-wrangler.json");
+      const outputPath = path.join(testDir, "special-alchemy.run.ts");
+      await fs.writeFile(testFilePath, JSON.stringify(spec));
+
+      const { exec } = await import("node:child_process");
+      const { promisify } = await import("node:util");
+      const execAsync = promisify(exec);
+
+      await execAsync(`bun ${scriptPath} ${testFilePath} ${outputPath}`);
+
+      const content = await fs.readFile(outputPath, "utf-8");
+      expect(content).toContain(
+        "Ai, BrowserRendering, Images, VersionMetadata",
+      );
+      expect(content).toContain("export const ai = new Ai()");
+      expect(content).toContain(
+        'export const browser = { type: "browser" as const }',
+      );
+      expect(content).toContain(
+        'export const images = { type: "images" as const }',
+      );
+      expect(content).toContain(
+        'export const versionMetadata = { type: "version_metadata" as const }',
+      );
+    });
+  });
+});

--- a/alchemy/test/scripts/wrangler-to-alchemy.test.ts
+++ b/alchemy/test/scripts/wrangler-to-alchemy.test.ts
@@ -1,495 +1,397 @@
-import fs from "node:fs/promises";
-import path from "node:path";
-import { describe, expect, it, beforeEach, afterEach } from "vitest";
-import type { WranglerJsonSpec } from "../../src/cloudflare/wrangler.json.ts";
+import { describe, expect, it } from "vitest";
+import { convertWranglerToAlchemy } from "../../../scripts/wrangler-to-alchemy.ts";
 
-// Import the functions we want to test
-// Note: We need to mock the CLI parts and test the core functions
-const scriptPath = path.resolve(
-  import.meta.dirname,
-  "../../../scripts/wrangler-to-alchemy.ts",
-);
+describe("wrangler-to-alchemy conversion", () => {
+  it("should convert basic wrangler.json", () => {
+    const input = JSON.stringify({
+      name: "my-worker",
+      main: "src/index.ts",
+      compatibility_date: "2023-12-01",
+    });
 
-// Create a temporary directory for test files
-const testDir = path.join(process.cwd(), ".test-tmp");
+    const output = convertWranglerToAlchemy(input);
 
-describe("wrangler-to-alchemy conversion script", () => {
-  // Helper function to run conversion script
-  async function runConversion(inputSpec: WranglerJsonSpec, filename = "test") {
-    const testFilePath = path.join(testDir, `${filename}-wrangler.json`);
-    const outputPath = path.join(testDir, `${filename}-alchemy.run.ts`);
-    
-    // Ensure test directory exists
-    await fs.mkdir(testDir, { recursive: true });
-    await fs.writeFile(testFilePath, JSON.stringify(inputSpec, null, 2));
-
-    const { exec } = await import("node:child_process");
-    const { promisify } = await import("node:util");
-    const execAsync = promisify(exec);
-
-    await execAsync(`bun ${scriptPath} ${testFilePath} ${outputPath}`);
-    
-    return await fs.readFile(outputPath, "utf-8");
-  }
-
-  beforeEach(async () => {
-    // Create test directory
-    await fs.mkdir(testDir, { recursive: true });
+    expect(output).toContain('import alchemy from "alchemy";');
+    expect(output).toContain('import { Worker } from "alchemy/cloudflare";');
+    expect(output).toContain('const app = await alchemy("my-worker"');
+    expect(output).toContain('await Worker("my-worker"');
+    expect(output).toContain('entrypoint: "src/index.ts"');
+    expect(output).toContain('compatibilityDate: "2023-12-01"');
+    expect(output).toContain("adopt: true");
+    expect(output).toContain("console.log(worker.url);");
+    expect(output).toContain("await app.finalize();");
   });
 
-  afterEach(async () => {
-    // Clean up test directory
-    try {
-      await fs.rm(testDir, { recursive: true, force: true });
-    } catch {
-      // Ignore cleanup errors
-    }
+  it("should convert worker with KV namespace", () => {
+    const input = JSON.stringify({
+      name: "kv-worker",
+      kv_namespaces: [{ binding: "MY_KV", id: "kv-id-123" }],
+    });
+
+    const output = convertWranglerToAlchemy(input);
+
+    expect(output).toContain("KVNamespace");
+    expect(output).toContain('await KVNamespace("MY_KV"');
+    expect(output).toContain('title: "MY_KV"');
+    expect(output).toContain("MY_KV: my_kv");
+    expect(output).toContain("// Resources");
   });
 
-  describe("parseArgs", () => {
-    it("should parse basic arguments", async () => {
-      // Test argument parsing by running the script with --help
-      const { exec } = await import("node:child_process");
-      const { promisify } = await import("node:util");
-      const execAsync = promisify(exec);
-
-      const { stdout } = await execAsync(`bun ${scriptPath} --help`);
-      expect(stdout).toContain("Usage: bun scripts/wrangler-to-alchemy.ts");
-      expect(stdout).toContain(
-        "Convert a wrangler.json file to an alchemy.run.ts file",
-      );
+  it("should convert worker with R2 bucket", () => {
+    const input = JSON.stringify({
+      name: "r2-worker",
+      r2_buckets: [{ binding: "MY_BUCKET", bucket_name: "my-bucket" }],
     });
 
-    it("should exit with error for missing arguments", async () => {
-      const { exec } = await import("node:child_process");
-      const { promisify } = await import("node:util");
-      const execAsync = promisify(exec);
+    const output = convertWranglerToAlchemy(input);
 
-      try {
-        await execAsync(`bun ${scriptPath}`);
-        expect.fail("Should have thrown an error");
-      } catch (error: any) {
-        expect(error.stderr).toContain("Error: Missing required argument");
-      }
-    });
+    expect(output).toContain("R2Bucket");
+    expect(output).toContain('await R2Bucket("my-bucket"');
+    expect(output).toContain('name: "my-bucket"');
+    expect(output).toContain("MY_BUCKET: my_bucket");
   });
 
-  describe("loadWranglerJson", () => {
-    it("should load valid wrangler.json", async () => {
-      const testSpec: WranglerJsonSpec = {
-        name: "test-worker",
-        main: "src/index.ts",
-        compatibility_date: "2023-12-01",
-      };
-
-      const testFilePath = path.join(testDir, "wrangler.json");
-      await fs.writeFile(testFilePath, JSON.stringify(testSpec, null, 2));
-
-      // We need to import and test the function, but since it's in a script file,
-      // we'll test via the CLI interface for now
-      const { exec } = await import("node:child_process");
-      const { promisify } = await import("node:util");
-      const execAsync = promisify(exec);
-      const outputPath = path.join(testDir, "alchemy.run.ts");
-
-      await execAsync(`bun ${scriptPath} ${testFilePath} ${outputPath}`);
-
-      const generatedContent = await fs.readFile(outputPath, "utf-8");
-      expect(generatedContent).toContain('import alchemy from "alchemy"');
-      expect(generatedContent).toContain(
-        'import { Worker } from "alchemy/cloudflare"',
-      );
-      expect(generatedContent).toContain('"test-worker"');
+  it("should convert worker with D1 database", () => {
+    const input = JSON.stringify({
+      name: "d1-worker",
+      d1_databases: [
+        { binding: "DB", database_id: "db-id-123", database_name: "my-db" },
+      ],
     });
 
-    it("should handle file not found error", async () => {
-      const { exec } = await import("node:child_process");
-      const { promisify } = await import("node:util");
-      const execAsync = promisify(exec);
-      const nonExistentPath = path.join(testDir, "nonexistent.json");
+    const output = convertWranglerToAlchemy(input);
 
-      try {
-        await execAsync(`bun ${scriptPath} ${nonExistentPath}`);
-        expect.fail("Should have thrown an error");
-      } catch (error: any) {
-        expect(error.code).toBe(1);
-        expect(error.stderr).toContain("File not found");
-      }
-    });
-
-    it("should handle invalid JSON", async () => {
-      const invalidJsonPath = path.join(testDir, "invalid.json");
-      // Ensure directory exists first
-      await fs.mkdir(testDir, { recursive: true });
-      await fs.writeFile(invalidJsonPath, "{ invalid json");
-
-      const { exec } = await import("node:child_process");
-      const { promisify } = await import("node:util");
-      const execAsync = promisify(exec);
-
-      try {
-        await execAsync(`bun ${scriptPath} ${invalidJsonPath}`);
-        expect.fail("Should have thrown an error");
-      } catch (error: any) {
-        expect(error.stderr).toContain("Invalid JSON");
-      }
-    });
+    expect(output).toContain("D1Database");
+    expect(output).toContain('await D1Database("my-db"');
+    expect(output).toContain('name: "my-db"');
+    expect(output).toContain("DB: db");
   });
 
-  describe("generateImports", () => {
-    it("should generate basic imports", async () => {
-      const spec: WranglerJsonSpec = {
-        name: "basic-worker",
-      };
-
-      const content = await runConversion(spec, "basic");
-      expect(content).toContain('import alchemy from "alchemy"');
-      expect(content).toContain('import { Worker } from "alchemy/cloudflare"');
-    });
-
-    it("should include KV imports when KV namespaces are present", async () => {
-      const spec: WranglerJsonSpec = {
-        name: "kv-worker",
-        kv_namespaces: [{ binding: "MY_KV", id: "kv-id-123" }],
-      };
-
-      const content = await runConversion(spec, "kv");
-      expect(content).toContain("KVNamespace");
-      expect(content).toContain('await KVNamespace("MY_KV"');
-    });
-
-    it("should include R2 imports when R2 buckets are present", async () => {
-      const spec: WranglerJsonSpec = {
-        name: "r2-worker",
-        r2_buckets: [{ binding: "MY_BUCKET", bucket_name: "my-bucket" }],
-      };
-
-      const content = await runConversion(spec, "r2");
-      expect(content).toContain("R2Bucket");
-      expect(content).toContain('await R2Bucket("my-bucket"');
-    });
-
-    it("should include D1 imports when D1 databases are present", async () => {
-      const spec: WranglerJsonSpec = {
-        name: "d1-worker",
-        d1_databases: [
-          { binding: "DB", database_id: "db-id-123", database_name: "my-db" },
-        ],
-      };
-
-      const content = await runConversion(spec, "d1");
-      expect(content).toContain("D1Database");
-      expect(content).toContain('await D1Database("my-db"');
-    });
-
-    it("should include multiple imports when multiple binding types are present", async () => {
-      const spec: WranglerJsonSpec = {
-        name: "multi-worker",
-        kv_namespaces: [{ binding: "MY_KV", id: "kv-id-123" }],
-        r2_buckets: [{ binding: "MY_BUCKET", bucket_name: "my-bucket" }],
-        d1_databases: [
-          { binding: "DB", database_id: "db-id-123", database_name: "my-db" },
-        ],
-        ai: { binding: "AI" },
-      };
-
-      const content = await runConversion(spec, "multi");
-      expect(content).toContain(
-        "KVNamespace, R2Bucket, D1Database, Ai, Worker",
-      );
-      expect(content).toContain("MY_KV: my_kv");
-      expect(content).toContain("MY_BUCKET: my_bucket");
-      expect(content).toContain("DB: db");
-      expect(content).toContain("AI: ai");
-    });
-  });
-
-  describe("generateBindings", () => {
-    it("should generate durable object bindings correctly", async () => {
-      const spec: WranglerJsonSpec = {
-        name: "do-worker",
-        durable_objects: {
-          bindings: [
-            {
-              name: "MY_DO",
-              class_name: "MyDurableObject",
-              script_name: "do-script",
-              environment: "production",
-            },
-          ],
-        },
-      };
-
-      const content = await runConversion(spec, "do");
-      expect(content).toContain("DurableObjectNamespace");
-      expect(content).toContain('new DurableObjectNamespace("MY_DO"');
-      expect(content).toContain('className: "MyDurableObject"');
-      expect(content).toContain('scriptName: "do-script"');
-      expect(content).toContain('environment: "production"');
-    });
-
-    it("should generate queue bindings and event sources correctly", async () => {
-      const spec: WranglerJsonSpec = {
-        name: "queue-worker",
-        queues: {
-          producers: [{ binding: "MY_QUEUE", queue: "my-queue" }],
-          consumers: [{ queue: "my-queue", max_batch_size: 10 }],
-        },
-      };
-
-      const content = await runConversion(spec, "queue");
-      expect(content).toContain("Queue");
-      expect(content).toContain('await Queue("my-queue"');
-      expect(content).toContain("eventSources: [my_queue]");
-    });
-
-    it("should generate workflow bindings correctly", async () => {
-      const spec: WranglerJsonSpec = {
-        name: "workflow-worker",
-        workflows: [
+  it("should convert worker with durable objects", () => {
+    const input = JSON.stringify({
+      name: "do-worker",
+      durable_objects: {
+        bindings: [
           {
-            name: "my-workflow",
-            binding: "MY_WORKFLOW",
-            class_name: "MyWorkflow",
-            script_name: "workflow-script",
+            name: "MY_DO",
+            class_name: "MyDurableObject",
+            script_name: "do-script",
+            environment: "production",
           },
         ],
-      };
-
-      const content = await runConversion(spec, "workflow");
-      expect(content).toContain("Workflow");
-      expect(content).toContain('new Workflow("my-workflow"');
-      expect(content).toContain('className: "MyWorkflow"');
-      expect(content).toContain('workflowName: "my-workflow"');
-      expect(content).toContain('scriptName: "workflow-script"');
+      },
     });
+
+    const output = convertWranglerToAlchemy(input);
+
+    expect(output).toContain("DurableObjectNamespace");
+    expect(output).toContain('new DurableObjectNamespace("MY_DO"');
+    expect(output).toContain('className: "MyDurableObject"');
+    expect(output).toContain('scriptName: "do-script"');
+    expect(output).toContain('environment: "production"');
+    expect(output).toContain("MY_DO: my_do");
   });
 
-  describe("generateWorkerConfig", () => {
-    it("should generate basic worker configuration", async () => {
-      const spec: WranglerJsonSpec = {
-        name: "basic-worker",
+  it("should convert worker with queues", () => {
+    const input = JSON.stringify({
+      name: "queue-worker",
+      queues: {
+        producers: [{ binding: "MY_QUEUE", queue: "my-queue" }],
+        consumers: [{ queue: "my-queue", max_batch_size: 10 }],
+      },
+    });
+
+    const output = convertWranglerToAlchemy(input);
+
+    expect(output).toContain("Queue");
+    expect(output).toContain('await Queue("my-queue"');
+    expect(output).toContain('name: "my-queue"');
+    expect(output).toContain("MY_QUEUE: my_queue");
+    expect(output).toContain("eventSources: [my_queue]");
+  });
+
+  it("should convert worker with workflows", () => {
+    const input = JSON.stringify({
+      name: "workflow-worker",
+      workflows: [
+        {
+          name: "my-workflow",
+          binding: "MY_WORKFLOW",
+          class_name: "MyWorkflow",
+          script_name: "workflow-script",
+        },
+      ],
+    });
+
+    const output = convertWranglerToAlchemy(input);
+
+    expect(output).toContain("Workflow");
+    expect(output).toContain('new Workflow("my-workflow"');
+    expect(output).toContain('className: "MyWorkflow"');
+    expect(output).toContain('workflowName: "my-workflow"');
+    expect(output).toContain('scriptName: "workflow-script"');
+    expect(output).toContain("MY_WORKFLOW: my_workflow");
+  });
+
+  it("should convert worker with AI binding", () => {
+    const input = JSON.stringify({
+      name: "ai-worker",
+      ai: { binding: "AI" },
+    });
+
+    const output = convertWranglerToAlchemy(input);
+
+    expect(output).toContain("Ai");
+    expect(output).toContain("export const ai = new Ai();");
+    expect(output).toContain("AI: ai");
+  });
+
+  it("should convert worker with browser binding", () => {
+    const input = JSON.stringify({
+      name: "browser-worker",
+      browser: { binding: "BROWSER" },
+    });
+
+    const output = convertWranglerToAlchemy(input);
+
+    expect(output).toContain("BrowserRendering");
+    expect(output).toContain(
+      'export const browser = { type: "browser" as const }',
+    );
+    expect(output).toContain("BROWSER: browser");
+  });
+
+  it("should convert worker with images binding", () => {
+    const input = JSON.stringify({
+      name: "images-worker",
+      images: { binding: "IMAGES" },
+    });
+
+    const output = convertWranglerToAlchemy(input);
+
+    expect(output).toContain("Images");
+    expect(output).toContain(
+      'export const images = { type: "images" as const }',
+    );
+    expect(output).toContain("IMAGES: images");
+  });
+
+  it("should convert worker with version metadata binding", () => {
+    const input = JSON.stringify({
+      name: "version-worker",
+      version_metadata: { binding: "VERSION" },
+    });
+
+    const output = convertWranglerToAlchemy(input);
+
+    expect(output).toContain("VersionMetadata");
+    expect(output).toContain(
+      'export const versionMetadata = { type: "version_metadata" as const }',
+    );
+    expect(output).toContain("VERSION: versionMetadata");
+  });
+
+  it("should convert worker with hyperdrive", () => {
+    const input = JSON.stringify({
+      name: "hyperdrive-worker",
+      hyperdrive: [
+        {
+          binding: "HYPERDRIVE",
+          id: "hyperdrive-id-123",
+          localConnectionString: "postgres://user:password@localhost:5432/mydb",
+        },
+      ],
+    });
+
+    const output = convertWranglerToAlchemy(input);
+
+    expect(output).toContain('import { secret } from "alchemy";');
+    expect(output).toContain("Hyperdrive");
+    expect(output).toContain('await Hyperdrive("hyperdrive-id-123"');
+    expect(output).toContain('scheme: "postgres"');
+    expect(output).toContain('host: "localhost"');
+    expect(output).toContain("port: 5432");
+    expect(output).toContain('database: "mydb"');
+    expect(output).toContain('user: "user"');
+    expect(output).toContain('password: secret("USER_PASSWORD")');
+  });
+
+  it("should convert worker with vectorize", () => {
+    const input = JSON.stringify({
+      name: "vectorize-worker",
+      vectorize: [{ binding: "VECTORIZE", index_name: "my-index" }],
+    });
+
+    const output = convertWranglerToAlchemy(input);
+
+    expect(output).toContain("VectorizeIndex");
+    expect(output).toContain('await VectorizeIndex("my-index"');
+    expect(output).toContain('name: "my-index"');
+    expect(output).toContain("VECTORIZE: vectorize");
+  });
+
+  it("should convert worker with environment variables", () => {
+    const input = JSON.stringify({
+      name: "env-worker",
+      vars: {
+        API_URL: "https://api.example.com",
+        DEBUG: "true",
+      },
+    });
+
+    const output = convertWranglerToAlchemy(input);
+
+    expect(output).toContain('"API_URL": "https://api.example.com"');
+    expect(output).toContain('"DEBUG": "true"');
+    expect(output).toContain("env: {");
+  });
+
+  it("should convert worker with cron triggers", () => {
+    const input = JSON.stringify({
+      name: "cron-worker",
+      triggers: {
+        crons: ["0 0 * * *", "0 12 * * *"],
+      },
+    });
+
+    const output = convertWranglerToAlchemy(input);
+
+    expect(output).toContain('crons: ["0 0 * * *","0 12 * * *"]');
+  });
+
+  it("should convert worker with routes", () => {
+    const input = JSON.stringify({
+      name: "route-worker",
+      routes: ["example.com/*", "*.example.com/api/*"],
+    });
+
+    const output = convertWranglerToAlchemy(input);
+
+    expect(output).toContain("Route");
+    expect(output).toContain("// Routes");
+    expect(output).toContain('await Route("route-0"');
+    expect(output).toContain('pattern: "example.com/*"');
+    expect(output).toContain('await Route("route-1"');
+    expect(output).toContain('pattern: "*.example.com/api/*"');
+  });
+
+  it("should convert worker with compatibility flags", () => {
+    const input = JSON.stringify({
+      name: "compat-worker",
+      compatibility_flags: ["nodejs_compat", "experimental_flag"],
+    });
+
+    const output = convertWranglerToAlchemy(input);
+
+    expect(output).toContain(
+      'compatibilityFlags: ["nodejs_compat","experimental_flag"]',
+    );
+  });
+
+  it("should convert worker with workers_dev", () => {
+    const input = JSON.stringify({
+      name: "dev-worker",
+      workers_dev: true,
+    });
+
+    const output = convertWranglerToAlchemy(input);
+
+    expect(output).toContain("url: true");
+  });
+
+  it("should convert complex worker with multiple bindings", () => {
+    const input = JSON.stringify({
+      name: "complex-worker",
+      main: "src/index.ts",
+      compatibility_date: "2023-12-01",
+      compatibility_flags: ["nodejs_compat"],
+      workers_dev: true,
+      kv_namespaces: [{ binding: "CACHE", id: "kv-cache-123" }],
+      r2_buckets: [{ binding: "STORAGE", bucket_name: "my-storage" }],
+      d1_databases: [
+        { binding: "DB", database_id: "db-123", database_name: "my-db" },
+      ],
+      ai: { binding: "AI" },
+      vars: {
+        API_URL: "https://api.example.com",
+        ENV: "production",
+      },
+      triggers: {
+        crons: ["0 */6 * * *"],
+      },
+      routes: ["*.example.com/*"],
+    });
+
+    const output = convertWranglerToAlchemy(input);
+
+    // Check imports
+    expect(output).toContain('import alchemy from "alchemy";');
+    expect(output).toContain(
+      "Ai, D1Database, KVNamespace, R2Bucket, Route, Worker",
+    );
+
+    // Check app initialization
+    expect(output).toContain('const app = await alchemy("complex-worker"');
+
+    // Check resources
+    expect(output).toContain("// Resources");
+    expect(output).toContain('await KVNamespace("CACHE"');
+    expect(output).toContain('await R2Bucket("my-storage"');
+    expect(output).toContain('await D1Database("my-db"');
+    expect(output).toContain("export const ai = new Ai();");
+
+    // Check worker config
+    expect(output).toContain("// Worker");
+    expect(output).toContain('await Worker("complex-worker"');
+    expect(output).toContain('entrypoint: "src/index.ts"');
+    expect(output).toContain('compatibilityDate: "2023-12-01"');
+    expect(output).toContain('compatibilityFlags: ["nodejs_compat"]');
+    expect(output).toContain("url: true");
+    expect(output).toContain("CACHE: cache");
+    expect(output).toContain("STORAGE: storage");
+    expect(output).toContain("DB: db");
+    expect(output).toContain("AI: ai");
+    expect(output).toContain('"API_URL": "https://api.example.com"');
+    expect(output).toContain('"ENV": "production"');
+    expect(output).toContain('crons: ["0 */6 * * *"]');
+
+    // Check routes
+    expect(output).toContain("// Routes");
+    expect(output).toContain('pattern: "*.example.com/*"');
+
+    // Check finalization
+    expect(output).toContain("console.log(worker.url);");
+    expect(output).toContain("await app.finalize();");
+  });
+
+  describe("error handling", () => {
+    it("should throw error for invalid JSON", () => {
+      const input = "{ invalid json";
+
+      expect(() => convertWranglerToAlchemy(input)).toThrow("Invalid JSON");
+    });
+
+    it("should throw error for missing name field", () => {
+      const input = JSON.stringify({
         main: "src/index.ts",
-        compatibility_date: "2023-12-01",
-        compatibility_flags: ["nodejs_compat"],
-        workers_dev: true,
-      };
+      });
 
-      const testFilePath = path.join(testDir, "worker-wrangler.json");
-      const outputPath = path.join(testDir, "worker-alchemy.run.ts");
-      await fs.writeFile(testFilePath, JSON.stringify(spec));
-
-      const { exec } = await import("node:child_process");
-      const { promisify } = await import("node:util");
-      const execAsync = promisify(exec);
-
-      await execAsync(`bun ${scriptPath} ${testFilePath} ${outputPath}`);
-
-      const content = await fs.readFile(outputPath, "utf-8");
-      expect(content).toContain('await Worker("basic-worker"');
-      expect(content).toContain('entrypoint: "src/index.ts"');
-      expect(content).toContain('compatibilityDate: "2023-12-01"');
-      expect(content).toContain('compatibilityFlags: ["nodejs_compat"]');
-      expect(content).toContain("url: true");
-      expect(content).toContain("adopt: true");
-    });
-
-    it("should include environment variables", async () => {
-      const spec: WranglerJsonSpec = {
-        name: "env-worker",
-        vars: {
-          API_URL: "https://api.example.com",
-          DEBUG: "true",
-        },
-      };
-
-      const testFilePath = path.join(testDir, "env-wrangler.json");
-      const outputPath = path.join(testDir, "env-alchemy.run.ts");
-      await fs.writeFile(testFilePath, JSON.stringify(spec));
-
-      const { exec } = await import("node:child_process");
-      const { promisify } = await import("node:util");
-      const execAsync = promisify(exec);
-
-      await execAsync(`bun ${scriptPath} ${testFilePath} ${outputPath}`);
-
-      const content = await fs.readFile(outputPath, "utf-8");
-      expect(content).toContain('"API_URL": "https://api.example.com"');
-      expect(content).toContain('"DEBUG": "true"');
-    });
-
-    it("should include cron triggers", async () => {
-      const spec: WranglerJsonSpec = {
-        name: "cron-worker",
-        triggers: {
-          crons: ["0 0 * * *", "0 12 * * *"],
-        },
-      };
-
-      const testFilePath = path.join(testDir, "cron-wrangler.json");
-      const outputPath = path.join(testDir, "cron-alchemy.run.ts");
-      await fs.writeFile(testFilePath, JSON.stringify(spec));
-
-      const { exec } = await import("node:child_process");
-      const { promisify } = await import("node:util");
-      const execAsync = promisify(exec);
-
-      await execAsync(`bun ${scriptPath} ${testFilePath} ${outputPath}`);
-
-      const content = await fs.readFile(outputPath, "utf-8");
-      expect(content).toContain('crons: ["0 0 * * *","0 12 * * *"]');
-    });
-  });
-
-  describe("hyperdrive bindings", () => {
-    it("should generate hyperdrive bindings with secret import", async () => {
-      const spec: WranglerJsonSpec = {
-        name: "hyperdrive-worker",
-        hyperdrive: [
-          {
-            binding: "HYPERDRIVE",
-            id: "hyperdrive-id-123",
-            localConnectionString:
-              "postgres://user:password@localhost:5432/mydb",
-          },
-        ],
-      };
-
-      const testFilePath = path.join(testDir, "hyperdrive-wrangler.json");
-      const outputPath = path.join(testDir, "hyperdrive-alchemy.run.ts");
-      await fs.writeFile(testFilePath, JSON.stringify(spec));
-
-      const { exec } = await import("node:child_process");
-      const { promisify } = await import("node:util");
-      const execAsync = promisify(exec);
-
-      await execAsync(`bun ${scriptPath} ${testFilePath} ${outputPath}`);
-
-      const content = await fs.readFile(outputPath, "utf-8");
-      expect(content).toContain('import { secret } from "alchemy"');
-      expect(content).toContain("Hyperdrive");
-      expect(content).toContain('await Hyperdrive("hyperdrive-id-123"');
-      expect(content).toContain('scheme: "postgres"');
-      expect(content).toContain('host: "localhost"');
-      expect(content).toContain("port: 5432");
-      expect(content).toContain('database: "mydb"');
-      expect(content).toContain('user: "user"');
-      expect(content).toContain('password: secret("USER_PASSWORD")');
-    });
-  });
-
-  describe("routes handling", () => {
-    it("should generate routes when present", async () => {
-      const spec: WranglerJsonSpec = {
-        name: "route-worker",
-        routes: ["example.com/*", "*.example.com/api/*"],
-      };
-
-      const testFilePath = path.join(testDir, "route-wrangler.json");
-      const outputPath = path.join(testDir, "route-alchemy.run.ts");
-      await fs.writeFile(testFilePath, JSON.stringify(spec));
-
-      const { exec } = await import("node:child_process");
-      const { promisify } = await import("node:util");
-      const execAsync = promisify(exec);
-
-      await execAsync(`bun ${scriptPath} ${testFilePath} ${outputPath}`);
-
-      const content = await fs.readFile(outputPath, "utf-8");
-      expect(content).toContain("// Routes");
-      expect(content).toContain('await Route("route-0"');
-      expect(content).toContain('pattern: "example.com/*"');
-      expect(content).toContain('await Route("route-1"');
-      expect(content).toContain('pattern: "*.example.com/api/*"');
-    });
-  });
-
-  describe("complete conversion", () => {
-    it("should generate a complete alchemy.run.ts file", async () => {
-      const spec: WranglerJsonSpec = {
-        name: "complete-worker",
-        main: "src/index.ts",
-        compatibility_date: "2023-12-01",
-        compatibility_flags: ["nodejs_compat"],
-        workers_dev: true,
-        kv_namespaces: [{ binding: "CACHE", id: "kv-cache-123" }],
-        vars: {
-          API_URL: "https://api.example.com",
-        },
-        triggers: {
-          crons: ["0 */6 * * *"],
-        },
-        routes: ["*.example.com/*"],
-      };
-
-      const content = await runConversion(spec, "complete");
-
-      // Check structure
-      expect(content).toContain('import alchemy from "alchemy"');
-      expect(content).toContain(
-        'import { KVNamespace, Worker } from "alchemy/cloudflare"',
+      expect(() => convertWranglerToAlchemy(input)).toThrow(
+        "wrangler.json must have a 'name' field",
       );
-      expect(content).toContain('const app = await alchemy("complete-worker"');
-      expect(content).toContain("// Resources");
-      expect(content).toContain("// Worker");
-      expect(content).toContain("// Routes");
-      expect(content).toContain("console.log(worker.url)");
-      expect(content).toContain("await app.finalize()");
-
-      // Check specific configurations
-      expect(content).toContain('await KVNamespace("CACHE"');
-      expect(content).toContain("CACHE: cache");
-      expect(content).toContain('"API_URL": "https://api.example.com"');
-      expect(content).toContain('crons: ["0 */6 * * *"]');
-      expect(content).toContain('pattern: "*.example.com/*"');
     });
-  });
 
-  describe("edge cases", () => {
-    it("should handle empty wrangler.json", async () => {
-      const spec: WranglerJsonSpec = {
+    it("should handle empty JSON object", () => {
+      const input = JSON.stringify({
         name: "empty-worker",
-      };
+      });
 
-      const content = await runConversion(spec, "empty");
-      expect(content).toContain('const app = await alchemy("empty-worker"');
-      expect(content).toContain('await Worker("empty-worker"');
-      expect(content).toContain("adopt: true");
-    });
+      const output = convertWranglerToAlchemy(input);
 
-    it("should handle special binding types like AI, Browser, Images", async () => {
-      const spec: WranglerJsonSpec = {
-        name: "special-worker",
-        ai: { binding: "AI" },
-        browser: { binding: "BROWSER" },
-        images: { binding: "IMAGES" },
-        version_metadata: { binding: "VERSION" },
-      };
-
-      const testFilePath = path.join(testDir, "special-wrangler.json");
-      const outputPath = path.join(testDir, "special-alchemy.run.ts");
-      await fs.writeFile(testFilePath, JSON.stringify(spec));
-
-      const { exec } = await import("node:child_process");
-      const { promisify } = await import("node:util");
-      const execAsync = promisify(exec);
-
-      await execAsync(`bun ${scriptPath} ${testFilePath} ${outputPath}`);
-
-      const content = await fs.readFile(outputPath, "utf-8");
-      expect(content).toContain(
-        "Ai, BrowserRendering, Images, VersionMetadata",
-      );
-      expect(content).toContain("export const ai = new Ai()");
-      expect(content).toContain(
-        'export const browser = { type: "browser" as const }',
-      );
-      expect(content).toContain(
-        'export const images = { type: "images" as const }',
-      );
-      expect(content).toContain(
-        'export const versionMetadata = { type: "version_metadata" as const }',
-      );
+      expect(output).toContain('const app = await alchemy("empty-worker"');
+      expect(output).toContain('await Worker("empty-worker"');
+      expect(output).toContain("adopt: true");
+      expect(output).toContain("await app.finalize();");
     });
   });
 });

--- a/alchemy/test/scripts/wrangler-to-alchemy.test.ts
+++ b/alchemy/test/scripts/wrangler-to-alchemy.test.ts
@@ -11,15 +11,25 @@ describe("wrangler-to-alchemy conversion", () => {
 
     const output = convertWranglerToAlchemy(input);
 
-    expect(output).toContain('import alchemy from "alchemy";');
-    expect(output).toContain('import { Worker } from "alchemy/cloudflare";');
-    expect(output).toContain('const app = await alchemy("my-worker"');
-    expect(output).toContain('await Worker("my-worker"');
-    expect(output).toContain('entrypoint: "src/index.ts"');
-    expect(output).toContain('compatibilityDate: "2023-12-01"');
-    expect(output).toContain("adopt: true");
-    expect(output).toContain("console.log(worker.url);");
-    expect(output).toContain("await app.finalize();");
+    const expectedOutput = `import alchemy from "alchemy";
+import { Worker } from "alchemy/cloudflare";
+
+const app = await alchemy("my-worker", {
+  // Configure your app here
+});
+
+// Worker
+export const worker = await Worker("my-worker", {
+  entrypoint: "src/index.ts",
+  compatibilityDate: "2023-12-01",
+  adopt: true,
+});
+
+console.log(worker.url);
+
+await app.finalize();`;
+
+    expect(output).toBe(expectedOutput);
   });
 
   it("should convert worker with KV namespace", () => {
@@ -30,11 +40,32 @@ describe("wrangler-to-alchemy conversion", () => {
 
     const output = convertWranglerToAlchemy(input);
 
-    expect(output).toContain("KVNamespace");
-    expect(output).toContain('await KVNamespace("MY_KV"');
-    expect(output).toContain('title: "MY_KV"');
-    expect(output).toContain("MY_KV: my_kv");
-    expect(output).toContain("// Resources");
+    const expectedOutput = `import alchemy from "alchemy";
+import { KVNamespace, Worker } from "alchemy/cloudflare";
+
+const app = await alchemy("kv-worker", {
+  // Configure your app here
+});
+
+// Resources
+export const my_kv = await KVNamespace("MY_KV", {
+  title: "MY_KV",
+  adopt: true,
+});
+
+// Worker
+export const worker = await Worker("kv-worker", {
+  bindings: {
+    MY_KV: my_kv,
+  },
+  adopt: true,
+});
+
+console.log(worker.url);
+
+await app.finalize();`;
+
+    expect(output).toBe(expectedOutput);
   });
 
   it("should convert worker with R2 bucket", () => {
@@ -45,10 +76,32 @@ describe("wrangler-to-alchemy conversion", () => {
 
     const output = convertWranglerToAlchemy(input);
 
-    expect(output).toContain("R2Bucket");
-    expect(output).toContain('await R2Bucket("my-bucket"');
-    expect(output).toContain('name: "my-bucket"');
-    expect(output).toContain("MY_BUCKET: my_bucket");
+    const expectedOutput = `import alchemy from "alchemy";
+import { R2Bucket, Worker } from "alchemy/cloudflare";
+
+const app = await alchemy("r2-worker", {
+  // Configure your app here
+});
+
+// Resources
+export const my_bucket = await R2Bucket("my-bucket", {
+  name: "my-bucket",
+  adopt: true,
+});
+
+// Worker
+export const worker = await Worker("r2-worker", {
+  bindings: {
+    MY_BUCKET: my_bucket,
+  },
+  adopt: true,
+});
+
+console.log(worker.url);
+
+await app.finalize();`;
+
+    expect(output).toBe(expectedOutput);
   });
 
   it("should convert worker with D1 database", () => {
@@ -61,10 +114,32 @@ describe("wrangler-to-alchemy conversion", () => {
 
     const output = convertWranglerToAlchemy(input);
 
-    expect(output).toContain("D1Database");
-    expect(output).toContain('await D1Database("my-db"');
-    expect(output).toContain('name: "my-db"');
-    expect(output).toContain("DB: db");
+    const expectedOutput = `import alchemy from "alchemy";
+import { D1Database, Worker } from "alchemy/cloudflare";
+
+const app = await alchemy("d1-worker", {
+  // Configure your app here
+});
+
+// Resources
+export const db = await D1Database("my-db", {
+  name: "my-db",
+  adopt: true,
+});
+
+// Worker
+export const worker = await Worker("d1-worker", {
+  bindings: {
+    DB: db,
+  },
+  adopt: true,
+});
+
+console.log(worker.url);
+
+await app.finalize();`;
+
+    expect(output).toBe(expectedOutput);
   });
 
   it("should convert worker with durable objects", () => {
@@ -84,12 +159,33 @@ describe("wrangler-to-alchemy conversion", () => {
 
     const output = convertWranglerToAlchemy(input);
 
-    expect(output).toContain("DurableObjectNamespace");
-    expect(output).toContain('new DurableObjectNamespace("MY_DO"');
-    expect(output).toContain('className: "MyDurableObject"');
-    expect(output).toContain('scriptName: "do-script"');
-    expect(output).toContain('environment: "production"');
-    expect(output).toContain("MY_DO: my_do");
+    const expectedOutput = `import alchemy from "alchemy";
+import { DurableObjectNamespace, Worker } from "alchemy/cloudflare";
+
+const app = await alchemy("do-worker", {
+  // Configure your app here
+});
+
+// Resources
+export const my_do = new DurableObjectNamespace("MY_DO", {
+  className: "MyDurableObject",
+  scriptName: "do-script",
+  environment: "production",
+});
+
+// Worker
+export const worker = await Worker("do-worker", {
+  bindings: {
+    MY_DO: my_do,
+  },
+  adopt: true,
+});
+
+console.log(worker.url);
+
+await app.finalize();`;
+
+    expect(output).toBe(expectedOutput);
   });
 
   it("should convert worker with queues", () => {
@@ -103,11 +199,33 @@ describe("wrangler-to-alchemy conversion", () => {
 
     const output = convertWranglerToAlchemy(input);
 
-    expect(output).toContain("Queue");
-    expect(output).toContain('await Queue("my-queue"');
-    expect(output).toContain('name: "my-queue"');
-    expect(output).toContain("MY_QUEUE: my_queue");
-    expect(output).toContain("eventSources: [my_queue]");
+    const expectedOutput = `import alchemy from "alchemy";
+import { Queue, Worker } from "alchemy/cloudflare";
+
+const app = await alchemy("queue-worker", {
+  // Configure your app here
+});
+
+// Resources
+export const my_queue = await Queue("my-queue", {
+  name: "my-queue",
+  adopt: true,
+});
+
+// Worker
+export const worker = await Worker("queue-worker", {
+  bindings: {
+    MY_QUEUE: my_queue,
+  },
+  eventSources: [my_queue],
+  adopt: true,
+});
+
+console.log(worker.url);
+
+await app.finalize();`;
+
+    expect(output).toBe(expectedOutput);
   });
 
   it("should convert worker with workflows", () => {
@@ -125,12 +243,33 @@ describe("wrangler-to-alchemy conversion", () => {
 
     const output = convertWranglerToAlchemy(input);
 
-    expect(output).toContain("Workflow");
-    expect(output).toContain('new Workflow("my-workflow"');
-    expect(output).toContain('className: "MyWorkflow"');
-    expect(output).toContain('workflowName: "my-workflow"');
-    expect(output).toContain('scriptName: "workflow-script"');
-    expect(output).toContain("MY_WORKFLOW: my_workflow");
+    const expectedOutput = `import alchemy from "alchemy";
+import { Worker, Workflow } from "alchemy/cloudflare";
+
+const app = await alchemy("workflow-worker", {
+  // Configure your app here
+});
+
+// Resources
+export const my_workflow = new Workflow("my-workflow", {
+  className: "MyWorkflow",
+  workflowName: "my-workflow",
+  scriptName: "workflow-script",
+});
+
+// Worker
+export const worker = await Worker("workflow-worker", {
+  bindings: {
+    MY_WORKFLOW: my_workflow,
+  },
+  adopt: true,
+});
+
+console.log(worker.url);
+
+await app.finalize();`;
+
+    expect(output).toBe(expectedOutput);
   });
 
   it("should convert worker with AI binding", () => {
@@ -141,9 +280,29 @@ describe("wrangler-to-alchemy conversion", () => {
 
     const output = convertWranglerToAlchemy(input);
 
-    expect(output).toContain("Ai");
-    expect(output).toContain("export const ai = new Ai();");
-    expect(output).toContain("AI: ai");
+    const expectedOutput = `import alchemy from "alchemy";
+import { Ai, Worker } from "alchemy/cloudflare";
+
+const app = await alchemy("ai-worker", {
+  // Configure your app here
+});
+
+// Resources
+export const ai = new Ai();
+
+// Worker
+export const worker = await Worker("ai-worker", {
+  bindings: {
+    AI: ai,
+  },
+  adopt: true,
+});
+
+console.log(worker.url);
+
+await app.finalize();`;
+
+    expect(output).toBe(expectedOutput);
   });
 
   it("should convert worker with browser binding", () => {
@@ -154,11 +313,29 @@ describe("wrangler-to-alchemy conversion", () => {
 
     const output = convertWranglerToAlchemy(input);
 
-    expect(output).toContain("BrowserRendering");
-    expect(output).toContain(
-      'export const browser = { type: "browser" as const }',
-    );
-    expect(output).toContain("BROWSER: browser");
+    const expectedOutput = `import alchemy from "alchemy";
+import { BrowserRendering, Worker } from "alchemy/cloudflare";
+
+const app = await alchemy("browser-worker", {
+  // Configure your app here
+});
+
+// Resources
+export const browser = { type: "browser" as const };
+
+// Worker
+export const worker = await Worker("browser-worker", {
+  bindings: {
+    BROWSER: browser,
+  },
+  adopt: true,
+});
+
+console.log(worker.url);
+
+await app.finalize();`;
+
+    expect(output).toBe(expectedOutput);
   });
 
   it("should convert worker with images binding", () => {
@@ -169,11 +346,29 @@ describe("wrangler-to-alchemy conversion", () => {
 
     const output = convertWranglerToAlchemy(input);
 
-    expect(output).toContain("Images");
-    expect(output).toContain(
-      'export const images = { type: "images" as const }',
-    );
-    expect(output).toContain("IMAGES: images");
+    const expectedOutput = `import alchemy from "alchemy";
+import { Images, Worker } from "alchemy/cloudflare";
+
+const app = await alchemy("images-worker", {
+  // Configure your app here
+});
+
+// Resources
+export const images = { type: "images" as const };
+
+// Worker
+export const worker = await Worker("images-worker", {
+  bindings: {
+    IMAGES: images,
+  },
+  adopt: true,
+});
+
+console.log(worker.url);
+
+await app.finalize();`;
+
+    expect(output).toBe(expectedOutput);
   });
 
   it("should convert worker with version metadata binding", () => {
@@ -184,11 +379,29 @@ describe("wrangler-to-alchemy conversion", () => {
 
     const output = convertWranglerToAlchemy(input);
 
-    expect(output).toContain("VersionMetadata");
-    expect(output).toContain(
-      'export const versionMetadata = { type: "version_metadata" as const }',
-    );
-    expect(output).toContain("VERSION: versionMetadata");
+    const expectedOutput = `import alchemy from "alchemy";
+import { VersionMetadata, Worker } from "alchemy/cloudflare";
+
+const app = await alchemy("version-worker", {
+  // Configure your app here
+});
+
+// Resources
+export const versionMetadata = { type: "version_metadata" as const };
+
+// Worker
+export const worker = await Worker("version-worker", {
+  bindings: {
+    VERSION: versionMetadata,
+  },
+  adopt: true,
+});
+
+console.log(worker.url);
+
+await app.finalize();`;
+
+    expect(output).toBe(expectedOutput);
   });
 
   it("should convert worker with hyperdrive", () => {
@@ -205,15 +418,42 @@ describe("wrangler-to-alchemy conversion", () => {
 
     const output = convertWranglerToAlchemy(input);
 
-    expect(output).toContain('import { secret } from "alchemy";');
-    expect(output).toContain("Hyperdrive");
-    expect(output).toContain('await Hyperdrive("hyperdrive-id-123"');
-    expect(output).toContain('scheme: "postgres"');
-    expect(output).toContain('host: "localhost"');
-    expect(output).toContain("port: 5432");
-    expect(output).toContain('database: "mydb"');
-    expect(output).toContain('user: "user"');
-    expect(output).toContain('password: secret("USER_PASSWORD")');
+    const expectedOutput = `import alchemy from "alchemy";
+import { Hyperdrive, Worker } from "alchemy/cloudflare";
+
+import { secret } from "alchemy";
+
+const app = await alchemy("hyperdrive-worker", {
+  // Configure your app here
+});
+
+// Resources
+export const hyperdrive = await Hyperdrive("hyperdrive-id-123", {
+  name: "hyperdrive-id-123",
+  origin: {
+    scheme: "postgres",
+    host: "localhost",
+    port: 5432,
+    database: "mydb",
+    user: "user",
+    password: secret("USER_PASSWORD"),
+  },
+  adopt: true,
+});
+
+// Worker
+export const worker = await Worker("hyperdrive-worker", {
+  bindings: {
+    HYPERDRIVE: hyperdrive,
+  },
+  adopt: true,
+});
+
+console.log(worker.url);
+
+await app.finalize();`;
+
+    expect(output).toBe(expectedOutput);
   });
 
   it("should convert worker with vectorize", () => {
@@ -224,10 +464,32 @@ describe("wrangler-to-alchemy conversion", () => {
 
     const output = convertWranglerToAlchemy(input);
 
-    expect(output).toContain("VectorizeIndex");
-    expect(output).toContain('await VectorizeIndex("my-index"');
-    expect(output).toContain('name: "my-index"');
-    expect(output).toContain("VECTORIZE: vectorize");
+    const expectedOutput = `import alchemy from "alchemy";
+import { VectorizeIndex, Worker } from "alchemy/cloudflare";
+
+const app = await alchemy("vectorize-worker", {
+  // Configure your app here
+});
+
+// Resources
+export const vectorize = await VectorizeIndex("my-index", {
+  name: "my-index",
+  adopt: true,
+});
+
+// Worker
+export const worker = await Worker("vectorize-worker", {
+  bindings: {
+    VECTORIZE: vectorize,
+  },
+  adopt: true,
+});
+
+console.log(worker.url);
+
+await app.finalize();`;
+
+    expect(output).toBe(expectedOutput);
   });
 
   it("should convert worker with environment variables", () => {
@@ -241,9 +503,27 @@ describe("wrangler-to-alchemy conversion", () => {
 
     const output = convertWranglerToAlchemy(input);
 
-    expect(output).toContain('"API_URL": "https://api.example.com"');
-    expect(output).toContain('"DEBUG": "true"');
-    expect(output).toContain("env: {");
+    const expectedOutput = `import alchemy from "alchemy";
+import { Worker } from "alchemy/cloudflare";
+
+const app = await alchemy("env-worker", {
+  // Configure your app here
+});
+
+// Worker
+export const worker = await Worker("env-worker", {
+  env: {
+      "API_URL": "https://api.example.com",
+      "DEBUG": "true"
+  },
+  adopt: true,
+});
+
+console.log(worker.url);
+
+await app.finalize();`;
+
+    expect(output).toBe(expectedOutput);
   });
 
   it("should convert worker with cron triggers", () => {
@@ -256,7 +536,24 @@ describe("wrangler-to-alchemy conversion", () => {
 
     const output = convertWranglerToAlchemy(input);
 
-    expect(output).toContain('crons: ["0 0 * * *","0 12 * * *"]');
+    const expectedOutput = `import alchemy from "alchemy";
+import { Worker } from "alchemy/cloudflare";
+
+const app = await alchemy("cron-worker", {
+  // Configure your app here
+});
+
+// Worker
+export const worker = await Worker("cron-worker", {
+  crons: ["0 0 * * *","0 12 * * *"],
+  adopt: true,
+});
+
+console.log(worker.url);
+
+await app.finalize();`;
+
+    expect(output).toBe(expectedOutput);
   });
 
   it("should convert worker with routes", () => {
@@ -267,12 +564,33 @@ describe("wrangler-to-alchemy conversion", () => {
 
     const output = convertWranglerToAlchemy(input);
 
-    expect(output).toContain("Route");
-    expect(output).toContain("// Routes");
-    expect(output).toContain('await Route("route-0"');
-    expect(output).toContain('pattern: "example.com/*"');
-    expect(output).toContain('await Route("route-1"');
-    expect(output).toContain('pattern: "*.example.com/api/*"');
+    const expectedOutput = `import alchemy from "alchemy";
+import { Route, Worker } from "alchemy/cloudflare";
+
+const app = await alchemy("route-worker", {
+  // Configure your app here
+});
+
+// Worker
+export const worker = await Worker("route-worker", {
+  adopt: true,
+});
+
+// Routes
+await Route("route-0", {
+  pattern: "example.com/*",
+  worker,
+});
+await Route("route-1", {
+  pattern: "*.example.com/api/*",
+  worker,
+});
+
+console.log(worker.url);
+
+await app.finalize();`;
+
+    expect(output).toBe(expectedOutput);
   });
 
   it("should convert worker with compatibility flags", () => {
@@ -283,9 +601,24 @@ describe("wrangler-to-alchemy conversion", () => {
 
     const output = convertWranglerToAlchemy(input);
 
-    expect(output).toContain(
-      'compatibilityFlags: ["nodejs_compat","experimental_flag"]',
-    );
+    const expectedOutput = `import alchemy from "alchemy";
+import { Worker } from "alchemy/cloudflare";
+
+const app = await alchemy("compat-worker", {
+  // Configure your app here
+});
+
+// Worker
+export const worker = await Worker("compat-worker", {
+  compatibilityFlags: ["nodejs_compat","experimental_flag"],
+  adopt: true,
+});
+
+console.log(worker.url);
+
+await app.finalize();`;
+
+    expect(output).toBe(expectedOutput);
   });
 
   it("should convert worker with workers_dev", () => {
@@ -296,7 +629,24 @@ describe("wrangler-to-alchemy conversion", () => {
 
     const output = convertWranglerToAlchemy(input);
 
-    expect(output).toContain("url: true");
+    const expectedOutput = `import alchemy from "alchemy";
+import { Worker } from "alchemy/cloudflare";
+
+const app = await alchemy("dev-worker", {
+  // Configure your app here
+});
+
+// Worker
+export const worker = await Worker("dev-worker", {
+  url: true,
+  adopt: true,
+});
+
+console.log(worker.url);
+
+await app.finalize();`;
+
+    expect(output).toBe(expectedOutput);
   });
 
   it("should convert complex worker with multiple bindings", () => {
@@ -324,44 +674,59 @@ describe("wrangler-to-alchemy conversion", () => {
 
     const output = convertWranglerToAlchemy(input);
 
-    // Check imports
-    expect(output).toContain('import alchemy from "alchemy";');
-    expect(output).toContain(
-      "Ai, D1Database, KVNamespace, R2Bucket, Route, Worker",
-    );
+    const expectedOutput = `import alchemy from "alchemy";
+import { Ai, D1Database, KVNamespace, R2Bucket, Route, Worker } from "alchemy/cloudflare";
 
-    // Check app initialization
-    expect(output).toContain('const app = await alchemy("complex-worker"');
+const app = await alchemy("complex-worker", {
+  // Configure your app here
+});
 
-    // Check resources
-    expect(output).toContain("// Resources");
-    expect(output).toContain('await KVNamespace("CACHE"');
-    expect(output).toContain('await R2Bucket("my-storage"');
-    expect(output).toContain('await D1Database("my-db"');
-    expect(output).toContain("export const ai = new Ai();");
+// Resources
+export const cache = await KVNamespace("CACHE", {
+  title: "CACHE",
+  adopt: true,
+});
+export const storage = await R2Bucket("my-storage", {
+  name: "my-storage",
+  adopt: true,
+});
+export const db = await D1Database("my-db", {
+  name: "my-db",
+  adopt: true,
+});
+export const ai = new Ai();
 
-    // Check worker config
-    expect(output).toContain("// Worker");
-    expect(output).toContain('await Worker("complex-worker"');
-    expect(output).toContain('entrypoint: "src/index.ts"');
-    expect(output).toContain('compatibilityDate: "2023-12-01"');
-    expect(output).toContain('compatibilityFlags: ["nodejs_compat"]');
-    expect(output).toContain("url: true");
-    expect(output).toContain("CACHE: cache");
-    expect(output).toContain("STORAGE: storage");
-    expect(output).toContain("DB: db");
-    expect(output).toContain("AI: ai");
-    expect(output).toContain('"API_URL": "https://api.example.com"');
-    expect(output).toContain('"ENV": "production"');
-    expect(output).toContain('crons: ["0 */6 * * *"]');
+// Worker
+export const worker = await Worker("complex-worker", {
+  entrypoint: "src/index.ts",
+  compatibilityDate: "2023-12-01",
+  compatibilityFlags: ["nodejs_compat"],
+  bindings: {
+    CACHE: cache,
+    STORAGE: storage,
+    DB: db,
+    AI: ai,
+  },
+  env: {
+      "API_URL": "https://api.example.com",
+      "ENV": "production"
+  },
+  crons: ["0 */6 * * *"],
+  url: true,
+  adopt: true,
+});
 
-    // Check routes
-    expect(output).toContain("// Routes");
-    expect(output).toContain('pattern: "*.example.com/*"');
+// Routes
+await Route("route-0", {
+  pattern: "*.example.com/*",
+  worker,
+});
 
-    // Check finalization
-    expect(output).toContain("console.log(worker.url);");
-    expect(output).toContain("await app.finalize();");
+console.log(worker.url);
+
+await app.finalize();`;
+
+    expect(output).toBe(expectedOutput);
   });
 
   describe("error handling", () => {
@@ -388,10 +753,23 @@ describe("wrangler-to-alchemy conversion", () => {
 
       const output = convertWranglerToAlchemy(input);
 
-      expect(output).toContain('const app = await alchemy("empty-worker"');
-      expect(output).toContain('await Worker("empty-worker"');
-      expect(output).toContain("adopt: true");
-      expect(output).toContain("await app.finalize();");
+      const expectedOutput = `import alchemy from "alchemy";
+import { Worker } from "alchemy/cloudflare";
+
+const app = await alchemy("empty-worker", {
+  // Configure your app here
+});
+
+// Worker
+export const worker = await Worker("empty-worker", {
+  adopt: true,
+});
+
+console.log(worker.url);
+
+await app.finalize();`;
+
+      expect(output).toBe(expectedOutput);
     });
   });
 });

--- a/scripts/wrangler-to-alchemy.ts
+++ b/scripts/wrangler-to-alchemy.ts
@@ -1,0 +1,507 @@
+#!/usr/bin/env bun
+
+import fs from "node:fs/promises";
+import type { WranglerJsonSpec } from "../alchemy/src/cloudflare/wrangler.json.ts";
+
+/**
+ * Script to convert a wrangler.json file into an alchemy.run.ts file
+ *
+ * Usage:
+ *   bun scripts/wrangler-to-alchemy.ts <wrangler.json> [output.ts]
+ *
+ * Examples:
+ *   bun scripts/wrangler-to-alchemy.ts wrangler.json
+ *   bun scripts/wrangler-to-alchemy.ts wrangler.json alchemy.run.ts
+ */
+
+interface ConversionOptions {
+  inputFile: string;
+  outputFile: string;
+}
+
+function parseArgs(): ConversionOptions {
+  const args = process.argv.slice(2);
+
+  if (args.length === 0 || args.includes("--help") || args.includes("-h")) {
+    console.log(`
+Usage: bun scripts/wrangler-to-alchemy.ts <wrangler.json> [output.ts]
+
+Convert a wrangler.json file to an alchemy.run.ts file.
+
+Arguments:
+  <wrangler.json>  Path to the wrangler.json file to convert
+  [output.ts]      Output file path (default: alchemy.run.ts)
+
+Examples:
+  bun scripts/wrangler-to-alchemy.ts wrangler.json
+  bun scripts/wrangler-to-alchemy.ts wrangler.json my-alchemy.run.ts
+`);
+    process.exit(0);
+  }
+
+  if (args.length < 1) {
+    console.error("Error: Missing required argument <wrangler.json>");
+    process.exit(1);
+  }
+
+  const inputFile = args[0];
+  const outputFile = args[1] || "alchemy.run.ts";
+
+  return { inputFile, outputFile };
+}
+
+async function loadWranglerJson(filePath: string): Promise<WranglerJsonSpec> {
+  try {
+    const content = await fs.readFile(filePath, "utf-8");
+    return JSON.parse(content) as WranglerJsonSpec;
+  } catch (error) {
+    if (error instanceof Error) {
+      if (error.message.includes("ENOENT")) {
+        throw new Error(`File not found: ${filePath}`);
+      }
+      if (error.message.includes("JSON")) {
+        throw new Error(`Invalid JSON in file: ${filePath}`);
+      }
+    }
+    throw error;
+  }
+}
+
+function generateImports(spec: WranglerJsonSpec): string[] {
+  const imports = new Set<string>();
+
+  // Always add basic imports
+  imports.add('import alchemy from "alchemy";');
+
+  // Add cloudflare imports based on what's used
+  const cloudflareImports = new Set<string>();
+  cloudflareImports.add("Worker");
+
+  // Check for different binding types and add corresponding imports
+  if (spec.kv_namespaces && spec.kv_namespaces.length > 0) {
+    cloudflareImports.add("KVNamespace");
+  }
+
+  if (spec.r2_buckets && spec.r2_buckets.length > 0) {
+    cloudflareImports.add("R2Bucket");
+  }
+
+  if (spec.d1_databases && spec.d1_databases.length > 0) {
+    cloudflareImports.add("D1Database");
+  }
+
+  if (spec.durable_objects && spec.durable_objects.bindings.length > 0) {
+    cloudflareImports.add("DurableObjectNamespace");
+  }
+
+  if (
+    spec.queues &&
+    (spec.queues.producers.length > 0 || spec.queues.consumers.length > 0)
+  ) {
+    cloudflareImports.add("Queue");
+  }
+
+  if (spec.workflows && spec.workflows.length > 0) {
+    cloudflareImports.add("Workflow");
+  }
+
+  if (spec.ai) {
+    cloudflareImports.add("Ai");
+  }
+
+  if (spec.browser) {
+    cloudflareImports.add("BrowserRendering");
+  }
+
+  if (spec.images) {
+    cloudflareImports.add("Images");
+  }
+
+  if (spec.vectorize && spec.vectorize.length > 0) {
+    cloudflareImports.add("VectorizeIndex");
+  }
+
+  if (
+    spec.analytics_engine_datasets &&
+    spec.analytics_engine_datasets.length > 0
+  ) {
+    cloudflareImports.add("AnalyticsEngine");
+  }
+
+  if (spec.hyperdrive && spec.hyperdrive.length > 0) {
+    cloudflareImports.add("Hyperdrive");
+  }
+
+  if (spec.pipelines && spec.pipelines.length > 0) {
+    cloudflareImports.add("Pipeline");
+  }
+
+  if (spec.secrets_store_secrets && spec.secrets_store_secrets.length > 0) {
+    cloudflareImports.add("SecretsStore");
+  }
+
+  if (spec.dispatch_namespaces && spec.dispatch_namespaces.length > 0) {
+    cloudflareImports.add("DispatchNamespace");
+  }
+
+  if (spec.version_metadata) {
+    cloudflareImports.add("VersionMetadata");
+  }
+
+  if (cloudflareImports.size > 0) {
+    const sortedImports = Array.from(cloudflareImports).sort().join(", ");
+    imports.add(`import { ${sortedImports} } from "alchemy/cloudflare";`);
+  }
+
+  return Array.from(imports);
+}
+
+function generateBindings(spec: WranglerJsonSpec): {
+  bindings: string[];
+  resources: string[];
+} {
+  const bindings: string[] = [];
+  const resources: string[] = [];
+
+  // KV Namespaces
+  spec.kv_namespaces?.forEach((kv) => {
+    const resourceName = kv.binding.toLowerCase();
+    resources.push(`export const ${resourceName} = await KVNamespace("${kv.binding}", {
+  title: "${kv.binding}",
+  adopt: true,
+});`);
+    bindings.push(`    ${kv.binding}: ${resourceName},`);
+  });
+
+  // R2 Buckets
+  spec.r2_buckets?.forEach((bucket) => {
+    const resourceName = bucket.binding.toLowerCase();
+    resources.push(`export const ${resourceName} = await R2Bucket("${bucket.bucket_name}", {
+  name: "${bucket.bucket_name}",
+  adopt: true,
+});`);
+    bindings.push(`    ${bucket.binding}: ${resourceName},`);
+  });
+
+  // D1 Databases
+  spec.d1_databases?.forEach((db) => {
+    const resourceName = db.binding.toLowerCase();
+    resources.push(`export const ${resourceName} = await D1Database("${db.database_name}", {
+  name: "${db.database_name}",
+  adopt: true,
+});`);
+    bindings.push(`    ${db.binding}: ${resourceName},`);
+  });
+
+  // Durable Objects
+  spec.durable_objects?.bindings.forEach((durable) => {
+    const resourceName = durable.name.toLowerCase();
+
+    resources.push(`export const ${resourceName} = new DurableObjectNamespace("${durable.name}", {
+  className: "${durable.class_name}",${
+    durable.script_name
+      ? `
+  scriptName: "${durable.script_name}",`
+      : ""
+  }${
+    durable.environment
+      ? `
+  environment: "${durable.environment}",`
+      : ""
+  }
+});`);
+    bindings.push(`    ${durable.name}: ${resourceName},`);
+  });
+
+  // Queues (producers only - consumers are handled as eventSources)
+  spec.queues?.producers.forEach((queue) => {
+    const resourceName = queue.binding.toLowerCase();
+    resources.push(`export const ${resourceName} = await Queue("${queue.queue}", {
+  name: "${queue.queue}",
+  adopt: true,
+});`);
+    bindings.push(`    ${queue.binding}: ${resourceName},`);
+  });
+
+  // Workflows
+  spec.workflows?.forEach((workflow) => {
+    const resourceName = workflow.binding.toLowerCase();
+    resources.push(`export const ${resourceName} = new Workflow("${workflow.name}", {
+  className: "${workflow.class_name}",
+  workflowName: "${workflow.name}",${
+    workflow.script_name
+      ? `
+  scriptName: "${workflow.script_name}",`
+      : ""
+  }
+});`);
+    bindings.push(`    ${workflow.binding}: ${resourceName},`);
+  });
+
+  // AI
+  if (spec.ai) {
+    resources.push("export const ai = new Ai();");
+    bindings.push(`    ${spec.ai.binding}: ai,`);
+  }
+
+  // Browser
+  if (spec.browser) {
+    resources.push(`export const browser = { type: "browser" as const };`);
+    bindings.push(`    ${spec.browser.binding}: browser,`);
+  }
+
+  // Images
+  if (spec.images) {
+    resources.push(`export const images = { type: "images" as const };`);
+    bindings.push(`    ${spec.images.binding}: images,`);
+  }
+
+  // Vectorize
+  spec.vectorize?.forEach((vectorize) => {
+    const resourceName = vectorize.binding.toLowerCase();
+    resources.push(`export const ${resourceName} = await VectorizeIndex("${vectorize.index_name}", {
+  name: "${vectorize.index_name}",
+  adopt: true,
+});`);
+    bindings.push(`    ${vectorize.binding}: ${resourceName},`);
+  });
+
+  // Analytics Engine
+  spec.analytics_engine_datasets?.forEach((analytics) => {
+    const resourceName = analytics.binding.toLowerCase();
+    resources.push(`export const ${resourceName} = await AnalyticsEngine("${analytics.dataset}", {
+  dataset: "${analytics.dataset}",
+  adopt: true,
+});`);
+    bindings.push(`    ${analytics.binding}: ${resourceName},`);
+  });
+
+  // Hyperdrive
+  spec.hyperdrive?.forEach((hyperdrive) => {
+    const resourceName = hyperdrive.binding.toLowerCase();
+    // Parse connection string to extract components
+    const url = new URL(hyperdrive.localConnectionString);
+    resources.push(`export const ${resourceName} = await Hyperdrive("${hyperdrive.id}", {
+  name: "${hyperdrive.id}",
+  origin: {
+    scheme: "${url.protocol.slice(0, -1)}",
+    host: "${url.hostname}",
+    port: ${url.port || (url.protocol === "postgres:" ? 5432 : 3306)},
+    database: "${url.pathname.slice(1)}",
+    user: "${url.username}",
+    password: secret("${url.username.toUpperCase()}_PASSWORD"),
+  },
+  adopt: true,
+});`);
+    bindings.push(`    ${hyperdrive.binding}: ${resourceName},`);
+  });
+
+  // Pipelines
+  spec.pipelines?.forEach((pipeline) => {
+    const resourceName = pipeline.binding.toLowerCase();
+    resources.push(`export const ${resourceName} = await Pipeline("${pipeline.pipeline}", {
+  name: "${pipeline.pipeline}",
+  adopt: true,
+});`);
+    bindings.push(`    ${pipeline.binding}: ${resourceName},`);
+  });
+
+  // Secrets Store
+  spec.secrets_store_secrets?.forEach((secret) => {
+    const resourceName = secret.binding.toLowerCase();
+    resources.push(`export const ${resourceName} = await SecretsStore("${secret.store_id}", {
+  name: "${secret.store_id}",
+  adopt: true,
+});`);
+    bindings.push(`    ${secret.binding}: ${resourceName},`);
+  });
+
+  // Dispatch Namespaces
+  spec.dispatch_namespaces?.forEach((dispatch) => {
+    const resourceName = dispatch.binding.toLowerCase();
+    resources.push(`export const ${resourceName} = await DispatchNamespace("${dispatch.namespace}", {
+  name: "${dispatch.namespace}",
+  adopt: true,
+});`);
+    bindings.push(`    ${dispatch.binding}: ${resourceName},`);
+  });
+
+  // Version Metadata
+  if (spec.version_metadata) {
+    resources.push(
+      `export const versionMetadata = { type: "version_metadata" as const };`,
+    );
+    bindings.push(`    ${spec.version_metadata.binding}: versionMetadata,`);
+  }
+
+  return { bindings, resources };
+}
+
+function generateEventSources(spec: WranglerJsonSpec): string[] {
+  const eventSources: string[] = [];
+
+  // Queue consumers - need to find the corresponding producer resource name
+  spec.queues?.consumers.forEach((consumer) => {
+    // Find the corresponding producer for this queue
+    const producer = spec.queues?.producers.find(
+      (p) => p.queue === consumer.queue,
+    );
+    if (producer) {
+      const resourceName = producer.binding.toLowerCase();
+      eventSources.push(resourceName);
+    }
+  });
+
+  return eventSources;
+}
+
+function generateWorkerConfig(
+  spec: WranglerJsonSpec,
+  bindingsArray: string[],
+  eventSources: string[],
+): string {
+  const config: string[] = [];
+
+  // Basic config
+  config.push(`export const worker = await Worker("${spec.name}", {`);
+
+  if (spec.main) {
+    config.push(`  entrypoint: "${spec.main}",`);
+  }
+
+  if (spec.compatibility_date) {
+    config.push(`  compatibilityDate: "${spec.compatibility_date}",`);
+  }
+
+  if (spec.compatibility_flags && spec.compatibility_flags.length > 0) {
+    config.push(
+      `  compatibilityFlags: ${JSON.stringify(spec.compatibility_flags)},`,
+    );
+  }
+
+  // Bindings
+  if (bindingsArray.length > 0) {
+    config.push("  bindings: {");
+    config.push(...bindingsArray);
+    config.push("  },");
+  }
+
+  // Environment variables
+  if (spec.vars && Object.keys(spec.vars).length > 0) {
+    config.push(
+      `  env: ${JSON.stringify(spec.vars, null, 4).replace(/\n/g, "\n  ")},`,
+    );
+  }
+
+  // Cron triggers
+  if (spec.triggers?.crons && spec.triggers.crons.length > 0) {
+    config.push(`  crons: ${JSON.stringify(spec.triggers.crons)},`);
+  }
+
+  // Event sources
+  if (eventSources.length > 0) {
+    config.push(`  eventSources: [${eventSources.join(", ")}],`);
+  }
+
+  // URLs
+  if (spec.workers_dev) {
+    config.push("  url: true,");
+  }
+
+  config.push("  adopt: true,");
+  config.push("});");
+
+  return config.join("\n");
+}
+
+async function generateAlchemyFile(spec: WranglerJsonSpec): Promise<string> {
+  const lines: string[] = [];
+
+  // Add imports
+  const imports = generateImports(spec);
+  lines.push(...imports);
+  lines.push("");
+
+  // Add secret import if needed (for hyperdrive passwords)
+  if (spec.hyperdrive && spec.hyperdrive.length > 0) {
+    lines.push('import { secret } from "alchemy";');
+    lines.push("");
+  }
+
+  // Add app initialization
+  lines.push(`const app = await alchemy("${spec.name}", {
+  // Configure your app here
+});`);
+  lines.push("");
+
+  // Generate resources and bindings
+  const { bindings, resources } = generateBindings(spec);
+
+  if (resources.length > 0) {
+    lines.push("// Resources");
+    lines.push(...resources);
+    lines.push("");
+  }
+
+  // Generate event sources
+  const eventSources = generateEventSources(spec);
+
+  // Generate worker configuration
+  lines.push("// Worker");
+  lines.push(generateWorkerConfig(spec, bindings, eventSources));
+  lines.push("");
+
+  // Add routes if present
+  if (spec.routes && spec.routes.length > 0) {
+    lines.push("// Routes");
+    spec.routes.forEach((route, index) => {
+      lines.push(`await Route("route-${index}", {
+  pattern: "${route}",
+  worker,
+});`);
+    });
+    lines.push("");
+  }
+
+  // Log the worker URL
+  lines.push("console.log(worker.url);");
+  lines.push("");
+
+  // Finalize the app
+  lines.push("await app.finalize();");
+
+  return lines.join("\n");
+}
+
+async function main() {
+  try {
+    const { inputFile, outputFile } = parseArgs();
+
+    console.log(`Converting ${inputFile} to ${outputFile}...`);
+
+    // Load and parse wrangler.json
+    const spec = await loadWranglerJson(inputFile);
+
+    // Generate alchemy.run.ts content
+    const content = await generateAlchemyFile(spec);
+
+    // Write output file
+    await fs.writeFile(outputFile, content, "utf-8");
+
+    console.log(`✅ Successfully converted ${inputFile} to ${outputFile}`);
+    console.log("\nNext steps:");
+    console.log("1. Review the generated file and adjust as needed");
+    console.log("2. Install dependencies: bun install");
+    console.log(`3. Run the deployment: bun ${outputFile}`);
+  } catch (error) {
+    console.error(
+      "❌ Error:",
+      error instanceof Error ? error.message : String(error),
+    );
+    process.exit(1);
+  }
+}
+
+if (import.meta.main) {
+  main();
+}


### PR DESCRIPTION
Implements a comprehensive conversion script that transforms Cloudflare wrangler.json files into equivalent alchemy.run.ts files.

## Features
- Parses wrangler.json with proper error handling
- Converts all major binding types (KV, R2, D1, Durable Objects, Queues, Workflows, AI, etc.)
- Generates smart imports based on actual usage
- Handles environment variables, cron triggers, and event sources
- Creates idiomatic Alchemy code with adopt: true
- CLI interface with help documentation

## Usage
```bash
bun scripts/wrangler-to-alchemy.ts <wrangler.json> [output.ts]
```

Closes #388

Generated with [Claude Code](https://claude.ai/code)