### PR TITLE
feat: allow colors in CI environments, only disable for NO_COLOR

### DIFF
--- a/alchemy/src/cloudflare/bundle/bundle-worker.ts
+++ b/alchemy/src/cloudflare/bundle/bundle-worker.ts
@@ -71,7 +71,7 @@ export async function bundleWorkerScript<B extends Bindings>(
         ).flat(),
       ),
     );
-    const useColor = !(process.env.CI || process.env.NO_COLOR);
+    const useColor = !process.env.NO_COLOR;
     logger.log(
       `${useColor ? kleur.gray("worker:") : "worker:"} ${useColor ? kleur.blue(props.name) : props.name}`,
     );

--- a/alchemy/src/util/cli.ts
+++ b/alchemy/src/util/cli.ts
@@ -17,9 +17,7 @@ type ColorName = keyof typeof colors;
 
 // Check if colors should be disabled
 const shouldDisableColors = (): boolean => {
-  return Boolean(
-    process.env.CI || process.env.NO_COLOR || !process.stdout.isTTY,
-  );
+  return Boolean(process.env.NO_COLOR || !process.stdout.isTTY);
 };
 
 // Apply color if colors are enabled


### PR DESCRIPTION
Remove process.env.CI checks from color handling logic to allow colors in CI environments. Colors are now only disabled when NO_COLOR is set or when output is not a TTY.

This change affects:
- alchemy/src/util/cli.ts: shouldDisableColors() function
- alchemy/src/cloudflare/bundle/bundle-worker.ts: kleur color handling

Closes #428

Generated with [Claude Code](https://claude.ai/code)