### PR TITLE
fix(cloudflare): align Queue Consumer settings with Cloudflare terminology

### DIFF
--- a/alchemy-web/docs/guides/cloudflare-queue.md
+++ b/alchemy-web/docs/guides/cloudflare-queue.md
@@ -85,6 +85,27 @@ export const worker = await Worker("my-worker", {
 });
 ```
 
+## Configure Queue Consumer with Settings
+
+Customize how your Worker processes queue messages by providing consumer settings.
+
+```ts
+import { Worker } from "alchemy/cloudflare";
+
+export const worker = await Worker("my-worker", {
+  eventSources: [{
+    queue,
+    settings: {
+      batchSize: 25,           // Process 25 messages at once
+      maxConcurrency: 5,       // Allow 5 concurrent invocations  
+      maxRetries: 3,           // Retry failed messages up to 3 times
+      maxBatchTimeout: 2,      // Wait up to 2 seconds to fill a batch
+      retryDelay: 30,          // Wait 30 seconds before retrying failed messages
+    }
+  }],
+});
+```
+
 ## Process Messages Using Consumer
 
 Implement the queue handler using a type-safe batch parameter.

--- a/alchemy-web/docs/providers/cloudflare/queue-consumer.md
+++ b/alchemy-web/docs/providers/cloudflare/queue-consumer.md
@@ -44,9 +44,36 @@ const consumer = await QueueConsumer("batch-processor", {
 });
 ```
 
-## Bind to a Worker
+## Configure via Worker EventSources
 
-Bind a queue consumer to a worker.
+Configure queue consumer settings directly through the Worker's eventSources (recommended approach).
+
+```ts
+import { Worker, Queue } from "alchemy/cloudflare";
+
+const queue = await Queue("notifications", {
+  name: "notifications",
+});
+
+await Worker("notification-worker", {
+  name: "notification-worker",
+  entrypoint: "./src/worker.ts",
+  eventSources: [{
+    queue, 
+    settings: {
+      batchSize: 25,           // Process 25 messages at once
+      maxConcurrency: 5,       // Allow 5 concurrent invocations
+      maxRetries: 3,           // Retry failed messages up to 3 times
+      maxBatchTimeout: 2,      // Wait up to 2 seconds to fill a batch
+      retryDelay: 30,          // Wait 30 seconds before retrying failed messages
+    }
+  }],
+});
+```
+
+## Manual QueueConsumer Resource
+
+Alternatively, create a QueueConsumer resource directly (for advanced use cases).
 
 ```ts
 import { Worker, QueueConsumer } from "alchemy/cloudflare";

--- a/alchemy-web/docs/providers/cloudflare/queue-consumer.md
+++ b/alchemy-web/docs/providers/cloudflare/queue-consumer.md
@@ -38,7 +38,7 @@ const consumer = await QueueConsumer("batch-processor", {
     batchSize: 50, // Process 50 messages at once
     maxConcurrency: 10, // Allow 10 concurrent invocations
     maxRetries: 5, // Retry failed messages up to 5 times
-    maxWaitTimeMs: 2000, // Wait up to 2 seconds to fill a batch
+    maxBatchTimeout: 2, // Wait up to 2 seconds to fill a batch
     retryDelay: 60, // Wait 60 seconds before retrying failed messages
   },
 });

--- a/alchemy-web/docs/providers/cloudflare/queue.md
+++ b/alchemy-web/docs/providers/cloudflare/queue.md
@@ -56,6 +56,33 @@ await Worker("my-worker", {
 });
 ```
 
+## Configure as Event Source
+
+Register a queue as an event source for a worker to consume messages with custom settings.
+
+```ts
+import { Worker, Queue } from "alchemy/cloudflare";
+
+const queue = await Queue("my-queue", {
+  name: "my-queue",
+});
+
+await Worker("my-worker", {
+  name: "my-worker",
+  script: "console.log('Hello, world!')",
+  eventSources: [{
+    queue,
+    settings: {
+      batchSize: 50,           // Process 50 messages at once
+      maxConcurrency: 10,      // Allow 10 concurrent invocations
+      maxRetries: 5,           // Retry failed messages up to 5 times
+      maxBatchTimeout: 2,      // Wait up to 2 seconds to fill a batch
+      retryDelay: 60,          // Wait 60 seconds before retrying failed messages
+    }
+  }],
+});
+```
+
 ## Queue with Dead Letter Queue
 
 Configure a dead letter queue for handling failed messages.

--- a/alchemy/src/cloudflare/queue-consumer.ts
+++ b/alchemy/src/cloudflare/queue-consumer.ts
@@ -32,10 +32,10 @@ export interface QueueConsumerSettings {
   maxRetries?: number;
 
   /**
-   * Maximum time in milliseconds to wait for batch to fill
-   * @default 500
+   * Maximum time in seconds to wait for batch to fill
+   * @default 1
    */
-  maxWaitTimeMs?: number;
+  maxBatchTimeout?: number;
 
   /**
    * Time in seconds to delay retry after a failure
@@ -134,7 +134,7 @@ export interface QueueConsumer
  *     batchSize: 50,         // Process 50 messages at once
  *     maxConcurrency: 10,    // Allow 10 concurrent invocations
  *     maxRetries: 5,         // Retry failed messages up to 5 times
- *     maxWaitTimeMs: 2000,   // Wait up to 2 seconds to fill a batch
+ *     maxBatchTimeout: 2,     // Wait up to 2 seconds to fill a batch
  *     retryDelay: 60         // Wait 60 seconds before retrying failed messages
  *   }
  * });
@@ -193,7 +193,7 @@ export const QueueConsumer = Resource(
             batchSize: consumerData.result.settings.batch_size,
             maxConcurrency: consumerData.result.settings.max_concurrency,
             maxRetries: consumerData.result.settings.max_retries,
-            maxWaitTimeMs: consumerData.result.settings.max_wait_time_ms,
+            maxBatchTimeout: consumerData.result.settings.max_batch_timeout,
             retryDelay: consumerData.result.settings.retry_delay,
             deadLetterQueue: consumerData.result.settings.dead_letter_queue,
           }
@@ -215,7 +215,7 @@ interface CloudflareQueueConsumerResponse {
       batch_size?: number;
       max_concurrency?: number;
       max_retries?: number;
-      max_wait_time_ms?: number;
+      max_batch_timeout?: number;
       retry_delay?: number;
       dead_letter_queue?: string;
     };
@@ -258,8 +258,8 @@ export async function createQueueConsumer(
       createPayload.settings.max_retries = props.settings.maxRetries;
     }
 
-    if (props.settings.maxWaitTimeMs !== undefined) {
-      createPayload.settings.max_wait_time_ms = props.settings.maxWaitTimeMs;
+    if (props.settings.maxBatchTimeout !== undefined) {
+      createPayload.settings.max_batch_timeout = props.settings.maxBatchTimeout;
     }
 
     if (props.settings.retryDelay !== undefined) {
@@ -346,8 +346,8 @@ async function updateQueueConsumer(
       updatePayload.settings.max_retries = props.settings.maxRetries;
     }
 
-    if (props.settings.maxWaitTimeMs !== undefined) {
-      updatePayload.settings.max_wait_time_ms = props.settings.maxWaitTimeMs;
+    if (props.settings.maxBatchTimeout !== undefined) {
+      updatePayload.settings.max_batch_timeout = props.settings.maxBatchTimeout;
     }
 
     if (props.settings.retryDelay !== undefined) {
@@ -420,7 +420,7 @@ export async function listQueueConsumers(
         batch_size?: number;
         max_concurrency?: number;
         max_retries?: number;
-        max_wait_time_ms?: number;
+        max_batch_timeout?: number;
         retry_delay?: number;
         dead_letter_queue?: string;
       };
@@ -444,7 +444,7 @@ export async function listQueueConsumers(
           batchSize: consumer.settings.batch_size,
           maxConcurrency: consumer.settings.max_concurrency,
           maxRetries: consumer.settings.max_retries,
-          maxWaitTimeMs: consumer.settings.max_wait_time_ms,
+          maxBatchTimeout: consumer.settings.max_batch_timeout,
           retryDelay: consumer.settings.retry_delay,
           deadLetterQueue: consumer.settings.dead_letter_queue,
         }
@@ -479,7 +479,7 @@ export async function listQueueConsumersForWorker(
       settings?: {
         batch_size?: number;
         max_retries?: number;
-        max_wait_time_ms?: number;
+        max_batch_timeout?: number;
         retry_delay?: number;
         dead_letter_queue?: string;
       };

--- a/alchemy/src/cloudflare/queue.ts
+++ b/alchemy/src/cloudflare/queue.ts
@@ -176,6 +176,27 @@ export type Queue<Body = unknown> = QueueResource<Body> &
  *   dlq: dlqQueue
  * });
  *
+ * @example
+ * // Use queue as an event source with custom consumer settings
+ * const processingQueue = await Queue("processing-queue", {
+ *   name: "processing-queue"
+ * });
+ *
+ * const worker = await Worker("queue-worker", {
+ *   name: "queue-worker", 
+ *   entrypoint: "./src/worker.ts",
+ *   eventSources: [{
+ *     queue: processingQueue,
+ *     settings: {
+ *       batchSize: 25,           // Process 25 messages at once
+ *       maxConcurrency: 5,       // Allow 5 concurrent invocations
+ *       maxRetries: 3,           // Retry failed messages up to 3 times
+ *       maxBatchTimeout: 2,      // Wait up to 2 seconds to fill a batch
+ *       retryDelay: 30,          // Wait 30 seconds before retrying failed messages
+ *     }
+ *   }]
+ * });
+ *
  * @see https://developers.cloudflare.com/queues/
  */
 export async function Queue<Body = unknown>(

--- a/alchemy/src/cloudflare/worker.ts
+++ b/alchemy/src/cloudflare/worker.ts
@@ -577,6 +577,30 @@ export function WorkerRef<
  * })
  *
  * @example
+ * // Create a worker that consumes queue messages with custom settings:
+ * const queue = await Queue("task-queue", {
+ *   name: "task-queue"
+ * });
+ *
+ * const queueWorker = await Worker("queue-processor", {
+ *   name: "queue-processor",
+ *   entrypoint: "./src/queue-processor.ts",
+ *   eventSources: [{
+ *     queue,
+ *     settings: {
+ *       batchSize: 50,           // Process 50 messages at once
+ *       maxConcurrency: 10,      // Allow 10 concurrent invocations
+ *       maxRetries: 3,           // Retry failed messages up to 3 times
+ *       maxBatchTimeout: 2,      // Wait up to 2 seconds to fill a batch
+ *       retryDelay: 60,          // Wait 60 seconds before retrying failed messages
+ *     }
+ *   }],
+ *   bindings: {
+ *     TASK_QUEUE: queue        // Also bind for sending messages
+ *   }
+ * })
+ *
+ * @example
  * // Create cross-script durable object binding where one worker
  * // defines the durable object and another worker accesses it:
  * const dataWorker = await Worker("data-worker", {

--- a/alchemy/src/cloudflare/wrangler.json.ts
+++ b/alchemy/src/cloudflare/wrangler.json.ts
@@ -250,7 +250,7 @@ export interface WranglerJsonSpec {
       max_batch_size?: number;
       max_concurrency?: number;
       max_retries?: number;
-      max_wait_time_ms?: number;
+      max_batch_timeout?: number;
       retry_delay?: number;
     }[];
   };
@@ -413,7 +413,7 @@ function processBindings(
       max_batch_size?: number;
       max_concurrency?: number;
       max_retries?: number;
-      max_wait_time_ms?: number;
+      max_batch_timeout?: number;
       retry_delay?: number;
     }[];
   } = {
@@ -449,7 +449,7 @@ function processBindings(
         max_batch_size: eventSource.settings?.batchSize,
         max_concurrency: eventSource.settings?.maxConcurrency,
         max_retries: eventSource.settings?.maxRetries,
-        max_wait_time_ms: eventSource.settings?.maxWaitTimeMs,
+        max_batch_timeout: eventSource.settings?.maxBatchTimeout,
         retry_delay: eventSource.settings?.retryDelay,
       });
     } else if (isQueue(eventSource)) {


### PR DESCRIPTION
Aligns Queue Consumer settings with Cloudflare's official terminology and units.

## Changes
- Rename `maxWaitTimeMs` to `maxBatchTimeout` to match Cloudflare API
- Change time units from milliseconds to seconds (default 500ms → 1s)
- Update API mapping from `max_wait_time_ms` to `max_batch_timeout`
- Update wrangler.json interface to match new API format
- Update documentation examples with new property name

Fixes #392

Generated with [Claude Code](https://claude.ai/code)