### PR TITLE
Add instrumentation to site

### DIFF
--- a/alchemy-web/alchemy.run.ts
+++ b/alchemy-web/alchemy.run.ts
@@ -1,5 +1,5 @@
 import alchemy from "alchemy";
-import { DOStateStore, Website } from "alchemy/cloudflare";
+import { DOStateStore, Website, Worker } from "alchemy/cloudflare";
 import { GitHubComment } from "alchemy/github";
 
 const stage = process.env.STAGE ?? process.env.PULL_REQUEST ?? "dev";
@@ -29,6 +29,11 @@ const website = await Website("website", {
 const url = domain ? `https://${domain}` : website.url;
 
 console.log(url);
+
+export const posthogWorker = await Worker("alchemy-posthog-worker", {
+  entrypoint: "./src/workers/posthog-worker.ts",
+  routes: ["ph.alchemy.run/*"],
+});
 
 if (process.env.PULL_REQUEST) {
   await GitHubComment("comment", {

--- a/alchemy-web/astro.config.mjs
+++ b/alchemy-web/astro.config.mjs
@@ -94,6 +94,19 @@ export default defineConfig({
         ],
       },
       plugins: [theme(), starlightLlmsTxt()],
+      head: [
+        {
+          // Posthog
+          tag: "script",
+          content: `
+            !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys getNextSurveyStep onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+            posthog.init('phc_1ZjunjRSQE5ij2xv0ir2tATiewyR6hLssSIiKrGQlBi', {
+              api_host:'https://ph.alchemy.run',
+              defaults: '2025-05-24'
+            })
+          `
+        },
+      ],
     }),
   ],
   trailingSlash: "ignore",

--- a/alchemy-web/src/workers/posthog-worker.ts
+++ b/alchemy-web/src/workers/posthog-worker.ts
@@ -1,0 +1,57 @@
+// Sourced from: https://posthog.com/docs/advanced/proxy/cloudflare
+// This worker is a reverse proxy for the Posthog API, used to bypass
+// common ad blockers.
+
+/// <reference types="@cloudflare/workers-types" />
+
+const API_HOST = "us.i.posthog.com"; // Change to "eu.i.posthog.com" for the EU region
+const ASSET_HOST = "us-assets.i.posthog.com"; // Change to "eu-assets.i.posthog.com" for the EU region
+
+async function handleRequest(
+  request: Request,
+  ctx: ExecutionContext,
+): Promise<Response> {
+  const url = new URL(request.url);
+  const pathname = url.pathname;
+  const search = url.search;
+  const pathWithParams = pathname + search;
+
+  if (pathname.startsWith("/static/")) {
+    return retrieveStatic(request, pathWithParams, ctx);
+  } else {
+    return forwardRequest(request, pathWithParams);
+  }
+}
+
+async function retrieveStatic(
+  request: Request,
+  pathname: string,
+  ctx: ExecutionContext,
+): Promise<Response> {
+  const cache = await caches.open("default");
+  let response = await cache.match(request);
+  if (!response) {
+    response = await fetch(`https://${ASSET_HOST}${pathname}`);
+    ctx.waitUntil(cache.put(request, response.clone()));
+  }
+  return response;
+}
+
+async function forwardRequest(
+  request: Request,
+  pathWithSearch: string,
+): Promise<Response> {
+  const originRequest = new Request(request);
+  originRequest.headers.delete("cookie");
+  return await fetch(`https://${API_HOST}${pathWithSearch}`, originRequest);
+}
+
+export default {
+  async fetch(
+    request: Request,
+    _: unknown,
+    ctx: ExecutionContext,
+  ): Promise<Response> {
+    return handleRequest(request, ctx);
+  },
+};


### PR DESCRIPTION
As we look to improve onboarding, its helpful to know where people are following off as they're visiting the site and exploring the docs. This PR adds [posthog](https://posthog.com) to help get better visibility into user behavior. 

I think there's also a good content opportunity here. Posthog [has a whole article](https://posthog.com/docs/advanced/proxy/cloudflare) on how to setup a reverse proxy for posthog (to get around common adblockers). With alchemy, you don't _need_ an article, it's just one piece of worker config. It makes me wonder how it could be packaged up further?