### PR TITLE
fix(fsss & fs): better support for windows file system

### DIFF
--- a/alchemy/src/fs/file-system-state-store.ts
+++ b/alchemy/src/fs/file-system-state-store.ts
@@ -128,7 +128,7 @@ export class FileSystemStateStore implements StateStore {
       throw new Error(`ID cannot include colons: ${key}`);
     }
     if (key.includes("/")) {
-      key = key.replaceAll("/", ":");
+      key = key.replaceAll("/", "-");
     }
     return path.join(this.dir, `${key}.json`);
   }

--- a/alchemy/src/fs/file-system-state-store.ts
+++ b/alchemy/src/fs/file-system-state-store.ts
@@ -7,6 +7,7 @@ import { deserializeState, type State, type StateStore } from "../state.ts";
 import { ignore } from "../util/ignore.ts";
 
 const stateRootDir = path.join(process.cwd(), ".alchemy");
+const ALCHEMY_SEPERATOR_CHAR = process.platform === "win32" ? "-" : ":";
 
 export class FileSystemStateStore implements StateStore {
   public readonly dir: string;
@@ -128,7 +129,10 @@ export class FileSystemStateStore implements StateStore {
       throw new Error(`ID cannot include colons: ${key}`);
     }
     if (key.includes("/")) {
-      key = key.replaceAll("/", "-");
+      //todo(michael): remove this next time we do a breaking change
+      //* windows doesn't support ":" in file paths, but we already use ":"
+      //* so now we use both to prevent breaking changes`
+      key = key.replaceAll("/", ALCHEMY_SEPERATOR_CHAR);
     }
     return path.join(this.dir, `${key}.json`);
   }

--- a/alchemy/src/fs/file.ts
+++ b/alchemy/src/fs/file.ts
@@ -184,9 +184,12 @@ export const File = Resource(
     }
 
     // Create directory and write file
-    await fs.promises.mkdir(path.dirname(filePath), {
-      recursive: true,
-    });
+    const dirName = path.dirname(filePath);
+    if (dirName !== ".") {
+      await fs.promises.mkdir(dirName, {
+        recursive: true,
+      });
+    }
 
     await fs.promises.writeFile(filePath, props.content);
 


### PR DESCRIPTION
## What this does
- doesn't call create folder if its trying to create `.`
- fixes a colon in file paths in FS-state-stire