### PR TITLE
feat(cloudflare): support RPC type in WorkerStub

### DIFF
--- a/alchemy-web/docs/guides/cloudflare-worker.md
+++ b/alchemy-web/docs/guides/cloudflare-worker.md
@@ -175,6 +175,39 @@ const frontend = await Worker("frontend", {
 });
 ```
 
+## Circular Worker Bindings
+
+When workers need to bind to each other (circular dependency), use `WorkerStub` to break the cycle:
+
+```ts
+import { Worker, WorkerStub } from "alchemy/cloudflare";
+import type { MyWorkerA } from "./src/worker-a.ts";
+import type { MyWorkerB } from "./src/worker-B.ts";
+
+// Create workerA that binds to workerB stub
+const workerA = await Worker("workerA", {
+  name: "worker-a",
+  entrypoint: "./src/workerA.ts",
+  rpc: type<MyWorkerA>,
+  bindings: {
+    // bind to a stub (empty worker)
+    WORKER_B: await WorkerStub<MyWorkerB>("workerB", {
+      name: "worker-b",
+      rpc: type<MyWorkerB>,
+    });,
+  },
+});
+
+// Create workerB that binds to workerA
+const workerB = await Worker("workerB", {
+  name: "worker-b",
+  entrypoint: "./src/workerB.ts",
+  bindings: {
+    WORKER_A: workerA,
+  },
+});
+```
+
 ## RPC
 
 Create a Worker with RPC capabilities using WorkerEntrypoint and typed RPC interfaces:

--- a/alchemy-web/docs/providers/cloudflare/worker.md
+++ b/alchemy-web/docs/providers/cloudflare/worker.md
@@ -174,6 +174,39 @@ const frontend = await Worker("frontend", {
 });
 ```
 
+## Circular Worker Bindings
+
+When workers need to bind to each other (circular dependency), use `WorkerStub` to break the cycle:
+
+```ts
+import { Worker, WorkerStub } from "alchemy/cloudflare";
+import type { MyWorkerA } from "./src/worker-a.ts";
+import type { MyWorkerB } from "./src/worker-B.ts";
+
+// Create workerA that binds to workerB stub
+const workerA = await Worker("workerA", {
+  name: "worker-a",
+  entrypoint: "./src/workerA.ts",
+  rpc: type<MyWorkerA>,
+  bindings: {
+    // bind to a stub (empty worker)
+    WORKER_B: await WorkerStub<MyWorkerB>("workerB", {
+      name: "worker-b",
+      rpc: type<MyWorkerB>,
+    });,
+  },
+});
+
+// Create workerB that binds to workerA
+const workerB = await Worker("workerB", {
+  name: "worker-b",
+  entrypoint: "./src/workerB.ts",
+  bindings: {
+    WORKER_A: workerA,
+  },
+});
+```
+
 ## RPC
 
 Create a Worker with RPC capabilities using WorkerEntrypoint and typed RPC interfaces:

--- a/alchemy/src/cloudflare/bound.ts
+++ b/alchemy/src/cloudflare/bound.ts
@@ -18,8 +18,20 @@ import type { SecretKey } from "./secret-key.ts";
 import type { Secret as CloudflareSecret } from "./secret.ts";
 import type { VectorizeIndexResource as _VectorizeIndex } from "./vectorize-index.ts";
 import type { VersionMetadata as _VersionMetadata } from "./version-metadata.ts";
+import type { WorkerStub } from "./worker-stub.ts";
 import type { Worker as _Worker, WorkerRef } from "./worker.ts";
 import type { Workflow as _Workflow } from "./workflow.ts";
+
+type BoundWorker<
+  RPC extends Rpc.WorkerEntrypointBranded = Rpc.WorkerEntrypointBranded,
+> = Service<RPC> & {
+  // cloudflare's Rpc.Provider type loses mapping between properties (jump to definition)
+  // we fix that using Pick to re-connect mappings
+  [property in keyof Pick<
+    RPC,
+    Extract<keyof Rpc.Provider<RPC, "fetch" | "connect">, keyof RPC>
+  >]: Rpc.Provider<RPC, "fetch" | "connect">[property];
+};
 
 export type Bound<T extends Binding> = T extends _DurableObjectNamespace<
   infer O
@@ -27,57 +39,52 @@ export type Bound<T extends Binding> = T extends _DurableObjectNamespace<
   ? DurableObjectNamespace<O>
   : T extends { type: "kv_namespace" }
     ? KVNamespace
-    : T extends _Worker<any, infer RPC> | WorkerRef<infer RPC>
-      ? Service<RPC> & {
-          // cloudflare's Rpc.Provider type loses mapping between properties (jump to definition)
-          // we fix that using Pick to re-connect mappings
-          [property in keyof Pick<
-            RPC,
-            Extract<keyof Rpc.Provider<RPC, "fetch" | "connect">, keyof RPC>
-          >]: Rpc.Provider<RPC, "fetch" | "connect">[property];
-        }
-      : T extends { type: "service" }
-        ? Service
-        : T extends _R2Bucket
-          ? R2Bucket
-          : T extends _AiGateway
-            ? AiGateway
-            : T extends _Hyperdrive
-              ? Hyperdrive
-              : T extends Secret
-                ? string
-                : T extends CloudflareSecret
-                  ? SecretsStoreSecret
-                  : T extends SecretKey
-                    ? CryptoKey
-                    : T extends Assets
-                      ? Service
-                      : T extends _Workflow<infer P>
-                        ? Workflow<P>
-                        : T extends D1DatabaseResource
-                          ? D1Database
-                          : T extends DispatchNamespaceResource
-                            ? { get(name: string): Fetcher }
-                            : T extends _VectorizeIndex
-                              ? VectorizeIndex
-                              : T extends _Queue<infer Body>
-                                ? Queue<Body>
-                                : T extends _AnalyticsEngineDataset
-                                  ? AnalyticsEngineDataset
-                                  : T extends _Pipeline<infer R>
-                                    ? Pipeline<R>
-                                    : T extends string
-                                      ? string
-                                      : T extends BrowserRendering
-                                        ? Fetcher
-                                        : T extends _Ai<infer M>
-                                          ? Ai<M>
-                                          : T extends _Images
-                                            ? ImagesBinding
-                                            : T extends _VersionMetadata
-                                              ? WorkerVersionMetadata
-                                              : T extends Self
-                                                ? Service
-                                                : T extends Json<infer T>
-                                                  ? T
-                                                  : Service;
+    : T extends WorkerStub<infer RPC>
+      ? BoundWorker<RPC>
+      : T extends _Worker<any, infer RPC> | WorkerRef<infer RPC>
+        ? BoundWorker<RPC>
+        : T extends { type: "service" }
+          ? Service
+          : T extends _R2Bucket
+            ? R2Bucket
+            : T extends _AiGateway
+              ? AiGateway
+              : T extends _Hyperdrive
+                ? Hyperdrive
+                : T extends Secret
+                  ? string
+                  : T extends CloudflareSecret
+                    ? SecretsStoreSecret
+                    : T extends SecretKey
+                      ? CryptoKey
+                      : T extends Assets
+                        ? Service
+                        : T extends _Workflow<infer P>
+                          ? Workflow<P>
+                          : T extends D1DatabaseResource
+                            ? D1Database
+                            : T extends DispatchNamespaceResource
+                              ? { get(name: string): Fetcher }
+                              : T extends _VectorizeIndex
+                                ? VectorizeIndex
+                                : T extends _Queue<infer Body>
+                                  ? Queue<Body>
+                                  : T extends _AnalyticsEngineDataset
+                                    ? AnalyticsEngineDataset
+                                    : T extends _Pipeline<infer R>
+                                      ? Pipeline<R>
+                                      : T extends string
+                                        ? string
+                                        : T extends BrowserRendering
+                                          ? Fetcher
+                                          : T extends _Ai<infer M>
+                                            ? Ai<M>
+                                            : T extends _Images
+                                              ? ImagesBinding
+                                              : T extends _VersionMetadata
+                                                ? WorkerVersionMetadata
+                                                : T extends Self
+                                                  ? Service
+                                                  : T extends Json<infer T>
+                                                    ? T
+                                                    : Service;

--- a/alchemy/src/cloudflare/worker-stub.ts
+++ b/alchemy/src/cloudflare/worker-stub.ts
@@ -1,5 +1,6 @@
 import type { Context } from "../context.ts";
 import { Resource, ResourceKind } from "../resource.ts";
+import type { type } from "../type.ts";
 import { handleApiError } from "./api-error.ts";
 import {
   createCloudflareApi,
@@ -10,22 +11,40 @@ import {
 /**
  * Properties for creating a Worker stub
  */
-export interface WorkerStubProps extends CloudflareApiOptions {
+export interface WorkerStubProps<
+  RPC extends Rpc.WorkerEntrypointBranded = Rpc.WorkerEntrypointBranded,
+> extends CloudflareApiOptions {
   /**
    * Name for the worker
    */
   name: string;
+
+  /**
+   * The RPC class to use for the worker.
+   *
+   * This is only used when using the rpc property.
+   */
+  rpc?: (new (...args: any[]) => RPC) | type<RPC>;
 }
 
 /**
  * Output returned after WorkerStub creation
  */
-export interface WorkerStub extends Resource<"cloudflare::WorkerStub"> {
+export interface WorkerStub<
+  RPC extends Rpc.WorkerEntrypointBranded = Rpc.WorkerEntrypointBranded,
+> extends Resource<"cloudflare::WorkerStub"> {
   type: "service";
   /**
    * The name of the worker
    */
   name: string;
+
+  /**
+   * Optional type branding for the worker's RPC entrypoint.
+   *
+   * @internal
+   */
+  __rpc__?: RPC;
 }
 
 export function isWorkerStub(resource: Resource): resource is WorkerStub {
@@ -47,33 +66,31 @@ export function isWorkerStub(resource: Resource): resource is WorkerStub {
  *
  * console.log(`Worker ${workerStub.name} exists: ${!workerStub.created}`);
  */
-export const WorkerStub = Resource(
-  "cloudflare::WorkerStub",
-  async function (
-    this: Context<WorkerStub>,
-    _id: string,
-    props: WorkerStubProps,
-  ): Promise<WorkerStub> {
-    // Create Cloudflare API client with automatic account discovery
-    const api = await createCloudflareApi(props);
+export const WorkerStub = Resource("cloudflare::WorkerStub", async function <
+  RPC extends Rpc.WorkerEntrypointBranded = Rpc.WorkerEntrypointBranded,
+>(this: Context<WorkerStub>, _id: string, props: WorkerStubProps<RPC>): Promise<
+  WorkerStub<RPC>
+> {
+  // Create Cloudflare API client with automatic account discovery
+  const api = await createCloudflareApi(props);
 
-    if (this.phase === "delete") {
-      // We don't actually delete the worker, just mark the resource as destroyed
-      return this.destroy();
-    }
+  if (this.phase === "delete") {
+    // We don't actually delete the worker, just mark the resource as destroyed
+    return this.destroy();
+  }
 
-    // If worker doesn't exist and we're in create phase, create an empty one
-    if (!(await exists(api, props.name)) && this.phase === "create") {
-      await createEmptyWorker(api, props.name);
-    }
+  // If worker doesn't exist and we're in create phase, create an empty one
+  if (!(await exists(api, props.name)) && this.phase === "create") {
+    await createEmptyWorker(api, props.name);
+  }
 
-    // Return the worker stub info
-    return this({
-      type: "service",
-      ...props,
-    });
-  },
-);
+  // Return the worker stub info
+  return this({
+    type: "service",
+    __rpc__: props.rpc as unknown as RPC,
+    ...props,
+  }) as WorkerStub<RPC>;
+});
 
 async function exists(
   api: CloudflareApi,

--- a/alchemy/test/cloudflare/worker-stub.test.ts
+++ b/alchemy/test/cloudflare/worker-stub.test.ts
@@ -1,0 +1,41 @@
+import { test } from "vitest";
+import { Worker, WorkerStub } from "../../src/cloudflare/index.ts";
+
+test("worker-stub-types", () => {
+  // type-only test
+  async function _() {
+    const { WorkerEntrypoint } = await import("cloudflare:workers");
+
+    class MyWorker extends WorkerEntrypoint {
+      async foo() {
+        return "foo";
+      }
+    }
+
+    const workerA = await Worker("workerA", {
+      entrypoint: "index.ts",
+      name: "workerA",
+      bindings: {
+        workerB: await WorkerStub<MyWorker>("workerB", {
+          name: "workerB",
+        }),
+      },
+    });
+
+    const _workerB = await Worker("workerB", {
+      entrypoint: "index.ts",
+      name: "workerB",
+      bindings: {
+        workerA,
+      },
+    });
+
+    const env = workerA.Env;
+
+    const _string: string = await env.workerB.foo();
+    // @ts-expect-error
+    const _number: number = await env.workerB.foo();
+    // @ts-expect-error
+    env.workerB.bar();
+  }
+});


### PR DESCRIPTION
```ts
const workerA = await Worker("workerA", {
  entrypoint: "index.ts",
  name: "workerA",
  bindings: {
    workerB: await WorkerStub<MyWorker>("workerB", {
      name: "workerB",
    }),
  },
});

const _workerB = await Worker("workerB", {
  entrypoint: "index.ts",
  name: "workerB",
  bindings: {
    workerA,
  },
});

const env = workerA.Env;

const _string: string = await env.workerB.foo();
// @ts-expect-error
const _number: number = await env.workerB.foo();
// @ts-expect-error
env.workerB.bar();
```