### PR TITLE
Update template names to avoid bun namespace collisions

### DIFF
--- a/alchemy/templates/astro/package.json
+++ b/alchemy/templates/astro/package.json
@@ -1,6 +1,6 @@
 {
   "type": "module",
-  "name": "astro",
+  "name": "@alchemy.run/astro-template",
   "version": "0.0.1",
   "scripts": {
     "astro": "astro",

--- a/alchemy/templates/nuxt/package.json
+++ b/alchemy/templates/nuxt/package.json
@@ -1,6 +1,6 @@
 {
   "type": "module",
-  "name": "nuxt",
+  "name": "@alchemy.run/nuxt-template",
   "private": true,
   "scripts": {
     "build": "nuxt build",

--- a/alchemy/templates/react-router/package.json
+++ b/alchemy/templates/react-router/package.json
@@ -1,6 +1,6 @@
 {
   "type": "module",
-  "name": "react-router",
+  "name": "@alchemy.run/react-router-template",
   "private": true,
   "scripts": {
     "build": "vite build",

--- a/alchemy/templates/rwsdk/package.json
+++ b/alchemy/templates/rwsdk/package.json
@@ -1,6 +1,6 @@
 {
   "type": "module",
-  "name": "rwsdk",
+  "name": "@alchemy.run/rwsdk-template",
   "version": "1.0.0",
   "description": "Build fast, server-driven webapps on Cloudflare with SSR, RSC, and realtime. ",
   "main": "index.js",

--- a/alchemy/templates/sveltekit/package.json
+++ b/alchemy/templates/sveltekit/package.json
@@ -1,6 +1,6 @@
 {
   "type": "module",
-  "name": "sveltekit",
+  "name": "@alchemy.run/sveltekit-template",
   "private": true,
   "version": "0.0.1",
   "scripts": {

--- a/alchemy/templates/tanstack-start/package.json
+++ b/alchemy/templates/tanstack-start/package.json
@@ -1,6 +1,6 @@
 {
   "type": "module",
-  "name": "tanstack-start",
+  "name": "@alchemy.run/tanstack-start-template",
   "private": true,
   "sideEffects": false,
   "scripts": {

--- a/alchemy/templates/typescript/package.json
+++ b/alchemy/templates/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "typescript",
+  "name": "@alchemy.run/typescript-template",
   "version": "0.0.0",
   "description": "Alchemy Typescript Project",
   "type": "module",

--- a/alchemy/templates/vite/package.json
+++ b/alchemy/templates/vite/package.json
@@ -1,6 +1,6 @@
 {
   "type": "module",
-  "name": "vite",
+  "name": "@alchemy.run/vite-template",
   "private": true,
   "version": "0.0.0",
   "scripts": {


### PR DESCRIPTION
I ran across this wild issue where typescript wasn't resolving. It persisted even after clearing `node_modules`. After listing out `node_modules` I noticed this

```sh
❯ ls -al node_modules/
...
lrwxrwxrwx@ - just-be 27 Jun 00:43 typescript -> ../alchemy/templates/typescript
...
```

Turns out some of the names in templates are generic enough to conflict with dependency names and bun just symlinks those packages over the original dependencies. 