### PR TITLE
fix(core): remove deserializeState function and use deserialize instead

### DIFF
--- a/alchemy/src/aws/s3-state-store.ts
+++ b/alchemy/src/aws/s3-state-store.ts
@@ -9,8 +9,8 @@ import {
 } from "@aws-sdk/client-s3";
 import { ResourceScope } from "../resource.ts";
 import type { Scope } from "../scope.ts";
-import { serialize } from "../serde.ts";
-import { deserializeState, type State, type StateStore } from "../state.ts";
+import { serialize, deserialize } from "../serde.ts";
+import type { State, StateStore } from "../state.ts";
 import { ignore } from "../util/ignore.ts";
 import { retry } from "./retry.ts";
 
@@ -175,7 +175,10 @@ export class S3StateStore implements StateStore {
       const content = await response.Body.transformToString();
 
       // Parse and deserialize the state data
-      const state = await deserializeState(this.scope, content);
+      const state = (await deserialize(
+        this.scope,
+        JSON.parse(content),
+      )) as State;
 
       // Create a new state object with proper output
       return {

--- a/alchemy/src/cloudflare/do-state-store/store.ts
+++ b/alchemy/src/cloudflare/do-state-store/store.ts
@@ -3,7 +3,7 @@ import { ResourceScope } from "../../resource.ts";
 import type { Scope } from "../../scope.ts";
 import { serialize } from "../../serde.ts";
 import type { State, StateStore } from "../../state.ts";
-import { deserializeState } from "../../state.ts";
+import { deserialize } from "../../serde.ts";
 import { createCloudflareApi, type CloudflareApiOptions } from "../api.ts";
 import { getAccountSubdomain } from "../worker/subdomain.ts";
 import { DOStateStoreClient, upsertStateStoreWorker } from "./internal.ts";
@@ -179,7 +179,7 @@ export class DOStateStore implements StateStore {
   }
 
   private async deserializeState(input: string): Promise<State> {
-    const state = await deserializeState(this.scope, input);
+    const state = (await deserialize(this.scope, JSON.parse(input))) as State;
     if (state.output === undefined) {
       state.output = {} as any;
     }

--- a/alchemy/src/cloudflare/r2-rest-state-store.ts
+++ b/alchemy/src/cloudflare/r2-rest-state-store.ts
@@ -1,7 +1,7 @@
 import { ResourceScope } from "../resource.ts";
 import type { Scope } from "../scope.ts";
-import { serialize } from "../serde.ts";
-import { deserializeState, type State, type StateStore } from "../state.ts";
+import { serialize, deserialize } from "../serde.ts";
+import type { State, StateStore } from "../state.ts";
 import { withExponentialBackoff } from "../util/retry.ts";
 import { CloudflareApiError, handleApiError } from "./api-error.ts";
 import {
@@ -212,7 +212,10 @@ export class R2RestStateStore implements StateStore {
       }
 
       // Parse and deserialize the state data
-      const state = await deserializeState(this.scope, await response.text());
+      const state = (await deserialize(
+        this.scope,
+        JSON.parse(await response.text()),
+      )) as State;
 
       // Create a new state object with proper output
       return {

--- a/alchemy/src/fs/file-system-state-store.ts
+++ b/alchemy/src/fs/file-system-state-store.ts
@@ -2,8 +2,8 @@ import fs from "node:fs";
 import path from "node:path";
 import { ResourceScope } from "../resource.ts";
 import type { Scope } from "../scope.ts";
-import { serialize } from "../serde.ts";
-import { deserializeState, type State, type StateStore } from "../state.ts";
+import { serialize, deserialize } from "../serde.ts";
+import type { State, StateStore } from "../state.ts";
 import { ignore } from "../util/ignore.ts";
 
 const stateRootDir = path.join(process.cwd(), ".alchemy");
@@ -69,7 +69,10 @@ export class FileSystemStateStore implements StateStore {
   async get(key: string): Promise<State | undefined> {
     try {
       const content = await fs.promises.readFile(this.getPath(key), "utf8");
-      const state = await deserializeState(this.scope, content);
+      const state = (await deserialize(
+        this.scope,
+        JSON.parse(content),
+      )) as State;
       if (state.output === undefined) {
         state.output = {} as any;
       }

--- a/alchemy/src/state.ts
+++ b/alchemy/src/state.ts
@@ -1,14 +1,5 @@
-import {
-  ResourceFQN,
-  ResourceID,
-  ResourceKind,
-  ResourceScope,
-  ResourceSeq,
-  type Resource,
-  type ResourceProps,
-} from "./resource.ts";
-import { Scope } from "./scope.ts";
-import { deserialize } from "./serde.ts";
+import type { Resource, ResourceProps } from "./resource.ts";
+import type { Scope } from "./scope.ts";
 
 export type State<
   Kind extends string = string,
@@ -49,35 +40,4 @@ export interface StateStore {
   all(): Promise<Record<string, State>>;
   set(key: string, value: State): Promise<void>;
   delete(key: string): Promise<void>;
-}
-
-export async function deserializeState(
-  scope: Scope,
-  content: string,
-): Promise<State> {
-  const state = (await deserialize(scope, JSON.parse(content))) as State;
-
-  if (ResourceID in state.output) {
-    // this is a new state
-    return state;
-  }
-  const output: any = state.output;
-  delete output.Kind;
-  delete output.ID;
-  delete output.FQN;
-  delete output.Scope;
-  delete output.Seq;
-  // fix this bug
-  if (state.kind === "scope") {
-    state.kind = Scope.KIND;
-  }
-  output[ResourceKind] = state.kind;
-  output[ResourceID] = state.id;
-  output[ResourceFQN] = state.fqn;
-  output[ResourceScope] = scope;
-  output[ResourceSeq] = state.seq;
-  state.output = output;
-  // re-write the state with the migrated format
-  await scope.state.set(state.id, state);
-  return state;
 }


### PR DESCRIPTION
Removes the `deserializeState` function and replaces all usage with `deserialize` directly.

## Changes
- Remove `deserializeState` function from state.ts as it's no longer needed
- Update all state stores to use `deserialize` directly instead of `deserializeState`
- Replace `deserializeState` calls with `deserialize(scope, JSON.parse(content))`
- Update imports to include deserialize from serde.ts

This removes the backwards compatibility layer for migrating old state formats since it's no longer needed.

Closes #597

Generated with [Claude Code](https://claude.ai/code)