### PR TITLE
feat(cloudflare): relax Durable Object RPC type constraint

### DIFF
--- a/alchemy/src/cloudflare/bindings.ts
+++ b/alchemy/src/cloudflare/bindings.ts
@@ -48,7 +48,7 @@ export type Binding =
   | D1DatabaseResource
   | DispatchNamespaceResource
   | AnalyticsEngineDataset
-  | DurableObjectNamespace<Rpc.DurableObjectBranded | undefined>
+  | DurableObjectNamespace<any>
   | HyperdriveResource
   | Images
   | KVNamespaceResource

--- a/alchemy/src/cloudflare/bound.ts
+++ b/alchemy/src/cloudflare/bound.ts
@@ -36,9 +36,7 @@ type BoundWorker<
 export type Bound<T extends Binding> = T extends _DurableObjectNamespace<
   infer O
 >
-  ? DurableObjectNamespace<
-      O extends Rpc.DurableObjectBranded | undefined ? O : any
-    >
+  ? DurableObjectNamespace<O & Rpc.DurableObjectBranded>
   : T extends { type: "kv_namespace" }
     ? KVNamespace
     : T extends WorkerStub<infer RPC>

--- a/alchemy/src/cloudflare/bound.ts
+++ b/alchemy/src/cloudflare/bound.ts
@@ -36,7 +36,9 @@ type BoundWorker<
 export type Bound<T extends Binding> = T extends _DurableObjectNamespace<
   infer O
 >
-  ? DurableObjectNamespace<O>
+  ? DurableObjectNamespace<
+      O extends Rpc.DurableObjectBranded | undefined ? O : any
+    >
   : T extends { type: "kv_namespace" }
     ? KVNamespace
     : T extends WorkerStub<infer RPC>

--- a/alchemy/src/cloudflare/durable-object-namespace.ts
+++ b/alchemy/src/cloudflare/durable-object-namespace.ts
@@ -41,9 +41,8 @@ export function isDurableObjectNamespace(
  *   environment: "production"
  * });
  */
-export class DurableObjectNamespace<
-  T extends Rpc.DurableObjectBranded | undefined = undefined,
-> implements DurableObjectNamespaceInput
+export class DurableObjectNamespace<T = any>
+  implements DurableObjectNamespaceInput
 {
   public readonly type = "durable_object_namespace" as const;
   // alias for bindingName to be consistent with other bindings


### PR DESCRIPTION
Relaxed the Durable Object RPC type constraint to make the API more user-friendly.

Removes the requirement for RPC types to extend DurableObjectBrand and instead uses intersection types internally to apply branding where needed at runtime.

Fixes #444

Generated with [Claude Code](https://claude.ai/code)