### PR TITLE
chore: remove smoke/* from workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,7 @@
     "alchemy",
     "alchemy/templates/*",
     "examples/*",
-    "stacks",
-    "smoke/*"
+    "stacks"
   ],
   "devDependencies": {
     "@biomejs/biome": "beta",


### PR DESCRIPTION
Removes `smoke/*` from the workspaces configuration in package.json as requested in issue #580.

Generated with [Claude Code](https://claude.ai/code)