### PR TITLE
chore: only regenerate build-date during version bump

### DIFF
--- a/alchemy/package.json
+++ b/alchemy/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build:cli": "./scripts/bundle-cli.sh",
     "build:workers": "bun ./scripts/build-workers.ts",
-    "build": "bun ./scripts/generate-build-date.ts && rm -rf ./*.tsbuildinfo && rm -rf ./lib && tsc -b && bun run build:cli && bun run build:workers",
+    "build": "rm -rf ./*.tsbuildinfo && rm -rf ./lib && tsc -b && bun run build:cli && bun run build:workers",
     "dev:cli": "./scripts/bundle-cli.sh --watch",
     "docs:gen": "rm -rf ./docs && typedoc",
     "postbuild": "cpx 'src/**/*/types.d.ts' lib",

--- a/scripts/bump.ts
+++ b/scripts/bump.ts
@@ -152,7 +152,11 @@ await $`bun install`;
 
 console.log(`Updated version to ${newVersion} in package.json`);
 
-await $`git add package.json alchemy/package.json bun.lock`;
+// Generate build date for the release
+console.log("Generating build date...");
+await $`cd alchemy && bun ./scripts/generate-build-date.ts`;
+
+await $`git add package.json alchemy/package.json alchemy/src/build-date.ts bun.lock`;
 await $`git commit -m "chore(release): ${newVersion}"`;
 await $`git tag v${newVersion}`;
 


### PR DESCRIPTION
Fixes #517

The build-date file was being regenerated on every build, causing it to appear as a change in every PR. This moves the generation to only run during version bumps.

**Changes:**
- Remove build-date generation from build script
- Add build-date generation to bump script and include in release commits

Generated with [Claude Code](https://claude.ai/code)