### PR TITLE
feat(core): warning if pendingDeletions has corrupted resources

### DIFF
--- a/alchemy/test/alchemy.test.ts
+++ b/alchemy/test/alchemy.test.ts
@@ -15,7 +15,7 @@ describe("alchemy.run", async () => {
 
       await alchemy.run("child", { phase: "read" }, async (child) => {
         expect(child.phase).toBe("read");
-        expect(child.appName).toEqual("samgoodwin-alchemy.test.ts");
+        expect(child.appName).toEqual(`${BRANCH_PREFIX}-alchemy.test.ts`);
         expect(child.scopeName).toBe("child");
         expect(child.parent).toBe(scope);
       });


### PR DESCRIPTION
- added tests matching the corrupted state cause by the DOSS issue. https://github.com/sam-goodwin/alchemy/issues/585
- made sure that corrupted state is disposed of. sadly we do not have enough information to reliably destroy this because we cannot identify the handler