### PR TITLE
feat: deprecate Context.phase in favor of Context.event

### DIFF
--- a/alchemy/src/context.ts
+++ b/alchemy/src/context.ts
@@ -17,7 +17,11 @@ export type Context<
 > = CreateContext<Out> | UpdateContext<Out, Props> | DeleteContext<Out, Props>;
 
 export interface CreateContext<Out extends Resource> extends BaseContext<Out> {
+  /**
+   * @deprecated Use `event` instead. Will be removed in a future version.
+   */
   phase: "create";
+  event: "create";
   output?: undefined;
   props?: undefined;
 }
@@ -26,7 +30,11 @@ export interface UpdateContext<
   Out extends Resource,
   Props extends ResourceProps = ResourceProps,
 > extends BaseContext<Out> {
+  /**
+   * @deprecated Use `event` instead. Will be removed in a future version.
+   */
   phase: "update";
+  event: "update";
   output: Out;
   props: Props;
 }
@@ -35,7 +43,11 @@ export interface DeleteContext<
   Out extends Resource,
   Props extends ResourceProps = ResourceProps,
 > extends BaseContext<Out> {
+  /**
+   * @deprecated Use `event` instead. Will be removed in a future version.
+   */
   phase: "delete";
+  event: "delete";
   output: Out;
   props: Props;
 }
@@ -130,6 +142,7 @@ export function context<
     id: id,
     fqn: fqn,
     phase,
+    event: phase,
     output: state.output,
     props,
     replace,


### PR DESCRIPTION
Deprecates `this.phase` on Context in favor of `this.event` while maintaining full backwards compatibility.

## Changes
- Add `event` property to all Context interfaces (CreateContext, UpdateContext, DeleteContext)
- Mark `phase` property as deprecated with JSDoc annotations
- Update context() function to set both phase and event properties
- Maintain full backwards compatibility for existing code using this.phase

## Testing
- All existing tests continue to pass
- Resource lifecycle handlers can use either `this.phase` or `this.event`
- Both properties return identical values

Closes #528

Generated with [Claude Code](https://claude.ai/code)