### PR TITLE
Read `apiToken` when creating DOStateStore

### DIFF
--- a/alchemy/src/cloudflare/do-state-store/store.ts
+++ b/alchemy/src/cloudflare/do-state-store/store.ts
@@ -58,6 +58,7 @@ export class DOStateStore implements StateStore {
   private async createClient() {
     const token =
       this.options.apiToken?.unencrypted ??
+      (await alchemy.secret.env.CLOUDFLARE_API_TOKEN).unencrypted ??
       this.options.worker?.token ??
       (await alchemy.secret.env.ALCHEMY_STATE_TOKEN).unencrypted;
     if (this.options.worker && "url" in this.options.worker) {


### PR DESCRIPTION
I noticed that when only passing `apiToken` into the DOStateStore it throws `Error: Environment variable ALCHEMY_STATE_TOKEN is not set`, but setting the same API token in `worker.token` works. IMO it aligns better with the API of the other configs to allow `apiToken`, instead of using a very specific `worker.token` config