### PR TITLE
fix: improve package manager handling in create-alchemy

### DIFF
--- a/alchemy/bin/alchemy.ts
+++ b/alchemy/bin/alchemy.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { parseArgs } from "node:util";
-import { createAlchemy } from "./create-alchemy.ts";
 import { bootstrapS3 } from "./bootstrap-s3.ts";
+import { createAlchemy } from "./create-alchemy.ts";
 
 // Parse command-line arguments. We allow unknown flags because different
 // sub-commands may accept different sets.

--- a/alchemy/bin/create-alchemy.ts
+++ b/alchemy/bin/create-alchemy.ts
@@ -375,7 +375,8 @@ async function initAstroProject(
   projectPath: string,
 ): Promise<void> {
   create(
-    `astro@latest ${projectName} -- --no-git --no-deploy --install ${options.yes ? "--yes" : ""}`,
+    pm,
+    `astro@latest ${projectName} ${pm === "npm" ? "--" : ""} --no-git --no-deploy --install ${options.yes ? "--yes" : ""}`,
   );
 
   await initWebsiteProject(projectPath, {
@@ -432,7 +433,8 @@ async function initReactRouterProject(
   projectPath: string,
 ): Promise<void> {
   create(
-    `cloudflare@2.49.3 ${projectName} -- --framework=react-router --no-git --no-deploy ${options.yes ? "--yes" : ""}`,
+    pm,
+    `cloudflare@2.49.3 ${projectName} ${pm === "npm" ? "--" : ""} --framework=react-router --no-git --no-deploy ${options.yes ? "--yes" : ""}`,
   );
 
   await initWebsiteProject(projectPath, {
@@ -1164,7 +1166,7 @@ async function mkdir(...path: string[]): Promise<void> {
 }
 
 function execCommand(command: string, cwd: string = process.cwd()): void {
-  console.log(command);
+  console.log(command.replaceAll(/ +/g, " "));
   try {
     execSync(command, { stdio: "inherit", cwd });
   } catch {
@@ -1206,7 +1208,11 @@ function npx(command: string, cwd: string = process.cwd()): void {
   );
 }
 
-function create(command: string, cwd: string = process.cwd()): void {
+function create(
+  pm: PackageManager,
+  command: string,
+  cwd: string = process.cwd(),
+): void {
   execCommand(
     `${getPackageManagerCommands(pm).create} ${options.yes ? "-y" : ""} ${command}`,
     cwd,


### PR DESCRIPTION
- Adds proper `--` flag handling for `npm` vs other package managers when creating projects with the Astro and React Router templates
- Normalizes whitespace in logged commands
- Update `create` function to accept package manager parameter