### PR TITLE
fix: Node LTS compatibility - replace Promise.withResolvers

### DIFF
--- a/alchemy/src/cloudflare/worker/http-server.ts
+++ b/alchemy/src/cloudflare/worker/http-server.ts
@@ -1,6 +1,7 @@
 import http from "node:http";
 import type { AddressInfo } from "node:net";
 import { Readable } from "node:stream";
+import { promiseWithResolvers } from "../../util/promise-with-resolvers.ts";
 
 export class HTTPServer {
   server: http.Server;
@@ -10,7 +11,7 @@ export class HTTPServer {
     port?: number;
     fetch: (request: Request) => Promise<Response>;
   }) {
-    const { promise, resolve } = Promise.withResolvers<void>();
+    const { promise, resolve } = promiseWithResolvers<void>();
     this.ready = promise;
     this.server = http
       .createServer(async (req, res) => {

--- a/alchemy/src/cloudflare/worker/miniflare.ts
+++ b/alchemy/src/cloudflare/worker/miniflare.ts
@@ -7,6 +7,10 @@ import type {
 import path from "node:path";
 import { findOpenPort } from "../../util/find-open-port.ts";
 import { logger } from "../../util/logger.ts";
+import {
+  promiseWithResolvers,
+  type PromiseWithResolvers,
+} from "../../util/promise-with-resolvers.ts";
 import { HTTPServer } from "./http-server.ts";
 import {
   buildMiniflareWorkerOptions,
@@ -40,7 +44,7 @@ class MiniflareServer {
   writer = this.stream.getWriter();
 
   async push(worker: MiniflareWorkerOptions) {
-    const promise = Promise.withResolvers<HTTPServer>();
+    const promise = promiseWithResolvers<HTTPServer>();
     const [, server] = await Promise.all([
       this.writer.write({ worker, promise }),
       promise.promise,

--- a/alchemy/src/util/deferred-promise.ts
+++ b/alchemy/src/util/deferred-promise.ts
@@ -1,5 +1,7 @@
+import { promiseWithResolvers } from "./promise-with-resolvers.ts";
+
 export class DeferredPromise<T> {
-  private promise = Promise.withResolvers<T>();
+  private promise = promiseWithResolvers<T>();
 
   status: "pending" | "fulfilled" | "rejected" = "pending";
 

--- a/alchemy/src/util/promise-with-resolvers.ts
+++ b/alchemy/src/util/promise-with-resolvers.ts
@@ -1,0 +1,26 @@
+/**
+ * Node 20+ compatible implementation of Promise.withResolvers()
+ * This provides the same functionality as the built-in Promise.withResolvers in Node 22+
+ */
+export function promiseWithResolvers<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: any) => void;
+} {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: any) => void;
+
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, resolve, reject };
+}
+
+/**
+ * Type alias for the return type of promiseWithResolvers
+ */
+export type PromiseWithResolvers<T> = ReturnType<
+  typeof promiseWithResolvers<T>
+>;

--- a/alchemy/src/util/promise-with-resolvers.ts
+++ b/alchemy/src/util/promise-with-resolvers.ts
@@ -9,9 +9,15 @@ export interface PromiseWithResolvers<T> {
 
 /**
  * Node 20+ compatible implementation of Promise.withResolvers()
- * This provides the same functionality as the built-in Promise.withResolvers in Node 22+
+ * Falls back to native Promise.withResolvers when available (Node 22+)
  */
 export function promiseWithResolvers<T>(): PromiseWithResolvers<T> {
+  // Use native implementation if available
+  if (typeof Promise.withResolvers === "function") {
+    return Promise.withResolvers<T>();
+  }
+
+  // Fallback implementation for Node 20+
   let resolve!: (value: T | PromiseLike<T>) => void;
   let reject!: (reason?: any) => void;
 

--- a/alchemy/src/util/promise-with-resolvers.ts
+++ b/alchemy/src/util/promise-with-resolvers.ts
@@ -1,12 +1,17 @@
 /**
- * Node 20+ compatible implementation of Promise.withResolvers()
- * This provides the same functionality as the built-in Promise.withResolvers in Node 22+
+ * Interface for the return type of promiseWithResolvers
  */
-export function promiseWithResolvers<T>(): {
+export interface PromiseWithResolvers<T> {
   promise: Promise<T>;
   resolve: (value: T | PromiseLike<T>) => void;
   reject: (reason?: any) => void;
-} {
+}
+
+/**
+ * Node 20+ compatible implementation of Promise.withResolvers()
+ * This provides the same functionality as the built-in Promise.withResolvers in Node 22+
+ */
+export function promiseWithResolvers<T>(): PromiseWithResolvers<T> {
   let resolve!: (value: T | PromiseLike<T>) => void;
   let reject!: (reason?: any) => void;
 
@@ -17,10 +22,3 @@ export function promiseWithResolvers<T>(): {
 
   return { promise, resolve, reject };
 }
-
-/**
- * Type alias for the return type of promiseWithResolvers
- */
-export type PromiseWithResolvers<T> = ReturnType<
-  typeof promiseWithResolvers<T>
->;


### PR DESCRIPTION
Fixes #520

This PR replaces `Promise.withResolvers` (Node 22+ feature) with a custom `promiseWithResolvers` utility function that provides the same functionality but works with Node 20+.

**Changes:**
- Created `alchemy/src/util/promise-with-resolvers.ts` with Node 20+ compatible implementation
- Updated `alchemy/src/util/deferred-promise.ts` to use `promiseWithResolvers`
- Updated `alchemy/src/cloudflare/worker/http-server.ts` to use `promiseWithResolvers`
- Updated `alchemy/src/cloudflare/worker/miniflare.ts` to use `promiseWithResolvers`

The custom implementation provides the exact same API as the built-in `Promise.withResolvers()` method, returning an object with `promise`, `resolve`, and `reject` properties.

Generated with [Claude Code](https://claude.ai/code)