### PR TITLE
fix(cloudflare): Website resource respects cwd prop for wrangler.jsonc placement

### DIFF
--- a/alchemy/src/cloudflare/website.ts
+++ b/alchemy/src/cloudflare/website.ts
@@ -188,7 +188,7 @@ export default {
           // we don't include the Assets binding until after build to make sure the asset manifest is correct
           // we generate the wrangler.json using all the bind
           ASSETS: await Assets("assets", {
-            path: assetDir,
+            path: path.join(cwd, assetDir),
           }),
         },
       } as WorkerProps<any> & { name: string })) as Website<B>;

--- a/alchemy/src/cloudflare/website.ts
+++ b/alchemy/src/cloudflare/website.ts
@@ -140,7 +140,7 @@ export async function Website<B extends Bindings>(
         compatibilityDate:
           props.compatibilityDate ?? DEFAULT_COMPATIBILITY_DATE,
         name: workerName,
-        entrypoint: props.main,
+        entrypoint: props.main ? path.join(cwd, props.main) : undefined,
         assets: {
           html_handling: "auto-trailing-slash",
           not_found_handling: props.spa ? "single-page-application" : "none",

--- a/alchemy/src/cloudflare/website.ts
+++ b/alchemy/src/cloudflare/website.ts
@@ -120,7 +120,7 @@ export async function Website<B extends Bindings>(
 
       function resolveAbsPath<S extends string | undefined>(f: S): S {
         return (
-          f ? (path.isAbsolute(f) ? f : path.join(cwd, f)) : undefined
+          f ? (path.isAbsolute(f) ? f : path.resolve(cwd, f)) : undefined
         ) as S;
       }
 
@@ -182,9 +182,7 @@ export default {
       if (wrangler) {
         // paths in wrangler.jsonc must be relative to it
         const relativeToWrangler = <S extends string | undefined>(f: S): S =>
-          (f
-            ? path.relative(path.dirname(wranglerJsonPath), resolveAbsPath(f))
-            : f) as S;
+          (f ? path.relative(path.dirname(wranglerJsonPath), f) : f) as S;
         await WranglerJson("wrangler.jsonc", {
           path: wranglerJsonPath,
           worker: workerProps,

--- a/alchemy/src/cloudflare/website.ts
+++ b/alchemy/src/cloudflare/website.ts
@@ -108,6 +108,7 @@ export async function Website<B extends Bindings>(
     throw new Error("ASSETS binding is reserved for internal use");
   }
   const wrangler = props.wrangler ?? true;
+  console.log(props);
 
   return alchemy.run(
     id,
@@ -115,32 +116,52 @@ export async function Website<B extends Bindings>(
       parent: Scope.current,
     },
     async () => {
+      // directory from which all relative paths are resolved
       const cwd = path.resolve(props.cwd || process.cwd());
-      const fileName =
+
+      function resolveAbsPath<S extends string | undefined>(f: S): S {
+        return (
+          f ? (path.isAbsolute(f) ? f : path.join(cwd, f)) : undefined
+        ) as S;
+      }
+
+      // absolute path to the wrangler.jsonc file
+      const wranglerJsonPath = resolveAbsPath(
         typeof wrangler === "boolean"
           ? "wrangler.jsonc"
           : typeof wrangler === "string"
             ? wrangler
-            : (wrangler?.path ?? "wrangler.jsonc");
-      const wranglerPath = fileName && path.join(cwd, fileName);
-      const wranglerMain =
+            : (wrangler?.path ?? "wrangler.jsonc"),
+      );
+
+      // absolute path to the worker entrypoint
+      const mainPath = resolveAbsPath(props.main);
+
+      // absolute path to the worker entrypoint (if different in wrangler.jsonc)
+      const wranglerMainPath = resolveAbsPath(
         typeof wrangler === "object"
-          ? (wrangler.main ?? props.main)
-          : props.main;
+          ? (wrangler.main ?? props.main!)
+          : props.main,
+      );
 
-      const workerName = props.name ?? id;
-
-      const assetDir =
+      // absolute path to the assets directory
+      const assetsDirPath = resolveAbsPath(
         typeof props.assets === "string"
           ? props.assets
-          : (props.assets?.dist ?? "dist");
+          : (props.assets?.dist ?? "dist"),
+      );
+
+      const workerName = props.name ?? id;
 
       const workerProps = {
         ...props,
         compatibilityDate:
           props.compatibilityDate ?? DEFAULT_COMPATIBILITY_DATE,
         name: workerName,
-        entrypoint: props.main ? path.join(cwd, props.main) : undefined,
+        entrypoint: mainPath
+          ? // this path should be relative to the process.cwd() because it is used by esbuild
+            path.relative(process.cwd(), mainPath)
+          : undefined,
         assets: {
           html_handling: "auto-trailing-slash",
           not_found_handling: props.spa ? "single-page-application" : "none",
@@ -160,14 +181,20 @@ export default {
       } as WorkerProps<any> & { name: string };
 
       if (wrangler) {
+        // paths in wrangler.jsonc must be relative to it
+        const relativeToWrangler = <S extends string | undefined>(f: S): S =>
+          (f
+            ? path.relative(path.dirname(wranglerJsonPath), resolveAbsPath(f))
+            : f) as S;
         await WranglerJson("wrangler.jsonc", {
-          path: wranglerPath,
+          path: wranglerJsonPath,
           worker: workerProps,
-          main: wranglerMain,
+          main: relativeToWrangler(wranglerMainPath),
           // hard-code the assets directory because we haven't yet included the assets binding
           assets: {
             binding: "ASSETS",
-            directory: assetDir,
+            // path must be relative to the wrangler.jsonc file
+            directory: relativeToWrangler(assetsDirPath),
           },
         });
       }
@@ -188,7 +215,8 @@ export default {
           // we don't include the Assets binding until after build to make sure the asset manifest is correct
           // we generate the wrangler.json using all the bind
           ASSETS: await Assets("assets", {
-            path: path.join(cwd, assetDir),
+            // Assets are discovered from proces.cwd(), not Website.cwd or wrangler.jsonc
+            path: path.relative(process.cwd(), assetsDirPath),
           }),
         },
       } as WorkerProps<any> & { name: string })) as Website<B>;

--- a/alchemy/src/cloudflare/website.ts
+++ b/alchemy/src/cloudflare/website.ts
@@ -122,8 +122,7 @@ export async function Website<B extends Bindings>(
           : typeof wrangler === "string"
             ? wrangler
             : (wrangler?.path ?? "wrangler.jsonc");
-      const wranglerPath =
-        fileName && path.relative(cwd, path.join(cwd, fileName));
+      const wranglerPath = fileName && path.join(cwd, fileName);
       const wranglerMain =
         typeof wrangler === "object"
           ? (wrangler.main ?? props.main)

--- a/alchemy/src/cloudflare/website.ts
+++ b/alchemy/src/cloudflare/website.ts
@@ -108,7 +108,6 @@ export async function Website<B extends Bindings>(
     throw new Error("ASSETS binding is reserved for internal use");
   }
   const wrangler = props.wrangler ?? true;
-  console.log(props);
 
   return alchemy.run(
     id,

--- a/alchemy/test/cloudflare/website.test.ts
+++ b/alchemy/test/cloudflare/website.test.ts
@@ -83,8 +83,8 @@ describe("Website Resource", () => {
         directory: expect.stringContaining("dist"),
       });
     } finally {
-      // await fs.rm(tempDir, { recursive: true, force: true });
-      // await destroy(scope);
+      await fs.rm(tempDir, { recursive: true, force: true });
+      await destroy(scope);
     }
   });
 

--- a/alchemy/test/cloudflare/website.test.ts
+++ b/alchemy/test/cloudflare/website.test.ts
@@ -1,0 +1,200 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { describe, expect } from "vitest";
+import { alchemy } from "../../src/alchemy.ts";
+import { Website } from "../../src/cloudflare/website.ts";
+import { destroy } from "../../src/destroy.ts";
+import { BRANCH_PREFIX } from "../util.ts";
+
+import "../../src/test/vitest.ts";
+
+const test = alchemy.test(import.meta, {
+  prefix: BRANCH_PREFIX,
+});
+
+describe("Website Resource", () => {
+  test("respects cwd property for wrangler.jsonc placement", async (scope) => {
+    const name = `${BRANCH_PREFIX}-test-website-cwd`;
+    const tempDir = path.join(".out", "alchemy-website-cwd-test");
+    const subDir = path.join(tempDir, "subproject");
+    const distDir = path.join(subDir, "dist");
+    const entrypoint = path.join(subDir, "worker.ts");
+    
+    try {
+      // Create temporary directory structure
+      await fs.rm(tempDir, { recursive: true, force: true });
+      await fs.mkdir(subDir, { recursive: true });
+      await fs.mkdir(distDir, { recursive: true });
+      
+      // Create a simple index.html in the dist directory
+      await fs.writeFile(
+        path.join(distDir, "index.html"),
+        "<html><body>Hello Website!</body></html>"
+      );
+
+      // Create a simple worker entrypoint
+      await fs.writeFile(
+        entrypoint,
+        `export default {
+          async fetch(request, env) {
+            return new Response("Hello from worker!");
+          }
+        };`
+      );
+
+      // Create website with cwd pointing to subdirectory
+      const website = await Website(name, {
+        cwd: subDir,
+        main: entrypoint,
+        assets: path.resolve(distDir), // Use absolute path for assets
+        wrangler: true,
+        adopt: true,
+      });
+
+      // Verify the website was created successfully
+      expect(website.name).toBe(name);
+      expect(website.url).toBeDefined();
+
+      // Verify wrangler.jsonc was created in the correct location (subDir)
+      const wranglerPath = path.join(subDir, "wrangler.jsonc");
+      const wranglerExists = await fs.access(wranglerPath).then(() => true).catch(() => false);
+      
+      expect(wranglerExists).toBe(true);
+
+      // Verify wrangler.jsonc was NOT created in the root tempDir
+      const rootWranglerPath = path.join(tempDir, "wrangler.jsonc");
+      const rootWranglerExists = await fs.access(rootWranglerPath).then(() => true).catch(() => false);
+      
+      expect(rootWranglerExists).toBe(false);
+
+      // Verify the contents of wrangler.jsonc
+      const wranglerContent = await fs.readFile(wranglerPath, "utf-8");
+      const wranglerJson = JSON.parse(wranglerContent);
+      
+      expect(wranglerJson.name).toBe(name);
+      expect(wranglerJson.assets).toMatchObject({
+        binding: "ASSETS",
+        directory: expect.stringContaining("dist"),
+      });
+      
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+      await destroy(scope);
+    }
+  });
+
+  test("respects cwd property with custom wrangler path", async (scope) => {
+    const name = `${BRANCH_PREFIX}-test-website-cwd-custom`;
+    const tempDir = path.join(".out", "alchemy-website-cwd-custom-test");
+    const subDir = path.join(tempDir, "myproject");
+    const distDir = path.join(subDir, "dist");
+    const entrypoint = path.join(subDir, "worker.ts");
+    
+    try {
+      // Create temporary directory structure
+      await fs.rm(tempDir, { recursive: true, force: true });
+      await fs.mkdir(subDir, { recursive: true });
+      await fs.mkdir(distDir, { recursive: true });
+      
+      // Create a simple index.html in the dist directory
+      await fs.writeFile(
+        path.join(distDir, "index.html"),
+        "<html><body>Hello Custom Website!</body></html>"
+      );
+
+      // Create a simple worker entrypoint
+      await fs.writeFile(
+        entrypoint,
+        `export default {
+          async fetch(request, env) {
+            return new Response("Hello from custom worker!");
+          }
+        };`
+      );
+
+      // Create website with cwd and custom wrangler filename
+      const website = await Website(name, {
+        cwd: subDir,
+        main: entrypoint,
+        assets: path.resolve(distDir), // Use absolute path for assets
+        wrangler: "custom-wrangler.json",
+        adopt: true,
+      });
+
+      // Verify the website was created successfully
+      expect(website.name).toBe(name);
+
+      // Verify custom wrangler file was created in the correct location (subDir)
+      const wranglerPath = path.join(subDir, "custom-wrangler.json");
+      const wranglerExists = await fs.access(wranglerPath).then(() => true).catch(() => false);
+      
+      expect(wranglerExists).toBe(true);
+
+      // Verify custom wrangler file was NOT created in the root tempDir
+      const rootWranglerPath = path.join(tempDir, "custom-wrangler.json");
+      const rootWranglerExists = await fs.access(rootWranglerPath).then(() => true).catch(() => false);
+      
+      expect(rootWranglerExists).toBe(false);
+      
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+      await destroy(scope);
+    }
+  });
+
+  test("places wrangler.jsonc in project root when no cwd specified", async (scope) => {
+    const name = `${BRANCH_PREFIX}-test-website-default-cwd`;
+    const tempDir = path.join(".out", "alchemy-website-default-test");
+    const distDir = path.join(tempDir, "dist");
+    const entrypoint = path.join(tempDir, "worker.ts");
+    
+    try {
+      // Create temporary directory structure
+      await fs.rm(tempDir, { recursive: true, force: true });
+      await fs.mkdir(distDir, { recursive: true });
+      
+      // Create a simple index.html in the dist directory
+      await fs.writeFile(
+        path.join(distDir, "index.html"),
+        "<html><body>Hello Default Website!</body></html>"
+      );
+
+      // Create a simple worker entrypoint
+      await fs.writeFile(
+        entrypoint,
+        `export default {
+          async fetch(request, env) {
+            return new Response("Hello from default worker!");
+          }
+        };`
+      );
+
+      // Create website without specifying cwd (should use process.cwd())
+      const website = await Website(name, {
+        main: entrypoint,
+        assets: path.join(tempDir, "dist"), // Use absolute path since no cwd specified
+        wrangler: true,
+        adopt: true,
+      });
+
+      // Verify the website was created successfully
+      expect(website.name).toBe(name);
+
+      // Verify wrangler.jsonc was created in the current working directory (project root)
+      // Since we didn't specify cwd, it should be placed relative to process.cwd()
+      const wranglerPath = path.join(process.cwd(), "wrangler.jsonc");
+      const wranglerExists = await fs.access(wranglerPath).then(() => true).catch(() => false);
+      
+      expect(wranglerExists).toBe(true);
+
+      // Clean up the wrangler.jsonc file in the project root
+      if (wranglerExists) {
+        await fs.rm(wranglerPath, { force: true });
+      }
+      
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+      await destroy(scope);
+    }
+  });
+});

--- a/alchemy/test/cloudflare/website.test.ts
+++ b/alchemy/test/cloudflare/website.test.ts
@@ -15,10 +15,10 @@ const test = alchemy.test(import.meta, {
 describe("Website Resource", () => {
   test("respects cwd property for wrangler.jsonc placement", async (scope) => {
     const name = `${BRANCH_PREFIX}-test-website-cwd`;
-    const tempDir = path.join(".out", "alchemy-website-cwd-test");
-    const subDir = path.join(tempDir, "subproject");
-    const distDir = path.join(subDir, "dist");
-    const entrypoint = path.join(subDir, "worker.ts");
+    const tempDir = path.resolve(".out", "alchemy-website-cwd-test");
+    const subDir = path.resolve(tempDir, "subproject");
+    const distDir = path.resolve(subDir, "dist");
+    const entrypoint = path.resolve(subDir, "worker.ts");
 
     try {
       // Create temporary directory structure
@@ -46,7 +46,7 @@ describe("Website Resource", () => {
       const website = await Website(name, {
         cwd: subDir,
         main: entrypoint,
-        assets: path.resolve(distDir), // Use absolute path for assets
+        assets: distDir, // Use absolute path for assets
         wrangler: true,
         adopt: true,
       });
@@ -83,14 +83,14 @@ describe("Website Resource", () => {
         directory: expect.stringContaining("dist"),
       });
     } finally {
-      await fs.rm(tempDir, { recursive: true, force: true });
-      await destroy(scope);
+      // await fs.rm(tempDir, { recursive: true, force: true });
+      // await destroy(scope);
     }
   });
 
   test("respects cwd property with custom wrangler path", async (scope) => {
     const name = `${BRANCH_PREFIX}-test-website-cwd-custom`;
-    const tempDir = path.join(".out", "alchemy-website-cwd-custom-test");
+    const tempDir = path.resolve(".out", "alchemy-website-cwd-custom-test");
     const subDir = path.join(tempDir, "myproject");
     const distDir = path.join(subDir, "dist");
     const entrypoint = path.join(subDir, "worker.ts");

--- a/alchemy/test/cloudflare/website.test.ts
+++ b/alchemy/test/cloudflare/website.test.ts
@@ -19,17 +19,17 @@ describe("Website Resource", () => {
     const subDir = path.join(tempDir, "subproject");
     const distDir = path.join(subDir, "dist");
     const entrypoint = path.join(subDir, "worker.ts");
-    
+
     try {
       // Create temporary directory structure
       await fs.rm(tempDir, { recursive: true, force: true });
       await fs.mkdir(subDir, { recursive: true });
       await fs.mkdir(distDir, { recursive: true });
-      
+
       // Create a simple index.html in the dist directory
       await fs.writeFile(
         path.join(distDir, "index.html"),
-        "<html><body>Hello Website!</body></html>"
+        "<html><body>Hello Website!</body></html>",
       );
 
       // Create a simple worker entrypoint
@@ -39,7 +39,7 @@ describe("Website Resource", () => {
           async fetch(request, env) {
             return new Response("Hello from worker!");
           }
-        };`
+        };`,
       );
 
       // Create website with cwd pointing to subdirectory
@@ -57,26 +57,31 @@ describe("Website Resource", () => {
 
       // Verify wrangler.jsonc was created in the correct location (subDir)
       const wranglerPath = path.join(subDir, "wrangler.jsonc");
-      const wranglerExists = await fs.access(wranglerPath).then(() => true).catch(() => false);
-      
+      const wranglerExists = await fs
+        .access(wranglerPath)
+        .then(() => true)
+        .catch(() => false);
+
       expect(wranglerExists).toBe(true);
 
       // Verify wrangler.jsonc was NOT created in the root tempDir
       const rootWranglerPath = path.join(tempDir, "wrangler.jsonc");
-      const rootWranglerExists = await fs.access(rootWranglerPath).then(() => true).catch(() => false);
-      
+      const rootWranglerExists = await fs
+        .access(rootWranglerPath)
+        .then(() => true)
+        .catch(() => false);
+
       expect(rootWranglerExists).toBe(false);
 
       // Verify the contents of wrangler.jsonc
       const wranglerContent = await fs.readFile(wranglerPath, "utf-8");
       const wranglerJson = JSON.parse(wranglerContent);
-      
+
       expect(wranglerJson.name).toBe(name);
       expect(wranglerJson.assets).toMatchObject({
         binding: "ASSETS",
         directory: expect.stringContaining("dist"),
       });
-      
     } finally {
       await fs.rm(tempDir, { recursive: true, force: true });
       await destroy(scope);
@@ -89,17 +94,17 @@ describe("Website Resource", () => {
     const subDir = path.join(tempDir, "myproject");
     const distDir = path.join(subDir, "dist");
     const entrypoint = path.join(subDir, "worker.ts");
-    
+
     try {
       // Create temporary directory structure
       await fs.rm(tempDir, { recursive: true, force: true });
       await fs.mkdir(subDir, { recursive: true });
       await fs.mkdir(distDir, { recursive: true });
-      
+
       // Create a simple index.html in the dist directory
       await fs.writeFile(
         path.join(distDir, "index.html"),
-        "<html><body>Hello Custom Website!</body></html>"
+        "<html><body>Hello Custom Website!</body></html>",
       );
 
       // Create a simple worker entrypoint
@@ -109,7 +114,7 @@ describe("Website Resource", () => {
           async fetch(request, env) {
             return new Response("Hello from custom worker!");
           }
-        };`
+        };`,
       );
 
       // Create website with cwd and custom wrangler filename
@@ -126,16 +131,21 @@ describe("Website Resource", () => {
 
       // Verify custom wrangler file was created in the correct location (subDir)
       const wranglerPath = path.join(subDir, "custom-wrangler.json");
-      const wranglerExists = await fs.access(wranglerPath).then(() => true).catch(() => false);
-      
+      const wranglerExists = await fs
+        .access(wranglerPath)
+        .then(() => true)
+        .catch(() => false);
+
       expect(wranglerExists).toBe(true);
 
       // Verify custom wrangler file was NOT created in the root tempDir
       const rootWranglerPath = path.join(tempDir, "custom-wrangler.json");
-      const rootWranglerExists = await fs.access(rootWranglerPath).then(() => true).catch(() => false);
-      
+      const rootWranglerExists = await fs
+        .access(rootWranglerPath)
+        .then(() => true)
+        .catch(() => false);
+
       expect(rootWranglerExists).toBe(false);
-      
     } finally {
       await fs.rm(tempDir, { recursive: true, force: true });
       await destroy(scope);
@@ -147,16 +157,16 @@ describe("Website Resource", () => {
     const tempDir = path.join(".out", "alchemy-website-default-test");
     const distDir = path.join(tempDir, "dist");
     const entrypoint = path.join(tempDir, "worker.ts");
-    
+
     try {
       // Create temporary directory structure
       await fs.rm(tempDir, { recursive: true, force: true });
       await fs.mkdir(distDir, { recursive: true });
-      
+
       // Create a simple index.html in the dist directory
       await fs.writeFile(
         path.join(distDir, "index.html"),
-        "<html><body>Hello Default Website!</body></html>"
+        "<html><body>Hello Default Website!</body></html>",
       );
 
       // Create a simple worker entrypoint
@@ -166,7 +176,7 @@ describe("Website Resource", () => {
           async fetch(request, env) {
             return new Response("Hello from default worker!");
           }
-        };`
+        };`,
       );
 
       // Create website without specifying cwd (should use process.cwd())
@@ -183,15 +193,17 @@ describe("Website Resource", () => {
       // Verify wrangler.jsonc was created in the current working directory (project root)
       // Since we didn't specify cwd, it should be placed relative to process.cwd()
       const wranglerPath = path.join(process.cwd(), "wrangler.jsonc");
-      const wranglerExists = await fs.access(wranglerPath).then(() => true).catch(() => false);
-      
+      const wranglerExists = await fs
+        .access(wranglerPath)
+        .then(() => true)
+        .catch(() => false);
+
       expect(wranglerExists).toBe(true);
 
       // Clean up the wrangler.jsonc file in the project root
       if (wranglerExists) {
         await fs.rm(wranglerPath, { force: true });
       }
-      
     } finally {
       await fs.rm(tempDir, { recursive: true, force: true });
       await destroy(scope);

--- a/bun.lock
+++ b/bun.lock
@@ -4262,6 +4262,8 @@
 
     "alchemy/@biomejs/biome": ["@biomejs/biome@1.9.4", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "1.9.4", "@biomejs/cli-darwin-x64": "1.9.4", "@biomejs/cli-linux-arm64": "1.9.4", "@biomejs/cli-linux-arm64-musl": "1.9.4", "@biomejs/cli-linux-x64": "1.9.4", "@biomejs/cli-linux-x64-musl": "1.9.4", "@biomejs/cli-win32-arm64": "1.9.4", "@biomejs/cli-win32-x64": "1.9.4" }, "bin": { "biome": "bin/biome" } }, "sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog=="],
 
+    "alchemy/@types/bun": ["@types/bun@1.2.17", "", { "dependencies": { "bun-types": "1.2.17" } }, "sha512-l/BYs/JYt+cXA/0+wUhulYJB6a6p//GTPiJ7nV+QHa8iiId4HZmnu/3J/SowP5g0rTiERY2kfGKXEK5Ehltx4Q=="],
+
     "alchemy/braintrust": ["braintrust@0.0.201", "", { "dependencies": { "@ai-sdk/provider": "^1.0.1", "@braintrust/core": "0.0.86", "@next/env": "^14.2.3", "@vercel/functions": "^1.0.2", "ai": "^3.2.16", "argparse": "^2.0.1", "chalk": "^4.1.2", "cli-progress": "^3.12.0", "cors": "^2.8.5", "dotenv": "^16.4.5", "esbuild": "^0.25.3", "eventsource-parser": "^1.1.2", "express": "^4.21.2", "graceful-fs": "^4.2.11", "http-errors": "^2.0.0", "minimatch": "^9.0.3", "mustache": "^4.2.0", "pluralize": "^8.0.0", "simple-git": "^3.21.0", "slugify": "^1.6.6", "source-map": "^0.7.4", "uuid": "^9.0.1", "zod": "^3.22.4", "zod-to-json-schema": "^3.22.5" }, "bin": { "braintrust": "dist/cli.js" } }, "sha512-qH4esyOskiQ25OzbmlnPMVKEImDuFANEuYknNEsgS2f3M7t5SfbZxdelbYWcFPbUwQO3TR3XktszWcc3+oAZKg=="],
 
     "alchemy/wrangler": ["wrangler@3.114.9", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.3.4", "@cloudflare/unenv-preset": "2.0.2", "@esbuild-plugins/node-globals-polyfill": "0.2.3", "@esbuild-plugins/node-modules-polyfill": "0.2.2", "blake3-wasm": "2.1.5", "esbuild": "0.17.19", "miniflare": "3.20250408.2", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.14", "workerd": "1.20250408.0" }, "optionalDependencies": { "fsevents": "~2.3.2", "sharp": "^0.33.5" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20250408.0" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-1e0gL+rxLF04kM9bW4sxoDGLXpJ1x53Rx1t18JuUm6F67qadKKPISyUAXuBeIQudWrCWEBXaTVnSdLHz0yBXbA=="],
@@ -4973,6 +4975,8 @@
     "alchemy/@biomejs/biome/@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@1.9.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg=="],
 
     "alchemy/@biomejs/biome/@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@1.9.4", "", { "os": "win32", "cpu": "x64" }, "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA=="],
+
+    "alchemy/@types/bun/bun-types": ["bun-types@1.2.17", "", { "dependencies": { "@types/node": "*" } }, "sha512-ElC7ItwT3SCQwYZDYoAH+q6KT4Fxjl8DtZ6qDulUFBmXA8YB4xo+l54J9ZJN+k2pphfn9vk7kfubeSd5QfTVJQ=="],
 
     "alchemy/braintrust/@braintrust/core": ["@braintrust/core@0.0.86", "", { "dependencies": { "@asteasolutions/zod-to-openapi": "^6.3.1", "uuid": "^9.0.1", "zod": "^3.22.4" } }, "sha512-kysTnKjizQl4EQGbLDK91Ao8UKMG111NgB+Stu88df9X2KHW5UpI63rShiucaVQt168fvr3UfRJbzfZ/t068bw=="],
 


### PR DESCRIPTION
Fixed issue where Website resource would place wrangler.jsonc in project root instead of the specified cwd directory in monorepos.

## Changes
- Fixed path calculation from `path.relative()` to `path.join()` in website.ts:125
- Added comprehensive tests for Website resource cwd functionality
- Tests validate both default and custom wrangler file placement

## Issue
Fixes #442

Generated with [Claude Code](https://claude.ai/code)