### PR TITLE
feat(stripe): Add Full Tier Support for Stripe Prices

### DIFF
--- a/alchemy-web/docs/providers/stripe/price.md
+++ b/alchemy-web/docs/providers/stripe/price.md
@@ -57,3 +57,99 @@ const meteredPrice = await Price("storage", {
   },
 });
 ```
+
+## Tiered Pricing
+
+### Graduated Tiers
+
+With graduated tiered pricing, different portions of usage are charged at different rates:
+
+```ts
+import { Price } from "alchemy/stripe";
+
+const apiUsagePrice = await Price("api-usage", {
+  currency: "usd",
+  product: "prod_xyz",
+  billingScheme: "tiered",
+  tiersMode: "graduated",
+  recurring: {
+    interval: "month",
+    usageType: "metered",
+  },
+  tiers: [
+    {
+      upTo: 10000,
+      unitAmount: 0, // First 10k API calls free
+    },
+    {
+      upTo: 50000,
+      unitAmount: 2, // $0.02 per call from 10k-50k
+    },
+    {
+      upTo: "inf",
+      unitAmount: 1, // $0.01 per call beyond 50k
+    },
+  ],
+});
+```
+
+### Volume-Based Tiers
+
+With volume-based pricing, the total quantity determines the rate for ALL units:
+
+```ts
+import { Price } from "alchemy/stripe";
+
+const storagePrice = await Price("storage-volume", {
+  currency: "usd",
+  product: "prod_xyz",
+  billingScheme: "tiered",
+  tiersMode: "volume",
+  recurring: {
+    interval: "month",
+  },
+  tiers: [
+    {
+      upTo: 100,
+      unitAmount: 500, // $5 per GB for up to 100GB total
+    },
+    {
+      upTo: 1000,
+      unitAmount: 400, // $4 per GB for 101-1000GB total
+    },
+    {
+      upTo: "inf",
+      unitAmount: 300, // $3 per GB for over 1000GB total
+    },
+  ],
+});
+```
+
+### Overage Cap with Flat Amount
+
+Protect customers from bill shock with a flat fee cap:
+
+```ts
+import { Price } from "alchemy/stripe";
+
+const cappedUsagePrice = await Price("api-calls-capped", {
+  currency: "usd",
+  product: "prod_xyz",
+  billingScheme: "tiered",
+  tiersMode: "graduated",
+  recurring: {
+    interval: "month",
+    usageType: "metered",
+  },
+  tiers: [
+    {
+      upTo: 100000,
+      unitAmount: 1, // $0.01 per call up to 100k
+    },
+    {
+      upTo: "inf",
+      flatAmount: 100000, // Cap at $1000 for unlimited usage
+    },
+  ],
+});
+```

--- a/alchemy/src/stripe/price.ts
+++ b/alchemy/src/stripe/price.ts
@@ -162,22 +162,24 @@ export interface PriceProps {
    * In `volume`-based tiering, the maximum quantity within a period determines the per unit price.
    * In `graduated` tiering, pricing can change as the quantity grows.
    */
-  tiersMode?: "graduated" | "volume";
+  tiersMode?: "graduated" | "volume" | undefined;
 
   /**
    * Apply a transformation to the reported usage or set quantity before computing the amount billed
    */
-  transformQuantity?: {
-    /**
-     * Divide usage by this number
-     */
-    divideBy: number;
+  transformQuantity?:
+    | {
+        /**
+         * Divide usage by this number
+         */
+        divideBy: number;
 
-    /**
-     * After dividing usage, either round the result `up` or `down`
-     */
-    round: "up" | "down";
-  };
+        /**
+         * After dividing usage, either round the result `up` or `down`
+         */
+        round: "up" | "down";
+      }
+    | undefined;
 }
 
 /**
@@ -217,15 +219,17 @@ export interface Price extends Resource<"stripe::Price">, PriceProps {
   /**
    * The tiering mode (graduated or volume)
    */
-  tiersMode?: "graduated" | "volume" | null;
+  tiersMode?: "graduated" | "volume" | undefined;
 
   /**
    * Transform quantity configuration
    */
-  transformQuantity?: {
-    divideBy: number;
-    round: "up" | "down";
-  } | null;
+  transformQuantity?:
+    | {
+        divideBy: number;
+        round: "up" | "down";
+      }
+    | undefined;
 }
 
 /**
@@ -509,7 +513,7 @@ export const Price = Resource(
         type: price.type as Stripe.Price.Type,
         lookupKey: price.lookup_key || undefined,
         tiers: tiers,
-        tiersMode: price.tiers_mode as "graduated" | "volume" | null,
+        tiersMode: price.tiers_mode ?? undefined,
         transformQuantity: transformQuantity,
       });
     } catch (error) {

--- a/alchemy/src/stripe/price.ts
+++ b/alchemy/src/stripe/price.ts
@@ -38,6 +38,37 @@ type TaxBehavior = Stripe.PriceCreateParams.TaxBehavior;
 type BillingScheme = Stripe.PriceCreateParams.BillingScheme;
 
 /**
+ * Properties for price tier configuration
+ */
+export interface PriceTier {
+  /**
+   * The flat billing amount for an entire tier, regardless of the number of units in the tier
+   */
+  flatAmount?: number;
+
+  /**
+   * Same as flat_amount, but accepts a decimal string with at most 12 decimal places
+   */
+  flatAmountDecimal?: string;
+
+  /**
+   * The per-unit amount to charge for units within this tier
+   */
+  unitAmount?: number;
+
+  /**
+   * Same as unit_amount, but accepts a decimal string with at most 12 decimal places
+   */
+  unitAmountDecimal?: string;
+
+  /**
+   * Specifies the upper bound of the tier. Can be a number or 'inf' for infinity.
+   * The last tier should have up_to set to 'inf'.
+   */
+  upTo: number | "inf";
+}
+
+/**
  * Properties for creating a Stripe price
  */
 export interface PriceProps {
@@ -119,6 +150,34 @@ export interface PriceProps {
    * If true, adopt existing resource if creation fails due to conflict
    */
   adopt?: boolean;
+
+  /**
+   * Each element represents a pricing tier. This parameter requires `billingScheme` to be set to `tiered`.
+   * An array of up to 250 tiers. Each tier has an upper bound and a price.
+   */
+  tiers?: PriceTier[];
+
+  /**
+   * Defines if the tiering price should be `graduated` or `volume` based.
+   * In `volume`-based tiering, the maximum quantity within a period determines the per unit price.
+   * In `graduated` tiering, pricing can change as the quantity grows.
+   */
+  tiersMode?: "graduated" | "volume";
+
+  /**
+   * Apply a transformation to the reported usage or set quantity before computing the amount billed
+   */
+  transformQuantity?: {
+    /**
+     * Divide usage by this number
+     */
+    divideBy: number;
+
+    /**
+     * After dividing usage, either round the result `up` or `down`
+     */
+    round: "up" | "down";
+  };
 }
 
 /**
@@ -149,6 +208,24 @@ export interface Price extends Resource<"stripe::Price">, PriceProps {
    * The lookup key (if any) used by the customer to identify this price object
    */
   lookupKey?: string;
+
+  /**
+   * The pricing tiers (if using tiered billing scheme)
+   */
+  tiers?: PriceTier[];
+
+  /**
+   * The tiering mode (graduated or volume)
+   */
+  tiersMode?: "graduated" | "volume" | null;
+
+  /**
+   * Transform quantity configuration
+   */
+  transformQuantity?: {
+    divideBy: number;
+    round: "up" | "down";
+  } | null;
 }
 
 /**
@@ -188,17 +265,56 @@ export interface Price extends Resource<"stripe::Price">, PriceProps {
  * });
  *
  * @example
- * // Create a tiered price with tax behavior
- * const tieredPrice = await Price("enterprise", {
+ * // Create a graduated tiered price with usage-based billing
+ * const tieredPrice = await Price("api-usage", {
  *   currency: "usd",
- *   unitAmount: 10000, // $100.00
  *   product: "prod_xyz",
  *   billingScheme: "tiered",
- *   taxBehavior: "exclusive",
- *   metadata: {
- *     tier: "enterprise",
- *     features: "all"
- *   }
+ *   tiersMode: "graduated",
+ *   recurring: {
+ *     interval: "month",
+ *     usageType: "metered"
+ *   },
+ *   tiers: [
+ *     {
+ *       upTo: 10000,
+ *       unitAmount: 0 // First 10k API calls free
+ *     },
+ *     {
+ *       upTo: 50000,
+ *       unitAmount: 2 // $0.02 per call up to 50k
+ *     },
+ *     {
+ *       upTo: "inf",
+ *       unitAmount: 1 // $0.01 per call beyond 50k
+ *     }
+ *   ]
+ * });
+ *
+ * @example
+ * // Create a volume-based tiered price with overage cap
+ * const volumePrice = await Price("storage", {
+ *   currency: "usd",
+ *   product: "prod_xyz",
+ *   billingScheme: "tiered",
+ *   tiersMode: "volume",
+ *   recurring: {
+ *     interval: "month"
+ *   },
+ *   tiers: [
+ *     {
+ *       upTo: 100,
+ *       unitAmount: 500 // $5 per GB for up to 100GB
+ *     },
+ *     {
+ *       upTo: 1000,
+ *       unitAmount: 400 // $4 per GB for 101-1000GB
+ *     },
+ *     {
+ *       upTo: "inf",
+ *       flatAmount: 300000 // Cap at $3000 for unlimited storage
+ *     }
+ *   ]
  * });
  */
 export const Price = Resource(
@@ -222,23 +338,38 @@ export const Price = Resource(
 
       return this.destroy();
     }
+
+    // Validate tier-related constraints
+    if (props.tiers && props.billingScheme !== "tiered") {
+      throw new Error("Tiers can only be used with billingScheme: 'tiered'");
+    }
+
+    if (props.tiers && (props.unitAmount || props.unitAmountDecimal)) {
+      throw new Error("Cannot set both tiers and unitAmount/unitAmountDecimal");
+    }
+
+    if (props.tiersMode && !props.tiers) {
+      throw new Error("tiersMode requires tiers to be defined");
+    }
+
     try {
       let price: Stripe.Price;
 
       if (this.phase === "update" && this.output?.id) {
         // Update existing price (limited properties can be updated)
-        const updateParams: Stripe.PriceUpdateParams = {
+        const updateParams: Stripe.PriceUpdateParams & { expand?: string[] } = {
           active: props.active,
           metadata: props.metadata,
           nickname: props.nickname,
           lookup_key: props.lookupKey,
           transfer_lookup_key: props.transferLookupKey,
+          expand: ["tiers"],
         };
 
         price = await stripe.prices.update(this.output.id, updateParams);
       } else {
         // Create new price
-        const createParams: Stripe.PriceCreateParams = {
+        const createParams: Stripe.PriceCreateParams & { expand?: string[] } = {
           currency: props.currency,
           product: props.product,
           active: props.active,
@@ -248,6 +379,7 @@ export const Price = Resource(
           tax_behavior: props.taxBehavior,
           lookup_key: props.lookupKey,
           transfer_lookup_key: props.transferLookupKey,
+          expand: ["tiers"],
         };
 
         // Add unit amount fields
@@ -267,6 +399,29 @@ export const Price = Resource(
           };
         }
 
+        // Add tier configuration if present
+        if (props.tiers) {
+          createParams.tiers = props.tiers.map((tier) => ({
+            up_to: tier.upTo === "inf" ? "inf" : tier.upTo,
+            flat_amount: tier.flatAmount,
+            flat_amount_decimal: tier.flatAmountDecimal,
+            unit_amount: tier.unitAmount,
+            unit_amount_decimal: tier.unitAmountDecimal,
+          }));
+        }
+
+        if (props.tiersMode) {
+          createParams.tiers_mode = props.tiersMode;
+        }
+
+        // Add transform quantity if present
+        if (props.transformQuantity) {
+          createParams.transform_quantity = {
+            divide_by: props.transformQuantity.divideBy,
+            round: props.transformQuantity.round,
+          };
+        }
+
         if (props.lookupKey) {
           const existingPrices = await stripe.prices.list({
             lookup_keys: [props.lookupKey],
@@ -275,19 +430,25 @@ export const Price = Resource(
           if (existingPrices.data.length > 0) {
             if (props.adopt) {
               const existingPrice = existingPrices.data[0];
-              const updateParams: Stripe.PriceUpdateParams = {
+              const updateParams: Stripe.PriceUpdateParams & {
+                expand?: string[];
+              } = {
                 active: props.active,
                 metadata: props.metadata,
                 nickname: props.nickname,
                 lookup_key: props.lookupKey,
                 transfer_lookup_key: props.transferLookupKey,
+                expand: ["tiers"],
               };
               price = await stripe.prices.update(
                 existingPrice.id,
                 updateParams,
               );
             } else {
-              price = existingPrices.data[0];
+              // Need to retrieve with expanded tiers
+              price = await stripe.prices.retrieve(existingPrices.data[0].id, {
+                expand: ["tiers"],
+              } as any);
             }
           } else {
             price = await stripe.prices.create(createParams);
@@ -310,6 +471,25 @@ export const Price = Resource(
           }
         : undefined;
 
+      // Transform Stripe tiers array to our format
+      const tiers = price.tiers
+        ? price.tiers.map((tier) => ({
+            flatAmount: tier.flat_amount || undefined,
+            flatAmountDecimal: tier.flat_amount_decimal || undefined,
+            unitAmount: tier.unit_amount || undefined,
+            unitAmountDecimal: tier.unit_amount_decimal || undefined,
+            upTo: tier.up_to === null ? ("inf" as const) : tier.up_to!,
+          }))
+        : undefined;
+
+      // Transform transform_quantity if present
+      const transformQuantity = price.transform_quantity
+        ? {
+            divideBy: price.transform_quantity.divide_by,
+            round: price.transform_quantity.round as "up" | "down",
+          }
+        : undefined;
+
       // Map Stripe API response to our output format
       return this({
         id: price.id,
@@ -328,6 +508,9 @@ export const Price = Resource(
         livemode: price.livemode,
         type: price.type as Stripe.Price.Type,
         lookupKey: price.lookup_key || undefined,
+        tiers: tiers,
+        tiersMode: price.tiers_mode as "graduated" | "volume" | null,
+        transformQuantity: transformQuantity,
       });
     } catch (error) {
       logger.error("Error creating/updating price:", error);

--- a/alchemy/test/stripe/meter.test.ts
+++ b/alchemy/test/stripe/meter.test.ts
@@ -194,7 +194,7 @@ describe("Stripe Meter Resource", () => {
         status: "active", // Keep status or specify to avoid unrelated changes
       };
 
-      expect(Meter(logicalId, attemptUpdateProps)).rejects.toThrow(
+      await expect(Meter(logicalId, attemptUpdateProps)).rejects.toThrow(
         /Attempted to update immutable properties/,
       );
     } finally {

--- a/alchemy/test/stripe/price.test.ts
+++ b/alchemy/test/stripe/price.test.ts
@@ -241,6 +241,230 @@ describe("Price Resource", () => {
     }
   });
 
+  test("create graduated tiered price", async (scope) => {
+    let product: Product | undefined;
+    let price: Price | undefined;
+
+    try {
+      // Create a test product
+      product = await Product(`${testProductId}-tiered-graduated`, {
+        name: `${BRANCH_PREFIX} Graduated Tiered Price Test Product`,
+        description: "A product for graduated tiered price testing",
+      });
+
+      // Create a graduated tiered price
+      price = await Price(`${testPriceId}-tiered-graduated`, {
+        product: product.id,
+        currency: "usd",
+        billingScheme: "tiered",
+        tiersMode: "graduated",
+        recurring: {
+          interval: "month",
+          usageType: "metered",
+        },
+        tiers: [
+          {
+            upTo: 10000,
+            unitAmount: 0, // First 10k free
+          },
+          {
+            upTo: 50000,
+            unitAmount: 2, // $0.02 per unit
+          },
+          {
+            upTo: "inf",
+            unitAmount: 1, // $0.01 per unit
+          },
+        ],
+      });
+
+      expect(price.id).toBeTruthy();
+      expect(price).toMatchObject({
+        product: product.id,
+        currency: "usd",
+        billingScheme: "tiered",
+        tiersMode: "graduated",
+      });
+
+      // Verify tiers are present and correct
+      expect(price.tiers).toHaveLength(3);
+      expect(price.tiers![0]).toMatchObject({
+        upTo: 10000,
+        unitAmountDecimal: "0",
+      });
+      expect(price.tiers![1]).toMatchObject({
+        upTo: 50000,
+        unitAmount: 2,
+      });
+      expect(price.tiers![2]).toMatchObject({
+        upTo: "inf",
+        unitAmount: 1,
+      });
+
+      // Verify with Stripe API (need to expand tiers)
+      const stripePrice = await stripe.prices.retrieve(price.id, {
+        expand: ["tiers"],
+      } as any);
+      expect(stripePrice.billing_scheme).toEqual("tiered");
+      expect(stripePrice.tiers_mode).toEqual("graduated");
+      expect(stripePrice.tiers).toHaveLength(3);
+      expect(stripePrice.tiers![0]).toMatchObject({
+        up_to: 10000,
+        unit_amount_decimal: "0",
+      });
+      expect(stripePrice.tiers![1]).toMatchObject({
+        up_to: 50000,
+        unit_amount: 2,
+      });
+      expect(stripePrice.tiers![2]).toMatchObject({
+        up_to: null, // Stripe represents "inf" as null
+        unit_amount: 1,
+      });
+    } catch (err) {
+      console.log(err);
+      throw err;
+    } finally {
+      await destroy(scope);
+
+      if (price?.id) {
+        await assertPriceDeactivated(price.id);
+      }
+      if (product?.id) {
+        await assertProductDeactivated(product.id);
+      }
+    }
+  });
+
+  test("create volume tiered price with flat amount", async (scope) => {
+    let product: Product | undefined;
+    let price: Price | undefined;
+
+    try {
+      // Create a test product
+      product = await Product(`${testProductId}-tiered-volume`, {
+        name: `${BRANCH_PREFIX} Volume Tiered Price Test Product`,
+        description: "A product for volume tiered price testing",
+      });
+
+      // Create a volume tiered price with overage cap
+      price = await Price(`${testPriceId}-tiered-volume`, {
+        product: product.id,
+        currency: "usd",
+        billingScheme: "tiered",
+        tiersMode: "volume",
+        recurring: {
+          interval: "month",
+        },
+        tiers: [
+          {
+            upTo: 100,
+            unitAmount: 500, // $5 per unit
+          },
+          {
+            upTo: 1000,
+            unitAmount: 400, // $4 per unit
+          },
+          {
+            upTo: "inf",
+            flatAmount: 300000, // Cap at $3000
+          },
+        ],
+      });
+
+      expect(price.id).toBeTruthy();
+      expect(price).toMatchObject({
+        product: product.id,
+        currency: "usd",
+        billingScheme: "tiered",
+        tiersMode: "volume",
+        tiers: [
+          { upTo: 100, unitAmount: 500 },
+          { upTo: 1000, unitAmount: 400 },
+          { upTo: "inf", flatAmount: 300000 },
+        ],
+      });
+
+      // Verify with Stripe API (need to expand tiers)
+      const stripePrice = await stripe.prices.retrieve(price.id, {
+        expand: ["tiers"],
+      } as any);
+      expect(stripePrice.billing_scheme).toEqual("tiered");
+      expect(stripePrice.tiers_mode).toEqual("volume");
+      expect(stripePrice.tiers).toHaveLength(3);
+      expect(stripePrice.tiers![2]).toMatchObject({
+        up_to: null,
+        flat_amount: 300000,
+      });
+    } catch (err) {
+      console.log(err);
+      throw err;
+    } finally {
+      await destroy(scope);
+
+      if (price?.id) {
+        await assertPriceDeactivated(price.id);
+      }
+      if (product?.id) {
+        await assertProductDeactivated(product.id);
+      }
+    }
+  });
+
+  test("tiered price validation", async (scope) => {
+    const product = await Product(`${testProductId}-tiered-validation`, {
+      name: `${BRANCH_PREFIX} Tiered Validation Test Product`,
+      description: "A product for tiered price validation testing",
+    });
+
+    try {
+      // Test: tiers requires billingScheme to be "tiered"
+      await expect(
+        Price(`${testPriceId}-tiered-invalid-scheme`, {
+          product: product.id,
+          currency: "usd",
+          billingScheme: "per_unit",
+          tiers: [
+            {
+              upTo: 100,
+              unitAmount: 500,
+            },
+          ],
+        }),
+      ).rejects.toThrow("Tiers can only be used with billingScheme: 'tiered'");
+
+      // Test: cannot set both tiers and unitAmount
+      await expect(
+        Price(`${testPriceId}-tiered-invalid-unit`, {
+          product: product.id,
+          currency: "usd",
+          billingScheme: "tiered",
+          unitAmount: 1000,
+          tiers: [
+            {
+              upTo: 100,
+              unitAmount: 500,
+            },
+          ],
+        }),
+      ).rejects.toThrow(
+        "Cannot set both tiers and unitAmount/unitAmountDecimal",
+      );
+
+      // Test: tiersMode requires tiers
+      await expect(
+        Price(`${testPriceId}-tiered-invalid-mode`, {
+          product: product.id,
+          currency: "usd",
+          billingScheme: "tiered",
+          tiersMode: "graduated",
+        }),
+      ).rejects.toThrow("tiersMode requires tiers to be defined");
+    } finally {
+      await destroy(scope);
+      await assertProductDeactivated(product.id);
+    }
+  });
+
   test("price adoption fails without lookup key", async (scope) => {
     const firstId = `${testPriceId}-no-key-first`;
     const secondId = `${testPriceId}-no-key-second`;


### PR DESCRIPTION
 Summary

  This PR adds comprehensive support for Stripe's tiered pricing models in the Price resource, enabling graduated and volume-based pricing
  configurations that are essential for SaaS and usage-based billing scenarios.

  What's Changed

  - Added PriceTier interface to define tier structure with support for:
    - flatAmount / flatAmountDecimal - Fixed price for entire tier
    - unitAmount / unitAmountDecimal - Per-unit pricing within tier
    - upTo - Upper bound of tier (number or "inf")
  - Extended PriceProps with:
    - tiers - Array of pricing tiers
    - tiersMode - "graduated" or "volume" pricing mode
    - transformQuantity - Optional quantity transformation settings
  - Enhanced Price resource implementation:
    - Proper tier serialization/deserialization with Stripe API
    - Automatic expansion of tiers in API responses
    - Validation to ensure tiers only used with billingScheme: "tiered"
  - Added comprehensive test coverage for:
    - Graduated tiered pricing
    - Volume-based tiered pricing with flat amounts
    - Tier validation scenarios

  Use Cases

  This enables common SaaS pricing models:

  1. API Usage Tiers - First X calls free, then graduated pricing
  2. Storage Tiers - Volume discounts as usage increases
  3. Overage Protection - Flat fee caps to prevent bill shock

  Example Usage

```typescript
  // Graduated pricing: different rates at different usage levels
  const apiPrice = await Price("api-usage", {
    product: "prod_123",
    currency: "usd",
    billingScheme: "tiered",
    tiersMode: "graduated",
    recurring: {
      interval: "month",
      usageType: "metered"
    },
    tiers: [
      { upTo: 10000, unitAmount: 0 },      // First 10k free
      { upTo: 50000, unitAmount: 2 },      // $0.02 per call
      { upTo: "inf", unitAmount: 1 }       // $0.01 per call
    ]
  });
```

```typescript
  // Volume pricing: rate applies to all units based on total
  const storagePrice = await Price("storage", {
    product: "prod_456",
    currency: "usd",
    billingScheme: "tiered",
    tiersMode: "volume",
    recurring: { interval: "month" },
    tiers: [
      { upTo: 100, unitAmount: 500 },      // $5/GB for up to 100GB
      { upTo: 1000, unitAmount: 400 },     // $4/GB for 101-1000GB
      { upTo: "inf", flatAmount: 300000 }  // Cap at $3000
    ]
  });
```

  Testing

  - ✅ All existing tests pass
  - ✅ Added new tests for tiered pricing scenarios
  - ✅ Validated against Stripe Test Mode
  - ✅ Linting and formatting checks pass

  Breaking Changes

  None. This is a backward-compatible enhancement.

  References

  - https://stripe.com/docs/products-prices/pricing-models#tiered-pricing
  - https://stripe.com/docs/api/prices/create#create_price-tiers

  ---
  🤖 Generated with https://claude.ai/code

  Co-Authored-By: Claude mailto:noreply@anthropic.com