### PR TITLE
feat(cloudflare): support Worker.domains for custom domains

### DIFF
--- a/alchemy-web/docs/guides/cloudflare-worker.md
+++ b/alchemy-web/docs/guides/cloudflare-worker.md
@@ -331,6 +331,26 @@ const worker = await Worker("api", {
 > [!TIP]
 > See the [Route](../providers/cloudflare/route.md) for more information.
 
+## Custom Domains
+
+Bind custom domains directly to your worker for a simpler routing setup:
+
+```ts
+import { Worker } from "alchemy/cloudflare";
+
+const worker = await Worker("api", {
+  name: "api-worker",
+  entrypoint: "./src/api.ts",
+  domains: ["api.example.com", "admin.example.com"],
+});
+
+// Access the created domains
+console.log(worker.domains); // Array of created CustomDomain resources
+```
+
+> [!TIP]
+> See the [Routes and Domains](https://developers.cloudflare.com/workers/configuration/routing/#what-is-best-for-me) Cloudflare docs to help decide between when to use a Route vs a Domain.
+
 ## Workers for Platforms
 
 Deploy workers to dispatch namespaces for multi-tenant architectures using Cloudflare's Workers for Platforms:

--- a/alchemy-web/docs/providers/cloudflare/custom-domain.md
+++ b/alchemy-web/docs/providers/cloudflare/custom-domain.md
@@ -7,9 +7,43 @@ description: Learn how to configure and manage Custom Domains for your Cloudflar
 
 The CustomDomain resource lets you attach a [custom domain](https://developers.cloudflare.com/workers/configuration/routing/custom-domains/) to a Cloudflare Worker.
 
-## Minimal Example
+## Worker Domains
 
-Bind a domain to a worker:
+The simplest way to bind custom domains is directly on the Worker:
+
+```ts
+import { Worker } from "alchemy/cloudflare";
+
+const worker = await Worker("api", {
+  name: "api-worker",
+  entrypoint: "./src/api.ts",
+  domains: ["api.example.com", "admin.example.com"],
+});
+
+// Access the created domains
+console.log(worker.domains); // Array of created CustomDomain resources
+```
+
+With additional options:
+
+```ts
+const worker = await Worker("api", {
+  name: "api-worker",
+  entrypoint: "./src/api.ts",
+  domains: [
+    {
+      domainName: "api.example.com",
+      zoneId: "YOUR_ZONE_ID", // Optional - will be inferred if not provided
+      adopt: true, // Adopt existing domain if it exists
+    },
+    "admin.example.com", // Zone ID will be inferred
+  ],
+});
+```
+
+## CustomDomain Resource
+
+You can also create custom domains independently:
 
 ```ts
 import { Worker, CustomDomain } from "alchemy/cloudflare";
@@ -26,7 +60,7 @@ const domain = await CustomDomain("api-domain", {
 });
 ```
 
-## With Environment
+### With Environment
 
 Bind a domain to a specific worker environment:
 
@@ -40,3 +74,6 @@ const domain = await CustomDomain("staging-domain", {
   environment: "staging",
 });
 ```
+
+> [!TIP]
+> See the [Routes and Domains](https://developers.cloudflare.com/workers/configuration/routing/#what-is-best-for-me) Cloudflare docs to help decide between when to use a Route vs a Domain.

--- a/alchemy-web/docs/providers/cloudflare/worker.md
+++ b/alchemy-web/docs/providers/cloudflare/worker.md
@@ -330,6 +330,26 @@ const worker = await Worker("api", {
 > [!TIP]
 > See the [Route](./route.md) for more information.
 
+## Custom Domains
+
+Bind custom domains directly to your worker for a simpler routing setup:
+
+```ts
+import { Worker } from "alchemy/cloudflare";
+
+const worker = await Worker("api", {
+  name: "api-worker",
+  entrypoint: "./src/api.ts",
+  domains: ["api.example.com", "admin.example.com"],
+});
+
+// Access the created domains
+console.log(worker.domains); // Array of created CustomDomain resources
+```
+
+> [!TIP]
+> See the [Routes and Domains](https://developers.cloudflare.com/workers/configuration/routing/#what-is-best-for-me) Cloudflare docs to help decide between when to use a Route vs a Domain.
+
 ## Workers for Platforms
 
 Deploy workers to dispatch namespaces for multi-tenant architectures using Cloudflare's Workers for Platforms:

--- a/alchemy/src/cloudflare/zone.ts
+++ b/alchemy/src/cloudflare/zone.ts
@@ -2,7 +2,11 @@ import type { Context } from "../context.ts";
 import { Resource } from "../resource.ts";
 import { logger } from "../util/logger.ts";
 import { handleApiError } from "./api-error.ts";
-import { createCloudflareApi, type CloudflareApiOptions } from "./api.ts";
+import {
+  createCloudflareApi,
+  type CloudflareApi,
+  type CloudflareApiOptions,
+} from "./api.ts";
 import type {
   AlwaysUseHTTPSValue,
   AutomaticHTTPSRewritesValue,
@@ -554,7 +558,7 @@ async function getZoneSettings(
  *
  * @example
  * // Look up a zone by domain name
- * const zone = await getZoneByDomain("example.com");
+ * const zone = await getZoneByDomain(api, "example.com");
  * if (zone) {
  *   console.log(`Zone ID: ${zone.id}`);
  *   console.log(`Nameservers: ${zone.nameservers.join(", ")}`);
@@ -562,17 +566,12 @@ async function getZoneSettings(
  *
  * @example
  * // Look up a zone with custom API options
- * const zone = await getZoneByDomain("example.com", {
- *   apiToken: myApiToken,
- *   accountId: "my-account-id"
- * });
+ * const zone = await getZoneByDomain(api, "example.com");
  */
 export async function getZoneByDomain(
+  api: CloudflareApi,
   domainName: string,
-  options: Partial<CloudflareApiOptions> = {},
 ): Promise<ZoneData | null> {
-  const api = await createCloudflareApi(options);
-
   const response = await api.get(
     `/zones?name=${encodeURIComponent(domainName)}`,
   );

--- a/alchemy/src/util/safe-fetch.ts
+++ b/alchemy/src/util/safe-fetch.ts
@@ -4,7 +4,7 @@ import { logger } from "./logger.ts";
 export async function safeFetch(
   url: string | URL | Request,
   options: RequestInit = {},
-  retries = 3,
+  retries = 10,
 ) {
   let latestErr: any;
   for (let attempt = 1; attempt <= retries; attempt++) {

--- a/alchemy/test/cloudflare/custom-domain.test.ts
+++ b/alchemy/test/cloudflare/custom-domain.test.ts
@@ -1,0 +1,89 @@
+import { afterAll, describe, expect } from "vitest";
+import { alchemy } from "../../src/alchemy.ts";
+import {
+  createCloudflareApi,
+  type CloudflareApi,
+} from "../../src/cloudflare/api.ts";
+import { Worker } from "../../src/cloudflare/worker.ts";
+import { Zone } from "../../src/cloudflare/zone.ts";
+import { destroy } from "../../src/destroy.ts";
+import type { Scope } from "../../src/scope.ts";
+import { BRANCH_PREFIX } from "../util.ts";
+// must import this or else alchemy.test won't exist
+import "../../src/test/vitest.ts";
+
+const test = alchemy.test(import.meta, {
+  prefix: BRANCH_PREFIX,
+  quiet: false,
+});
+
+const testDomain = `${BRANCH_PREFIX}-custom-domain-test.com`;
+
+let zone: Zone;
+let scope: Scope | undefined;
+
+test.beforeAll(async (_scope) => {
+  zone = await Zone(`${BRANCH_PREFIX}-zone`, {
+    name: testDomain,
+  });
+  scope = _scope;
+});
+
+afterAll(async () => {
+  if (scope) {
+    await destroy(scope);
+  }
+});
+
+const api = await createCloudflareApi();
+
+describe("Custom Domain", () => {
+  test("should create a custom domain", async (scope) => {
+    try {
+      const worker = await Worker(`${BRANCH_PREFIX}-worker-1`, {
+        domains: [`sub.${testDomain}`],
+        script: `
+          export default {
+            fetch(request, env) {
+              return new Response('Hello from ${BRANCH_PREFIX}-worker-1!');
+            }
+          }
+        `,
+        adopt: true,
+      });
+
+      expect(worker.domains?.[0]).toMatchObject({
+        name: `sub.${testDomain}`,
+        zoneId: zone.id,
+      });
+      await assertCustomDomain(api, worker, `sub.${testDomain}`);
+    } finally {
+      await destroy(scope);
+    }
+  });
+});
+
+export async function assertCustomDomain(
+  api: CloudflareApi,
+  worker: Worker,
+  domain: string,
+) {
+  const domains = (await (
+    await api.get(`/accounts/${api.accountId}/workers/domains`)
+  ).json()) as {
+    result: {
+      hostname: string;
+      zone_id: string;
+      service: string;
+      environment: string;
+    }[];
+  };
+  expect(domains.result).toContainEqual(
+    expect.objectContaining({
+      hostname: domain,
+      zone_id: zone.id,
+      service: worker.name,
+      environment: "production",
+    }),
+  );
+}


### PR DESCRIPTION
You can now configure `domains` on the `Worker` resource:

```ts
import { Worker } from "alchemy/cloudflare";

const worker = await Worker("api", {
  name: "api-worker",
  entrypoint: "./src/api.ts",
  domains: ["api.example.com", "admin.example.com"],
});
```

It supports an `string | object`:
```ts
const worker = await Worker("api", {
  name: "api-worker",
  entrypoint: "./src/api.ts",
  domains: [
    {
      domainName: "api.example.com",
      zoneId: "YOUR_ZONE_ID", // Optional - will be inferred if not provided
      adopt: true, // Adopt existing domain if it exists
    },
    "admin.example.com", // Zone ID will be inferred
  ],
});
```

The same change has been made for `routes`, opening it up to accept `string` for brevity.
```ts
const worker = await Worker("api", {
  name: "api-worker",
  entrypoint: "./src/api.ts",
  routes: ["api.example.com/*"],
});
```


