### PR TITLE
feat(cloudflare): add URL support to WorkerStub

### DIFF
--- a/alchemy/src/cloudflare/worker-stub.ts
+++ b/alchemy/src/cloudflare/worker-stub.ts
@@ -20,6 +20,14 @@ export interface WorkerStubProps<
   name: string;
 
   /**
+   * Whether to enable a workers.dev URL for this worker
+   *
+   * If true, the worker will be available at {name}.{subdomain}.workers.dev
+   * @default true
+   */
+  url?: boolean;
+
+  /**
    * The RPC class to use for the worker.
    *
    * This is only used when using the rpc property.
@@ -38,6 +46,12 @@ export interface WorkerStub<
    * The name of the worker
    */
   name: string;
+
+  /**
+   * The worker's URL if enabled
+   * Format: {name}.{subdomain}.workers.dev
+   */
+  url?: string;
 
   /**
    * Optional type branding for the worker's RPC entrypoint.
@@ -59,12 +73,21 @@ export function isWorkerStub(resource: Resource): resource is WorkerStub {
  * exists and creates an empty one if needed.
  *
  * @example
- * // Reserve a worker name without deploying code
+ * // Reserve a worker name without deploying code, with URL enabled (default)
  * const workerStub = await WorkerStub("my-worker", {
  *   name: "my-reserved-worker"
  * });
  *
- * console.log(`Worker ${workerStub.name} exists: ${!workerStub.created}`);
+ * console.log(`Worker ${workerStub.name} is available at: ${workerStub.url}`);
+ *
+ * @example
+ * // Reserve a worker name without enabling URL
+ * const workerStub = await WorkerStub("my-worker", {
+ *   name: "my-reserved-worker",
+ *   url: false
+ * });
+ *
+ * console.log(`Worker ${workerStub.name} created without URL`);
  */
 export const WorkerStub = Resource("cloudflare::WorkerStub", async function <
   RPC extends Rpc.WorkerEntrypointBranded = Rpc.WorkerEntrypointBranded,
@@ -84,11 +107,21 @@ export const WorkerStub = Resource("cloudflare::WorkerStub", async function <
     await createEmptyWorker(api, props.name);
   }
 
+  // Configure URL if requested (defaults to true)
+  const enableUrl = props.url ?? true;
+  const workerUrl = await configureWorkerStubURL(
+    this,
+    api,
+    props.name,
+    enableUrl,
+  );
+
   // Return the worker stub info
   return this({
     type: "service",
     __rpc__: props.rpc as unknown as RPC,
     ...props,
+    url: workerUrl,
   }) as WorkerStub<RPC>;
 });
 
@@ -167,4 +200,59 @@ async function createEmptyWorker(
       `Failed to create empty worker: ${uploadResponse.status} ${uploadResponse.statusText}`,
     );
   }
+}
+
+async function configureWorkerStubURL(
+  ctx: Context<WorkerStub>,
+  api: CloudflareApi,
+  workerName: string,
+  url: boolean,
+): Promise<string | undefined> {
+  let workerUrl;
+  if (url) {
+    // Enable the workers.dev subdomain for this worker
+    await api.post(
+      `/accounts/${api.accountId}/workers/scripts/${workerName}/subdomain`,
+      { enabled: true, previews_enabled: true },
+      {
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+
+    // Get the account's workers.dev subdomain
+    const subdomainResponse = await api.get(
+      `/accounts/${api.accountId}/workers/subdomain`,
+    );
+
+    if (!subdomainResponse.ok) {
+      throw new Error(
+        `Could not fetch workers.dev subdomain: ${subdomainResponse.status} ${subdomainResponse.statusText}`,
+      );
+    }
+    const subdomainData: {
+      result: {
+        subdomain: string;
+      };
+    } = await subdomainResponse.json();
+    const subdomain = subdomainData.result?.subdomain;
+
+    if (subdomain) {
+      workerUrl = `https://${workerName}.${subdomain}.workers.dev`;
+    }
+  } else if (url === false && ctx.output?.url) {
+    // Explicitly disable URL if it was previously enabled
+    const response = await api.post(
+      `/accounts/${api.accountId}/workers/scripts/${workerName}/subdomain`,
+      JSON.stringify({ enabled: false }),
+      {
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+    if (!response.ok) {
+      throw new Error(
+        `Failed to disable worker URL: ${response.status} ${response.statusText}`,
+      );
+    }
+  }
+  return workerUrl;
 }

--- a/alchemy/src/cloudflare/worker.ts
+++ b/alchemy/src/cloudflare/worker.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { BUILD_DATE } from "../build-date.ts";
 import type { Context } from "../context.ts";
 import type { BundleProps } from "../esbuild/bundle.ts";
 import { InnerResourceScope, Resource, ResourceKind } from "../resource.ts";
@@ -13,7 +14,6 @@ import { getContentType } from "../util/content-type.ts";
 import { logger } from "../util/logger.ts";
 import { withExponentialBackoff } from "../util/retry.ts";
 import { slugify } from "../util/slugify.ts";
-import { BUILD_DATE } from "../build-date.ts";
 import { CloudflareApiError, handleApiError } from "./api-error.ts";
 import {
   type CloudflareApi,
@@ -1468,7 +1468,7 @@ export async function assertWorkerDoesNotExist<B extends Bindings>(
 }
 
 export async function configureURL<B extends Bindings>(
-  ctx: Context<Worker<B>>,
+  ctx: Context<Worker<B>> | Context<WorkerStub>,
   api: CloudflareApi,
   workerName: string,
   url: boolean,

--- a/alchemy/test/cloudflare/worker-stub.test.ts
+++ b/alchemy/test/cloudflare/worker-stub.test.ts
@@ -49,7 +49,7 @@ test("worker-stub-url-types", () => {
     const stubWithUrl = await WorkerStub("stub-with-url", {
       name: "stub-with-url",
     });
-    
+
     // Should have URL property
     const _url1: string | undefined = stubWithUrl.url;
 
@@ -58,7 +58,7 @@ test("worker-stub-url-types", () => {
       name: "stub-explicit-url",
       url: true,
     });
-    
+
     const _url2: string | undefined = stubExplicitUrl.url;
 
     // Test with URL disabled
@@ -66,7 +66,7 @@ test("worker-stub-url-types", () => {
       name: "stub-no-url",
       url: false,
     });
-    
+
     const _url3: string | undefined = stubNoUrl.url;
   }
 });

--- a/alchemy/test/cloudflare/worker-stub.test.ts
+++ b/alchemy/test/cloudflare/worker-stub.test.ts
@@ -41,3 +41,32 @@ test("worker-stub-types", () => {
     env.workerB.bar();
   }
 });
+
+test("worker-stub-url-types", () => {
+  // type-only test for URL functionality
+  async function _() {
+    // Test with URL enabled (default)
+    const stubWithUrl = await WorkerStub("stub-with-url", {
+      name: "stub-with-url",
+    });
+    
+    // Should have URL property
+    const _url1: string | undefined = stubWithUrl.url;
+
+    // Test with URL explicitly enabled
+    const stubExplicitUrl = await WorkerStub("stub-explicit-url", {
+      name: "stub-explicit-url",
+      url: true,
+    });
+    
+    const _url2: string | undefined = stubExplicitUrl.url;
+
+    // Test with URL disabled
+    const stubNoUrl = await WorkerStub("stub-no-url", {
+      name: "stub-no-url",
+      url: false,
+    });
+    
+    const _url3: string | undefined = stubNoUrl.url;
+  }
+});

--- a/stacks/src/repo.run.ts
+++ b/stacks/src/repo.run.ts
@@ -1,8 +1,8 @@
 // ensure providers are registered (for deletion purposes)
-import "../alchemy/src/aws/index.ts";
-import "../alchemy/src/aws/oidc/index.ts";
-import "../alchemy/src/cloudflare/index.ts";
-import "../alchemy/src/os/index.ts";
+import "alchemy/aws";
+import "alchemy/aws/oidc";
+import "alchemy/cloudflare";
+import "alchemy/os";
 
 import alchemy from "alchemy";
 import { AccountId, Role, SSMParameter } from "alchemy/aws";
@@ -53,6 +53,7 @@ const githubRole = await Role("github-oidc-role", {
 
 const stateStore = await R2Bucket("state-store", {
   name: "alchemy-state-store",
+  adopt: true,
 });
 
 const testEnvironment = await RepositoryEnvironment("test environment", {


### PR DESCRIPTION
Add url property to WorkerStub that defaults to true, matching worker.ts functionality:
- Add `url?: boolean` to WorkerStubProps (defaults to true)
- Add `url?: string` to WorkerStub interface for returned URL
- Implement configureWorkerStubURL function using same API calls as worker.ts
- Update JSDoc examples and add type tests

Resolves #463

Generated with [Claude Code](https://claude.ai/code)