### PR TITLE
feat: rename "up" phase to "apply" with backward compatibility

### DIFF
--- a/alchemy-web/docs/concepts/destroy.md
+++ b/alchemy-web/docs/concepts/destroy.md
@@ -13,7 +13,7 @@ Resource destruction in Alchemy removes resources from both your state file and 
 ```typescript
 // Destroys all resources in the application
 const app = await alchemy("my-app", {
-  phase: "destroy"  // or process.argv.includes("--destroy") ? "destroy" : "up"
+  phase: "destroy"  // or process.argv.includes("--destroy") ? "destroy" : "apply"
 });
 ```
 Use for: Complete teardown of environments, cleaning up all infrastructure managed by the app.
@@ -41,7 +41,7 @@ Use for: Targeted cleanup of specific resources or test resources without affect
 // In alchemy.run.ts
 const app = await alchemy("my-app", {
   stage: "dev",
-  phase: process.argv.includes("--destroy") ? "destroy" : "up"
+  phase: process.argv.includes("--destroy") ? "destroy" : "apply"
 });
 
 // Run with: bun ./alchemy.run.ts --destroy

--- a/alchemy-web/docs/concepts/phase.md
+++ b/alchemy-web/docs/concepts/phase.md
@@ -1,23 +1,26 @@
 ---
 order: 2
 title: Phase
-description: Master the three execution phases in Alchemy - up, destroy, and read. Learn when to use each phase for deploying, tearing down, or accessing your infrastructure.
+description: Master the three execution phases in Alchemy - apply, destroy, and read. Learn when to use each phase for deploying, tearing down, or accessing your infrastructure.
 ---
 
 # Phase
 
 An Alchemy app can run in one of three phases:
-1. `"up"` - resources should be created, updated and deleted as necessary.
+1. `"apply"` - resources should be created, updated and deleted as necessary.
 2. `"destroy"` - all resources in the stage should be deleted and the program should not proceed
 3. `"read"` - run the program end-to-end but do not create, update or delete any resources
 
-## `"up"`
+> [!NOTE]
+> The `"up"` phase is deprecated but still supported for backward compatibility. Use `"apply"` instead.
 
-The **Up** phase creates, updates and deletes resources. This is the default mode and the most common. It's how you deploy your app (synchronize resources).
+## `"apply"`
+
+The **Apply** phase creates, updates and deletes resources. This is the default mode and the most common. It's how you deploy your app (synchronize resources).
 
 ```ts
 const app = await alchemy("my-app", {
-  phase: "up"
+  phase: "apply"
 });
 
 const worker = await Worker("my-app", { .. }); // <- will be created or updated
@@ -63,7 +66,7 @@ await app.finalize() // <- will not delete any orphaned resources
 > ```ts
 > // ./alchemy.run.ts
 > const app = await alchemy({
->   phase: process.env.PHASE ?? "up"    
+>   phase: process.env.PHASE ?? "apply"    
 > });
 >
 > // export your infrastructure

--- a/alchemy-web/docs/concepts/state.md
+++ b/alchemy-web/docs/concepts/state.md
@@ -102,7 +102,7 @@ import { DOStateStore } from "alchemy/cloudflare";
 // Set CLOUDFLARE_API_KEY, CLOUDFLARE_EMAIL, and ALCHEMY_STATE_TOKEN env vars
 const app = await alchemy("my-app", {
   stage: "prod",
-  phase: process.argv.includes("--destroy") ? "destroy" : "up",
+  phase: process.argv.includes("--destroy") ? "destroy" : "apply",
   stateStore: (scope) => new DOStateStore(scope)
 });
 ```
@@ -117,7 +117,7 @@ import { DOStateStore } from "alchemy/cloudflare";
 
 const app = await alchemy("my-app", {
   stage: "prod", 
-  phase: process.argv.includes("--destroy") ? "destroy" : "up",
+  phase: process.argv.includes("--destroy") ? "destroy" : "apply",
   stateStore: (scope) => new DOStateStore(scope, {
     // Cloudflare API credentials
     apiKey: alchemy.secret(process.env.CLOUDFLARE_API_KEY),
@@ -141,7 +141,7 @@ Alchemy also supports state storage using Cloudflare R2, though DOStateStore is 
 // Example with Cloudflare R2 state store
 const app = await alchemy("my-app", {
   stage: "prod",
-  phase: process.argv.includes("--destroy") ? "destroy" : "up",
+  phase: process.argv.includes("--destroy") ? "destroy" : "apply",
   stateStore: (scope) => new R2RestStateStore(scope, {
     apiKey: alchemy.secret(process.env.CLOUDFLARE_API_KEY),
     email: process.env.CLOUDFLARE_EMAIL,
@@ -159,7 +159,7 @@ import { S3StateStore } from "alchemy/aws";
 
 const app = await alchemy("my-app", {
   stage: "prod",
-  phase: process.argv.includes("--destroy") ? "destroy" : "up",
+  phase: process.argv.includes("--destroy") ? "destroy" : "apply",
   stateStore: (scope) => new S3StateStore(scope, {
     bucketName: "my-app-alchemy-state",
     region: "us-east-1"

--- a/alchemy-web/docs/guides/cli.md
+++ b/alchemy-web/docs/guides/cli.md
@@ -82,7 +82,7 @@ const app = await alchemy("my-app");
 
 // Explicit options override CLI args
 const app = await alchemy("my-app", {
-  phase: "up", // This overrides --destroy or --read
+  phase: "apply", // This overrides --destroy or --read
   stage: "prod", // This overrides --stage
   quiet: false, // This overrides --quiet
 });

--- a/alchemy-web/docs/guides/custom-state-store.md
+++ b/alchemy-web/docs/guides/custom-state-store.md
@@ -339,7 +339,7 @@ To use your custom state store, pass it to the Alchemy app initialization:
 ```typescript
 const app = await alchemy("my-app", {
   stage: "prod",
-  phase: process.argv.includes("--destroy") ? "destroy" : "up",
+  phase: process.argv.includes("--destroy") ? "destroy" : "apply",
   stateStore: (scope) => new InMemoryStateStore(scope)
 });
 

--- a/alchemy-web/docs/providers/aws/s3-state-store.md
+++ b/alchemy-web/docs/providers/aws/s3-state-store.md
@@ -16,7 +16,7 @@ import { S3StateStore } from "alchemy/aws";
 
 const app = await alchemy("my-app", {
   stage: "prod",
-  phase: process.argv.includes("--destroy") ? "destroy" : "up",
+  phase: process.argv.includes("--destroy") ? "destroy" : "apply",
   stateStore: (scope) => new S3StateStore(scope, {
     bucketName: "my-app-alchemy-state",
     region: "us-east-1"

--- a/alchemy/src/alchemy.ts
+++ b/alchemy/src/alchemy.ts
@@ -32,6 +32,10 @@ function parseCliArgs(): Partial<AlchemyOptions> {
     options.phase = "destroy";
   } else if (args.includes("--read")) {
     options.phase = "read";
+  } else if (args.includes("--apply")) {
+    options.phase = "apply";
+  } else if (args.includes("--up")) {
+    options.phase = "up";
   }
 
   if (
@@ -76,14 +80,14 @@ export const alchemy: Alchemy = _alchemy as any;
  * @example
  * // Simple usage with automatic CLI argument parsing
  * const app = await alchemy("my-app");
- * // Now supports: --destroy, --read, --quiet, --stage my-stage
+ * // Now supports: --destroy, --read, --apply, --up (deprecated), --quiet, --stage my-stage
  * // Environment variables: PASSWORD, ALCHEMY_PASSWORD, ALCHEMY_STAGE, USER
  *
  * @example
  * // Create an application scope with explicit options (overrides CLI args)
  * const app = await alchemy("github:alchemy", {
  *   stage: "prod",
- *   phase: "up",
+ *   phase: "apply",
  *   // Required for encrypting/decrypting secrets
  *   password: process.env.SECRET_PASSPHRASE
  * });
@@ -118,7 +122,7 @@ export interface Alchemy {
   /**
    * Creates a new application scope with the given name and options.
    * Used to create and manage resources with proper secret handling.
-   * Automatically parses CLI arguments: --destroy, --read, --quiet, --stage <name>
+   * Automatically parses CLI arguments: --destroy, --read, --apply, --up (deprecated), --quiet, --stage <name>
    * Environment variables: PASSWORD, ALCHEMY_PASSWORD, ALCHEMY_STAGE, USER
    *
    * @example
@@ -179,7 +183,15 @@ async function _alchemy(
       ...options,
     };
 
-    const phase = isRuntime ? "read" : (mergedOptions?.phase ?? "up");
+    const phase = isRuntime ? "read" : (mergedOptions?.phase ?? "apply");
+
+    // Show deprecation warning if "up" phase is explicitly used
+    if (mergedOptions?.phase === "up") {
+      logger.warn(
+        `The "up" phase is deprecated and will be removed in a future version. Please use "apply" instead.`,
+      );
+    }
+
     const telemetryClient =
       mergedOptions?.parent?.telemetryClient ??
       TelemetryClient.create({
@@ -332,7 +344,7 @@ async function _alchemy(
   ].join("\n");
 }
 
-export type Phase = "up" | "destroy" | "read";
+export type Phase = "apply" | "up" | "destroy" | "read";
 
 export interface AlchemyOptions {
   /**
@@ -342,7 +354,7 @@ export interface AlchemyOptions {
   /**
    * Determines whether the resources will be created/updated or deleted.
    *
-   * @default "up"
+   * @default "apply"
    */
   phase?: Phase;
   /**
@@ -440,10 +452,19 @@ async function run<T>(
           RunOptions,
           (this: Scope, scope: Scope) => Promise<T>,
         ]);
+  const phase = isRuntime ? "read" : (options?.phase ?? "apply");
+
+  // Show deprecation warning if "up" phase is explicitly used
+  if (options?.phase === "up") {
+    logger.warn(
+      `The "up" phase is deprecated and will be removed in a future version. Please use "apply" instead.`,
+    );
+  }
+
   const telemetryClient =
     options?.parent?.telemetryClient ??
     TelemetryClient.create({
-      phase: isRuntime ? "read" : (options?.phase ?? "up"),
+      phase,
       enabled: options?.telemetry ?? true,
       quiet: options?.quiet ?? false,
     });

--- a/alchemy/src/alchemy.ts
+++ b/alchemy/src/alchemy.ts
@@ -344,7 +344,8 @@ async function _alchemy(
   ].join("\n");
 }
 
-export type Phase = "apply" | "up" | "destroy" | "read";
+export const PhaseOptions = ["apply", "up", "destroy", "read"] as const;
+export type Phase = (typeof PhaseOptions)[number];
 
 export interface AlchemyOptions {
   /**

--- a/alchemy/src/test/bun.ts
+++ b/alchemy/src/test/bun.ts
@@ -136,7 +136,7 @@ export function test(meta: ImportMeta, defaultOptions?: TestOptions): test {
     scopeName: `${defaultOptions.prefix ? `${defaultOptions.prefix}-` : ""}${path.basename(meta.filename)}`,
     // parent: globalTestScope,
     stateStore: defaultOptions?.stateStore,
-    phase: "up",
+    phase: "apply",
     telemetryClient: new NoopTelemetryClient(),
   });
 

--- a/alchemy/src/test/vitest.ts
+++ b/alchemy/src/test/vitest.ts
@@ -141,7 +141,7 @@ export function test(
   const scope = new Scope({
     scopeName: `${defaultOptions.prefix ? `${defaultOptions.prefix}-` : ""}${path.basename(meta.filename)}`,
     stateStore: defaultOptions?.stateStore,
-    phase: "up",
+    phase: "apply",
     telemetryClient: new NoopTelemetryClient(),
     quiet: defaultOptions.quiet,
   });

--- a/alchemy/test/alchemy.test.ts
+++ b/alchemy/test/alchemy.test.ts
@@ -11,7 +11,7 @@ const test = alchemy.test(import.meta, {
 describe("alchemy.run", async () => {
   describe("read mode", async () => {
     test("can create a scope", async (scope) => {
-      expect(scope.phase).toBe("up");
+      expect(scope.phase).toBe("apply");
 
       await alchemy.run("child", { phase: "read" }, async (child) => {
         expect(child.phase).toBe("read");

--- a/alchemy/test/runtime/app.ts
+++ b/alchemy/test/runtime/app.ts
@@ -7,7 +7,7 @@ import { Queue } from "../../src/cloudflare/queue.js";
 import { Worker } from "../../src/cloudflare/worker.js";
 
 const app = await alchemy("my-bootstrap-ap", {
-  phase: process.argv.includes("--destroy") ? "destroy" : "up",
+  phase: process.argv.includes("--destroy") ? "destroy" : "apply",
 });
 
 const bucket = await R2Bucket("my-bootstrap-bucket", {

--- a/examples/cloudflare-orange/alchemy.run.ts
+++ b/examples/cloudflare-orange/alchemy.run.ts
@@ -4,7 +4,7 @@ import { Orange, R2RestStateStore } from "alchemy/cloudflare";
 const BRANCH_PREFIX = process.env.BRANCH_PREFIX ?? "";
 
 const app = await alchemy("cloudflare-orange", {
-  phase: process.argv.includes("--destroy") ? "destroy" : "up",
+  phase: process.argv.includes("--destroy") ? "destroy" : "apply",
   stateStore:
     process.env.ALCHEMY_STATE_STORE === "cloudflare"
       ? (scope) => new R2RestStateStore(scope)

--- a/examples/docker/alchemy.run.ts
+++ b/examples/docker/alchemy.run.ts
@@ -4,7 +4,7 @@ import * as docker from "alchemy/docker";
 // Initialize Alchemy
 const app = await alchemy("docker", {
   // Determine the phase based on command line arguments
-  phase: process.argv[2] === "destroy" ? "destroy" : "up",
+  phase: process.argv[2] === "destroy" ? "destroy" : "apply",
   stage: process.argv[3],
   quiet: process.argv.includes("--quiet"),
 });

--- a/stacks/src/env.ts
+++ b/stacks/src/env.ts
@@ -24,7 +24,7 @@ export default {
       ? "destroy"
       : process.argv.includes("--read")
         ? "read"
-        : "up"),
+        : "apply"),
   // pass the password in (you can get it from anywhere, e.g. stdin)
   password: process.env.SECRET_PASSPHRASE,
   quiet: process.argv.includes("--quiet"),


### PR DESCRIPTION
Implements #529 - Rename phase "up" to "apply" and deprecate (but still support "up")

## Summary
This PR renames the "up" phase to "apply" throughout the Alchemy codebase while maintaining full backward compatibility.

## Changes
- Updated Phase type to include both "apply" and "up" (with "apply" as primary)
- Changed default phase from "up" to "apply" across the codebase
- Added deprecation warnings when "up" is used explicitly
- Support both --apply and --up CLI flags (--up shows deprecation warning)
- Updated all core infrastructure, test frameworks, and examples
- Updated comprehensive documentation to use "apply" as preferred phase

## Backward Compatibility
- All existing code using "up" continues to work
- Deprecation warnings guide users to "apply"
- State files with "up" phase remain readable

Generated with [Claude Code](https://claude.ai/code)