### PR TITLE
fix(cloudflare): consistent ports for miniflare dev server

### DIFF
--- a/alchemy/src/cloudflare/worker/miniflare.ts
+++ b/alchemy/src/cloudflare/worker/miniflare.ts
@@ -5,6 +5,7 @@ import type {
   WorkerOptions,
 } from "miniflare";
 import path from "node:path";
+import { findOpenPort } from "../../util/find-open-port.ts";
 import { logger } from "../../util/logger.ts";
 import { HTTPServer } from "./http-server.ts";
 import {
@@ -85,7 +86,7 @@ class MiniflareServer {
       return existing;
     }
     const server = new HTTPServer({
-      port: worker.port,
+      port: worker.port ?? (await findOpenPort()),
       fetch: this.createRequestHandler(worker.name as string),
     });
     this.servers.set(worker.name, server);

--- a/alchemy/src/util/find-open-port.ts
+++ b/alchemy/src/util/find-open-port.ts
@@ -1,0 +1,27 @@
+import net from "node:net";
+
+export async function findOpenPort(min = 1337, max = 65535): Promise<number> {
+  for (let port = min; port <= max; port++) {
+    if (await isPortAvailable("0.0.0.0", port)) {
+      return port;
+    }
+  }
+  throw new Error(`No open port found between ${min} and ${max}`);
+}
+
+async function isPortAvailable(host: string, port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const server = net.createServer();
+    server.unref();
+
+    server.on("error", () => {
+      // Port is in use
+      resolve(false);
+    });
+
+    server.listen(port, host, () => {
+      // Port is available
+      server.close(() => resolve(true));
+    });
+  });
+}

--- a/examples/cloudflare-worker-simple/alchemy.run.ts
+++ b/examples/cloudflare-worker-simple/alchemy.run.ts
@@ -37,7 +37,6 @@ export const worker1 = await Worker("worker", {
     DO: doNamespace,
   },
   compatibilityFlags: ["nodejs_compat"],
-  dev: { port: 3000 },
 });
 export const worker2 = await Worker("worker2", {
   name: "cloudflare-worker-simple-2",
@@ -47,7 +46,6 @@ export const worker2 = await Worker("worker2", {
     DO: doNamespace,
   },
   compatibilityFlags: ["nodejs_compat"],
-  dev: { port: 3001 },
 });
 
 console.log(`worker1.url: ${worker1.url}`);


### PR DESCRIPTION
Finds an open port starting at 1337 to use for Miniflare dev.