### PR TITLE
Add smoke/.gitkeep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ wrangler.jsonc
 
 .smoke
 smoke
+!smoke/.gitkeep
 .svelte-kit
 
 .astro


### PR DESCRIPTION
On a fresh install, `bun install` fails:

```console
 bun i
[0.92ms] ".env"
bun install v1.0.29 (a146856d)
26 |   "workspaces": [
       ^
warn: workspaces directory prefix not found "smoke/"
   at /Users/eric/Projects/ericclemmons/alchemy/package.json:26:3
```

This just makes it such that it’s available for install.