### PR TITLE
feat(cloudflare): add CustomHostname resource for Cloudflare for SaaS

### DIFF
--- a/alchemy-web/docs/providers/cloudflare/custom-hostname.md
+++ b/alchemy-web/docs/providers/cloudflare/custom-hostname.md
@@ -1,0 +1,187 @@
+# CustomHostname
+
+Create and manage Custom Hostnames for Cloudflare for SaaS. Custom Hostnames allow you to provide SSL certificates for your customer's domains that point to your Cloudflare zone.
+
+## Example Usage
+
+### Basic Custom Hostname
+
+Create a custom hostname with default SSL settings:
+
+```ts
+import { Zone, CustomHostname } from "@alchemy/cloudflare";
+
+const zone = await Zone("example-zone", {
+  name: "example.com"
+});
+
+const customHostname = await CustomHostname("customer-hostname", {
+  hostname: "app.customer.com",
+  zone: zone,
+  ssl: {
+    method: "http",
+    type: "dv"
+  }
+});
+
+console.log(`Custom hostname ID: ${customHostname.id}`);
+console.log(`Status: ${customHostname.status}`);
+console.log(`SSL Status: ${customHostname.ssl.status}`);
+```
+
+### Custom Hostname with Advanced SSL Settings
+
+Create a custom hostname with specific SSL configuration:
+
+```ts
+const customHostname = await CustomHostname("secure-hostname", {
+  hostname: "secure.customer.com", 
+  zone: "your-zone-id",
+  ssl: {
+    method: "txt",
+    type: "dv",
+    settings: {
+      http2: "on",
+      tls_1_3: "on",
+      min_tls_version: "1.2"
+    },
+    bundle_method: "optimal"
+  },
+  custom_metadata: {
+    customer_id: "12345",
+    plan: "enterprise"
+  }
+});
+```
+
+### Custom Hostname with Wildcard Certificate
+
+Create a wildcard custom hostname:
+
+```ts
+const wildcardHostname = await CustomHostname("wildcard-hostname", {
+  hostname: "*.customer.com",
+  zone: zone,
+  ssl: {
+    method: "txt",
+    type: "dv",
+    wildcard: true,
+    bundle_method: "ubiquitous"
+  }
+});
+```
+
+## Properties
+
+### Required Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `hostname` | `string` | The custom hostname to create (e.g., "app.customer.com") |
+| `zone` | `string \| Zone` | The zone where the custom hostname will be created |
+
+### Optional Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `ssl` | `CustomHostnameSslSettings` | SSL configuration for the hostname |
+| `custom_metadata` | `Record<string, string>` | Custom metadata key-value pairs |
+
+### SSL Settings
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `method` | `"http" \| "txt" \| "email"` | `"http"` | SSL certificate validation method |
+| `type` | `"dv"` | `"dv"` | SSL certificate type (Domain Validated) |
+| `bundle_method` | `"ubiquitous" \| "optimal" \| "force_ubiquitous"` | `"ubiquitous"` | Certificate bundle method |
+| `wildcard` | `boolean` | `false` | Enable wildcard certificate |
+| `settings` | `object` | - | Advanced SSL settings |
+
+### Advanced SSL Settings
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `http2` | `"on" \| "off"` | `"on"` | Enable HTTP/2 |
+| `tls_1_3` | `"on" \| "off"` | `"on"` | Enable TLS 1.3 |
+| `min_tls_version` | `"1.0" \| "1.1" \| "1.2" \| "1.3"` | `"1.2"` | Minimum TLS version |
+| `ciphers` | `string[]` | - | Custom cipher list |
+
+## Outputs
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `id` | `string` | Unique identifier for the custom hostname |
+| `zoneId` | `string` | Zone ID where the hostname was created |
+| `status` | `string` | Current status of the custom hostname |
+| `ssl` | `object` | SSL certificate information and status |
+| `ownershipVerification` | `object` | Ownership verification details |
+| `ownershipVerificationHttp` | `object` | HTTP verification details (if applicable) |
+| `verificationErrors` | `string[]` | Any verification errors |
+| `createdAt` | `number` | Creation timestamp |
+| `modifiedAt` | `number` | Last modification timestamp |
+
+## Status Values
+
+Custom hostnames can have the following status values:
+
+- `pending_validation` - Waiting for domain validation
+- `pending_issuance` - SSL certificate being issued
+- `pending_deployment` - SSL certificate being deployed
+- `active` - Custom hostname is active and ready to use
+- `moved` - Hostname moved to different account
+- `deleted` - Hostname has been deleted
+
+## SSL Verification Methods
+
+### HTTP Verification (`method: "http"`)
+
+With HTTP verification, Cloudflare will make an HTTP request to verify domain ownership:
+
+```ts
+// Access verification details from the hostname output
+if (customHostname.ownershipVerificationHttp) {
+  console.log(`Place this content: ${customHostname.ownershipVerificationHttp.httpBody}`);
+  console.log(`At this URL: ${customHostname.ownershipVerificationHttp.httpUrl}`);
+}
+```
+
+### TXT Record Verification (`method: "txt"`)
+
+With TXT verification, you need to create a DNS TXT record:
+
+```ts
+// Access verification details from the hostname output
+if (customHostname.ownershipVerification) {
+  console.log(`Create TXT record: ${customHostname.ownershipVerification.name}`);
+  console.log(`With value: ${customHostname.ownershipVerification.value}`);
+}
+```
+
+## Error Handling
+
+Check for verification errors:
+
+```ts
+if (customHostname.verificationErrors && customHostname.verificationErrors.length > 0) {
+  console.error("Verification errors:", customHostname.verificationErrors);
+}
+```
+
+## Best Practices
+
+1. **Use TXT verification for production** - More secure than HTTP verification
+2. **Monitor status** - Check the status and verification errors regularly
+3. **Use metadata for tracking** - Store customer information in custom_metadata
+4. **Choose appropriate bundle method** - Use "optimal" for better performance, "ubiquitous" for compatibility
+5. **Enable modern TLS settings** - Use TLS 1.3 and modern cipher suites when possible
+
+## Related Resources
+
+- [Zone](./zone.md) - Cloudflare zone management
+- [CustomDomain](./custom-domain.md) - Worker custom domains
+- [DNS Records](./dns-records.md) - DNS record management
+
+## Reference
+
+- [Cloudflare Custom Hostnames API](https://developers.cloudflare.com/api/resources/custom_hostnames/)
+- [Cloudflare for SaaS Documentation](https://developers.cloudflare.com/cloudflare-for-platforms/cloudflare-for-saas/)

--- a/alchemy/src/cloudflare/custom-hostname.ts
+++ b/alchemy/src/cloudflare/custom-hostname.ts
@@ -1,0 +1,627 @@
+import type { Context } from "../context.ts";
+import { Resource } from "../resource.ts";
+import { logger } from "../util/logger.ts";
+import { handleApiError } from "./api-error.ts";
+import {
+  createCloudflareApi,
+  type CloudflareApi,
+  type CloudflareApiOptions,
+} from "./api.ts";
+import type { Zone } from "./zone.ts";
+
+/**
+ * SSL settings for custom hostname
+ */
+export interface CustomHostnameSslSettings {
+  /**
+   * SSL certificate method
+   * "http" - HTTP validation
+   * "txt" - TXT record validation
+   * "email" - Email validation
+   * @default "http"
+   */
+  method?: "http" | "txt" | "email";
+
+  /**
+   * SSL certificate type
+   * "dv" - Domain Validated
+   * @default "dv"
+   */
+  type?: "dv";
+
+  /**
+   * SSL certificate settings
+   */
+  settings?: {
+    /**
+     * HTTP/2 settings
+     * "on" - Enable HTTP/2
+     * "off" - Disable HTTP/2
+     * @default "on"
+     */
+    http2?: "on" | "off";
+
+    /**
+     * TLS 1.3 settings
+     * "on" - Enable TLS 1.3
+     * "off" - Disable TLS 1.3
+     * @default "on"
+     */
+    tls_1_3?: "on" | "off";
+
+    /**
+     * Minimum TLS version
+     * @default "1.2"
+     */
+    min_tls_version?: "1.0" | "1.1" | "1.2" | "1.3";
+
+    /**
+     * Cipher list
+     */
+    ciphers?: string[];
+  };
+
+  /**
+   * Bundle method for certificate
+   * "ubiquitous" - Ubiquitous bundle
+   * "optimal" - Optimal bundle
+   * "force_ubiquitous" - Force ubiquitous bundle
+   * @default "ubiquitous"
+   */
+  bundle_method?: "ubiquitous" | "optimal" | "force_ubiquitous";
+
+  /**
+   * Wildcard setting
+   * @default false
+   */
+  wildcard?: boolean;
+}
+
+/**
+ * Properties for creating or updating a CustomHostname
+ */
+export interface CustomHostnameProps extends CloudflareApiOptions {
+  /**
+   * The custom hostname
+   */
+  hostname: string;
+
+  /**
+   * The zone where the custom hostname will be created.
+   * Can be a Zone resource or zone ID string.
+   */
+  zone: string | Zone;
+
+  /**
+   * SSL configuration for the custom hostname
+   */
+  ssl?: CustomHostnameSslSettings;
+
+  /**
+   * Custom metadata for the hostname (key-value pairs)
+   */
+  custom_metadata?: Record<string, string>;
+}
+
+/**
+ * SSL verification details from Cloudflare API
+ */
+interface CustomHostnameSslVerification {
+  method: string;
+  type: string;
+  record_name?: string;
+  record_value?: string;
+  txt_name?: string;
+  txt_value?: string;
+  http_url?: string;
+  http_body?: string;
+}
+
+/**
+ * SSL status from Cloudflare API
+ */
+interface CustomHostnameSsl {
+  id?: string;
+  status: string;
+  method: string;
+  type: string;
+  verification_type?: string;
+  verification_info?: CustomHostnameSslVerification;
+  certificate_authority?: string;
+  bundle_method?: string;
+  wildcard?: boolean;
+  settings?: {
+    http2?: string;
+    tls_1_3?: string;
+    min_tls_version?: string;
+    ciphers?: string[];
+  };
+}
+
+/**
+ * Ownership verification from Cloudflare API
+ */
+interface CustomHostnameOwnershipVerification {
+  type: string;
+  name: string;
+  value: string;
+}
+
+/**
+ * Cloudflare Custom Hostname object structure from API
+ */
+interface CloudflareCustomHostname {
+  id: string;
+  hostname: string;
+  ssl: CustomHostnameSsl;
+  custom_metadata?: Record<string, string>;
+  status: string;
+  verification_errors?: string[];
+  ownership_verification?: CustomHostnameOwnershipVerification;
+  ownership_verification_http?: {
+    http_url: string;
+    http_body: string;
+  };
+  created_at: string;
+  modified_at?: string;
+}
+
+/**
+ * Output returned after CustomHostname creation/update
+ */
+export interface CustomHostname
+  extends Resource<"cloudflare::CustomHostname">,
+    Omit<CustomHostnameProps, "zone"> {
+  /**
+   * The unique identifier for the custom hostname
+   */
+  id: string;
+
+  /**
+   * The zone ID where the custom hostname was created
+   */
+  zoneId: string;
+
+  /**
+   * Current status of the custom hostname
+   * "pending_validation" - Waiting for validation
+   * "pending_issuance" - Certificate being issued
+   * "pending_deployment" - Certificate being deployed
+   * "active" - Active and ready to use
+   * "moved" - Hostname moved to different account
+   * "deleted" - Hostname deleted
+   */
+  status: string;
+
+  /**
+   * SSL certificate information and status
+   */
+  ssl: CustomHostnameSsl;
+
+  /**
+   * Ownership verification information
+   */
+  ownershipVerification?: CustomHostnameOwnershipVerification;
+
+  /**
+   * HTTP ownership verification (if applicable)
+   */
+  ownershipVerificationHttp?: {
+    httpUrl: string;
+    httpBody: string;
+  };
+
+  /**
+   * Any verification errors
+   */
+  verificationErrors?: string[];
+
+  /**
+   * Time at which the custom hostname was created
+   */
+  createdAt: number;
+
+  /**
+   * Time at which the custom hostname was last modified
+   */
+  modifiedAt?: number;
+}
+
+/**
+ * Create and manage Custom Hostnames for Cloudflare for SaaS.
+ * Custom Hostnames allow you to provide SSL certificates for your customer's domains.
+ *
+ * @example
+ * ## Basic Custom Hostname
+ *
+ * Create a custom hostname with default SSL settings:
+ *
+ * ```ts
+ * const zone = await Zone("example-zone", {
+ *   name: "example.com"
+ * });
+ *
+ * const customHostname = await CustomHostname("customer-hostname", {
+ *   hostname: "app.customer.com",
+ *   zone: zone,
+ *   ssl: {
+ *     method: "http",
+ *     type: "dv"
+ *   }
+ * });
+ * ```
+ *
+ * @example
+ * ## Custom Hostname with Advanced SSL Settings
+ *
+ * Create a custom hostname with specific SSL configuration:
+ *
+ * ```ts
+ * const customHostname = await CustomHostname("secure-hostname", {
+ *   hostname: "secure.customer.com",
+ *   zone: "your-zone-id",
+ *   ssl: {
+ *     method: "txt",
+ *     type: "dv",
+ *     settings: {
+ *       http2: "on",
+ *       tls_1_3: "on",
+ *       min_tls_version: "1.2"
+ *     },
+ *     bundle_method: "optimal"
+ *   },
+ *   custom_metadata: {
+ *     customer_id: "12345",
+ *     plan: "enterprise"
+ *   }
+ * });
+ * ```
+ *
+ * @see https://developers.cloudflare.com/api/resources/custom_hostnames/
+ * @see https://developers.cloudflare.com/cloudflare-for-platforms/cloudflare-for-saas/start/getting-started/
+ */
+export const CustomHostname = Resource(
+  "cloudflare::CustomHostname",
+  async function (
+    this: Context<CustomHostname>,
+    logicalId: string,
+    props: CustomHostnameProps,
+  ): Promise<CustomHostname> {
+    // Create Cloudflare API client with automatic account discovery
+    const api = await createCloudflareApi(props);
+
+    // Validate required properties
+    if (!props.hostname) {
+      throw new Error("Hostname (props.hostname) is required");
+    }
+    if (!props.zone) {
+      throw new Error("Zone (props.zone) is required");
+    }
+
+    // Extract zone ID from Zone resource or use string directly
+    const zoneId = typeof props.zone === "string" ? props.zone : props.zone.id;
+
+    if (this.phase === "delete") {
+      await deleteCustomHostname(this, api, zoneId, logicalId);
+      return this.destroy();
+    }
+
+    // Create or Update phase
+    return await ensureCustomHostname(this, api, zoneId, logicalId, props);
+  },
+);
+
+/**
+ * Helper function to delete the custom hostname
+ */
+async function deleteCustomHostname(
+  context: Context<CustomHostname>,
+  api: CloudflareApi,
+  zoneId: string,
+  logicalId: string,
+): Promise<void> {
+  const customHostnameId = context.output?.id;
+
+  if (!customHostnameId) {
+    logger.warn(
+      `Cannot delete CustomHostname ${logicalId}: Missing custom hostname ID in state. Assuming already deleted.`,
+    );
+    return;
+  }
+
+  logger.log(`Deleting CustomHostname ${customHostnameId} from zone ${zoneId}`);
+
+  const response = await api.delete(
+    `/zones/${zoneId}/custom_hostnames/${customHostnameId}`,
+  );
+
+  logger.log(
+    `Delete result for ${customHostnameId}:`,
+    response.status,
+    response.statusText,
+  );
+
+  // 404 is acceptable during deletion for idempotency
+  if (!response.ok && response.status !== 404) {
+    await handleApiError(
+      response,
+      "deleting",
+      "custom hostname",
+      customHostnameId,
+    );
+    throw new Error(
+      `Failed to delete custom hostname ${customHostnameId}: ${response.statusText}`,
+    );
+  }
+}
+
+/**
+ * Helper function to create or update the custom hostname
+ */
+async function ensureCustomHostname(
+  context: Context<CustomHostname>,
+  api: CloudflareApi,
+  zoneId: string,
+  _logicalId: string,
+  props: CustomHostnameProps,
+): Promise<CustomHostname> {
+  const hostname = props.hostname;
+  let existingHostname: CloudflareCustomHostname | undefined;
+
+  // Check if custom hostname already exists in the zone
+  logger.log(
+    `Checking existing custom hostnames for zone ${zoneId} and hostname ${hostname}`,
+  );
+
+  const listResponse = await api.get(`/zones/${zoneId}/custom_hostnames`);
+
+  if (!listResponse.ok) {
+    await handleApiError(
+      listResponse,
+      "listing",
+      "custom hostnames",
+      `Zone ${zoneId}`,
+    );
+    throw new Error(
+      `Failed to list custom hostnames for zone ${zoneId}: ${listResponse.statusText}`,
+    );
+  }
+
+  const listData = (await listResponse.json()) as {
+    result?: CloudflareCustomHostname[];
+    success: boolean;
+  };
+
+  if (!listData.success || !listData.result) {
+    throw new Error(
+      `Failed to parse list custom hostnames response: ${JSON.stringify(listData)}`,
+    );
+  }
+
+  // Find existing hostname by hostname value
+  existingHostname = listData.result.find((h) => h.hostname === hostname);
+
+  let operationPerformed: "create" | "update" | "none" = "none";
+  let resultHostname: CloudflareCustomHostname;
+
+  if (existingHostname) {
+    // Update existing hostname if needed
+    const needsUpdate = doesCustomHostnameNeedUpdate(existingHostname, props);
+
+    if (needsUpdate) {
+      operationPerformed = "update";
+      logger.log(
+        `Updating custom hostname: ${hostname} (ID: ${existingHostname.id})`,
+      );
+
+      const updatePayload = buildCustomHostnamePayload(props);
+      const patchResponse = await api.patch(
+        `/zones/${zoneId}/custom_hostnames/${existingHostname.id}`,
+        updatePayload,
+      );
+
+      if (!patchResponse.ok) {
+        await handleApiError(
+          patchResponse,
+          "updating",
+          "custom hostname",
+          hostname,
+        );
+        throw new Error(
+          `Failed to update custom hostname ${hostname}: ${patchResponse.statusText}`,
+        );
+      }
+
+      const patchResult = (await patchResponse.json()) as {
+        result?: CloudflareCustomHostname;
+        success: boolean;
+      };
+
+      if (!patchResult.success || !patchResult.result) {
+        throw new Error(
+          `Failed to parse update custom hostname response: ${JSON.stringify(patchResult)}`,
+        );
+      }
+
+      resultHostname = patchResult.result;
+      logger.log(`Successfully updated custom hostname: ${hostname}`);
+    } else {
+      logger.log(
+        `Custom hostname already exists and is up to date: ${hostname} (ID: ${existingHostname.id})`,
+      );
+      resultHostname = existingHostname;
+    }
+  } else {
+    // Create new custom hostname
+    operationPerformed = "create";
+    logger.log(`Creating custom hostname: ${hostname} in zone ${zoneId}`);
+
+    const createPayload = buildCustomHostnamePayload(props);
+    const postResponse = await api.post(
+      `/zones/${zoneId}/custom_hostnames`,
+      createPayload,
+    );
+
+    if (!postResponse.ok) {
+      await handleApiError(
+        postResponse,
+        "creating",
+        "custom hostname",
+        hostname,
+      );
+      throw new Error(
+        `Failed to create custom hostname ${hostname}: ${postResponse.statusText}`,
+      );
+    }
+
+    const postResult = (await postResponse.json()) as {
+      result?: CloudflareCustomHostname;
+      success: boolean;
+    };
+
+    if (!postResult.success || !postResult.result) {
+      throw new Error(
+        `Failed to parse create custom hostname response: ${JSON.stringify(postResult)}`,
+      );
+    }
+
+    resultHostname = postResult.result;
+    logger.log(
+      `Successfully created custom hostname: ${hostname} (ID: ${resultHostname.id})`,
+    );
+  }
+
+  const now = Date.now();
+
+  // Construct the output state
+  return context({
+    ...props,
+    id: resultHostname.id,
+    zoneId,
+    hostname: resultHostname.hostname,
+    status: resultHostname.status,
+    ssl: resultHostname.ssl,
+    custom_metadata: resultHostname.custom_metadata,
+    ownershipVerification: resultHostname.ownership_verification,
+    ownershipVerificationHttp: resultHostname.ownership_verification_http
+      ? {
+          httpUrl: resultHostname.ownership_verification_http.http_url,
+          httpBody: resultHostname.ownership_verification_http.http_body,
+        }
+      : undefined,
+    verificationErrors: resultHostname.verification_errors,
+    createdAt: new Date(resultHostname.created_at).getTime(),
+    modifiedAt: resultHostname.modified_at
+      ? new Date(resultHostname.modified_at).getTime()
+      : operationPerformed !== "none"
+        ? now
+        : context.output?.modifiedAt,
+  });
+}
+
+/**
+ * Helper function to build the API payload for custom hostname creation/update
+ */
+function buildCustomHostnamePayload(props: CustomHostnameProps) {
+  const payload: any = {
+    hostname: props.hostname,
+  };
+
+  if (props.ssl) {
+    payload.ssl = {
+      method: props.ssl.method || "http",
+      type: props.ssl.type || "dv",
+    };
+
+    if (props.ssl.settings) {
+      payload.ssl.settings = props.ssl.settings;
+    }
+
+    if (props.ssl.bundle_method) {
+      payload.ssl.bundle_method = props.ssl.bundle_method;
+    }
+
+    if (props.ssl.wildcard !== undefined) {
+      payload.ssl.wildcard = props.ssl.wildcard;
+    }
+  }
+
+  if (props.custom_metadata) {
+    payload.custom_metadata = props.custom_metadata;
+  }
+
+  return payload;
+}
+
+/**
+ * Helper function to determine if a custom hostname needs updating
+ */
+function doesCustomHostnameNeedUpdate(
+  existing: CloudflareCustomHostname,
+  props: CustomHostnameProps,
+): boolean {
+  // Check SSL settings
+  if (props.ssl) {
+    if (props.ssl.method && existing.ssl.method !== props.ssl.method) {
+      return true;
+    }
+    if (props.ssl.type && existing.ssl.type !== props.ssl.type) {
+      return true;
+    }
+    if (
+      props.ssl.bundle_method &&
+      existing.ssl.bundle_method !== props.ssl.bundle_method
+    ) {
+      return true;
+    }
+    if (
+      props.ssl.wildcard !== undefined &&
+      existing.ssl.wildcard !== props.ssl.wildcard
+    ) {
+      return true;
+    }
+    if (props.ssl.settings) {
+      const existingSettings = existing.ssl.settings || {};
+      if (
+        props.ssl.settings.http2 &&
+        existingSettings.http2 !== props.ssl.settings.http2
+      ) {
+        return true;
+      }
+      if (
+        props.ssl.settings.tls_1_3 &&
+        existingSettings.tls_1_3 !== props.ssl.settings.tls_1_3
+      ) {
+        return true;
+      }
+      if (
+        props.ssl.settings.min_tls_version &&
+        existingSettings.min_tls_version !== props.ssl.settings.min_tls_version
+      ) {
+        return true;
+      }
+    }
+  }
+
+  // Check custom metadata
+  if (props.custom_metadata) {
+    const existingMetadata = existing.custom_metadata || {};
+    const newMetadata = props.custom_metadata;
+
+    // Compare metadata keys and values
+    const existingKeys = Object.keys(existingMetadata);
+    const newKeys = Object.keys(newMetadata);
+
+    if (existingKeys.length !== newKeys.length) {
+      return true;
+    }
+
+    for (const key of newKeys) {
+      if (existingMetadata[key] !== newMetadata[key]) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}

--- a/alchemy/src/cloudflare/index.ts
+++ b/alchemy/src/cloudflare/index.ts
@@ -14,6 +14,7 @@ export * from "./bucket.ts";
 export * from "./bundle/external.ts";
 export * from "./bundle/local-dev-cloudflare-shim.ts";
 export * from "./custom-domain.ts";
+export * from "./custom-hostname.ts";
 export * from "./d1-clone.ts";
 export * from "./d1-database.ts";
 export * from "./d1-export.ts";

--- a/alchemy/test/cloudflare/custom-hostname.test.ts
+++ b/alchemy/test/cloudflare/custom-hostname.test.ts
@@ -1,0 +1,275 @@
+import { describe, expect } from "vitest";
+import { alchemy } from "../../src/alchemy.ts";
+import { createCloudflareApi } from "../../src/cloudflare/api.ts";
+import { CustomHostname } from "../../src/cloudflare/custom-hostname.ts";
+import { Zone } from "../../src/cloudflare/zone.ts";
+import { destroy } from "../../src/destroy.ts";
+import { BRANCH_PREFIX } from "../util.ts";
+
+import "../../src/test/vitest.ts";
+
+const api = await createCloudflareApi();
+
+const test = alchemy.test(import.meta, {
+  prefix: BRANCH_PREFIX,
+});
+
+describe("CustomHostname Resource", () => {
+  // Use BRANCH_PREFIX for deterministic, non-colliding hostnames
+  const testZoneName = `${BRANCH_PREFIX}-custom-hostname.dev`;
+  const testHostname1 = `app1.${BRANCH_PREFIX}-customer.com`;
+  const testHostname2 = `app2.${BRANCH_PREFIX}-customer.com`;
+
+  test("create, update, and delete custom hostname", async (scope) => {
+    let zone: Zone | undefined;
+    let customHostname: CustomHostname | undefined;
+
+    try {
+      // First create a zone for our custom hostnames
+      zone = await Zone("custom-hostname-zone", {
+        name: testZoneName,
+        type: "full",
+        jumpStart: false,
+      });
+
+      expect(zone.id).toBeTruthy();
+      expect(zone.name).toEqual(testZoneName);
+
+      // Create a custom hostname with basic settings
+      customHostname = await CustomHostname("test-custom-hostname", {
+        hostname: testHostname1,
+        zone: zone,
+        ssl: {
+          method: "http",
+          type: "dv",
+          settings: {
+            http2: "on",
+            tls_1_3: "on",
+            min_tls_version: "1.2",
+          },
+          bundle_method: "ubiquitous",
+        },
+        custom_metadata: {
+          customer_id: "test-customer-1",
+          plan: "basic",
+        },
+      });
+
+      expect(customHostname.id).toBeTruthy();
+      expect(customHostname.hostname).toEqual(testHostname1);
+      expect(customHostname.zoneId).toEqual(zone.id);
+      expect(customHostname.status).toBeTruthy();
+      expect(customHostname.ssl).toBeTruthy();
+      expect(customHostname.ssl.method).toEqual("http");
+      expect(customHostname.ssl.type).toEqual("dv");
+      expect(customHostname.custom_metadata).toEqual({
+        customer_id: "test-customer-1",
+        plan: "basic",
+      });
+      expect(customHostname.createdAt).toBeTruthy();
+
+      // Verify custom hostname was created by querying the API directly
+      const getResponse = await api.get(
+        `/zones/${zone.id}/custom_hostnames/${customHostname.id}`,
+      );
+      expect(getResponse.status).toEqual(200);
+
+      const responseData: any = await getResponse.json();
+      expect(responseData.result.hostname).toEqual(testHostname1);
+      expect(responseData.result.ssl.method).toEqual("http");
+
+      // Update the custom hostname with different settings
+      customHostname = await CustomHostname("test-custom-hostname", {
+        hostname: testHostname1,
+        zone: zone.id, // Test using zone ID directly instead of Zone resource
+        ssl: {
+          method: "txt", // Change method
+          type: "dv",
+          settings: {
+            http2: "off", // Change setting
+            tls_1_3: "on",
+            min_tls_version: "1.3", // Change min TLS version
+          },
+          bundle_method: "optimal", // Change bundle method
+        },
+        custom_metadata: {
+          customer_id: "test-customer-1",
+          plan: "premium", // Update metadata
+          environment: "production", // Add new metadata
+        },
+      });
+
+      expect(customHostname.id).toBeTruthy();
+      expect(customHostname.hostname).toEqual(testHostname1);
+      expect(customHostname.ssl.method).toEqual("txt");
+      expect(customHostname.ssl.bundle_method).toEqual("optimal");
+      expect(customHostname.custom_metadata).toEqual({
+        customer_id: "test-customer-1",
+        plan: "premium",
+        environment: "production",
+      });
+      expect(customHostname.modifiedAt).toBeTruthy();
+
+      // Verify settings were updated in the API
+      const updatedResponse = await api.get(
+        `/zones/${zone.id}/custom_hostnames/${customHostname.id}`,
+      );
+      const updatedData: any = await updatedResponse.json();
+
+      expect(updatedData.result.ssl.method).toEqual("txt");
+      expect(updatedData.result.ssl.bundle_method).toEqual("optimal");
+      expect(updatedData.result.custom_metadata?.plan).toEqual("premium");
+      expect(updatedData.result.custom_metadata?.environment).toEqual(
+        "production",
+      );
+    } finally {
+      // Always clean up, even if test assertions fail
+      await destroy(scope);
+
+      // Verify custom hostname is deleted
+      if (customHostname && zone) {
+        const getDeletedResponse = await api.get(
+          `/zones/${zone.id}/custom_hostnames/${customHostname.id}`,
+        );
+        expect(getDeletedResponse.status).toEqual(404);
+      }
+
+      // Verify zone is deleted
+      if (zone) {
+        const getDeletedZoneResponse = await api.get(`/zones/${zone.id}`);
+        expect(getDeletedZoneResponse.status).toEqual(400);
+      }
+    }
+  });
+
+  test("create custom hostname with minimal configuration", async (scope) => {
+    let zone: Zone | undefined;
+    let customHostname: CustomHostname | undefined;
+
+    try {
+      // Create a zone for our custom hostname
+      zone = await Zone("minimal-custom-hostname-zone", {
+        name: `${BRANCH_PREFIX}-minimal.dev`,
+        type: "full",
+        jumpStart: false,
+      });
+
+      // Create custom hostname with minimal configuration
+      customHostname = await CustomHostname("minimal-custom-hostname", {
+        hostname: testHostname2,
+        zone: zone,
+        // Only required fields, rely on defaults for SSL settings
+      });
+
+      expect(customHostname.id).toBeTruthy();
+      expect(customHostname.hostname).toEqual(testHostname2);
+      expect(customHostname.zoneId).toEqual(zone.id);
+      expect(customHostname.ssl).toBeTruthy();
+      // Should use default SSL method and type
+      expect(customHostname.ssl.method).toBeTruthy();
+      expect(customHostname.ssl.type).toBeTruthy();
+
+      // Verify via API
+      const getResponse = await api.get(
+        `/zones/${zone.id}/custom_hostnames/${customHostname.id}`,
+      );
+      expect(getResponse.status).toEqual(200);
+
+      const responseData: any = await getResponse.json();
+      expect(responseData.result.hostname).toEqual(testHostname2);
+    } finally {
+      // Always clean up
+      await destroy(scope);
+
+      // Verify cleanup
+      if (customHostname && zone) {
+        const getDeletedResponse = await api.get(
+          `/zones/${zone.id}/custom_hostnames/${customHostname.id}`,
+        );
+        expect(getDeletedResponse.status).toEqual(404);
+      }
+    }
+  });
+
+  test("handle custom hostname that already exists", async (scope) => {
+    let zone: Zone | undefined;
+    let customHostname1: CustomHostname | undefined;
+    let customHostname2: CustomHostname | undefined;
+
+    try {
+      // Create a zone for our custom hostname
+      zone = await Zone("existing-custom-hostname-zone", {
+        name: `${BRANCH_PREFIX}-existing.dev`,
+        type: "full",
+        jumpStart: false,
+      });
+
+      const testHostname = `existing.${BRANCH_PREFIX}-customer.com`;
+
+      // Create the first custom hostname
+      customHostname1 = await CustomHostname("existing-custom-hostname-1", {
+        hostname: testHostname,
+        zone: zone,
+        ssl: {
+          method: "http",
+          type: "dv",
+        },
+        custom_metadata: {
+          version: "1",
+        },
+      });
+
+      expect(customHostname1.id).toBeTruthy();
+      expect(customHostname1.hostname).toEqual(testHostname);
+
+      // Create a second custom hostname with the same hostname - should adopt the existing one
+      customHostname2 = await CustomHostname("existing-custom-hostname-2", {
+        hostname: testHostname,
+        zone: zone,
+        ssl: {
+          method: "txt", // Different method
+          type: "dv",
+        },
+        custom_metadata: {
+          version: "2", // Different metadata
+        },
+      });
+
+      // Should update the existing hostname rather than create a new one
+      expect(customHostname2.id).toEqual(customHostname1.id);
+      expect(customHostname2.hostname).toEqual(testHostname);
+      expect(customHostname2.ssl.method).toEqual("txt"); // Should be updated
+      expect(customHostname2.custom_metadata?.version).toEqual("2"); // Should be updated
+
+      // Verify only one custom hostname exists for this hostname
+      const listResponse = await api.get(`/zones/${zone.id}/custom_hostnames`);
+      const listData: any = await listResponse.json();
+      const matchingHostnames = listData.result.filter(
+        (h: any) => h.hostname === testHostname,
+      );
+      expect(matchingHostnames).toHaveLength(1);
+      expect(matchingHostnames[0].id).toEqual(customHostname1.id);
+    } finally {
+      // Always clean up
+      await destroy(scope);
+    }
+  });
+});
+
+/**
+ * Helper function to verify custom hostname does not exist
+ */
+async function _assertCustomHostnameDoesNotExist(
+  api: any,
+  zoneId: string,
+  customHostnameId: string,
+) {
+  const response = await api.get(
+    `/zones/${zoneId}/custom_hostnames/${customHostnameId}`,
+  );
+  if (response.status !== 404) {
+    throw new Error(
+      `Expected custom hostname ${customHostnameId} to not exist, but got status ${response.status}`,
+    );
+  }
+}


### PR DESCRIPTION
Implements CustomHostname resource for Cloudflare's SSL for SaaS feature:

- Complete TypeScript interfaces following Cloudflare API spec
- Full CRUD lifecycle with proper error handling
- Support for SSL verification methods (HTTP, TXT, email)
- Advanced SSL settings and custom metadata
- Comprehensive test suite (requires SSL for SaaS account)
- Complete documentation with examples

Closes #435

Generated with [Claude Code](https://claude.ai/code)