### PR TITLE
fix: prevent telemetry failures from causing system failures

### DIFF
--- a/alchemy/src/scope.ts
+++ b/alchemy/src/scope.ts
@@ -219,7 +219,14 @@ export class Scope {
   }
 
   public async init() {
-    await Promise.all([this.state.init?.(), this.telemetryClient.ready]);
+    await Promise.all([
+      this.state.init?.(),
+      this.telemetryClient.ready.catch((error) => {
+        if (!this.quiet) {
+          console.warn("Telemetry initialization failed:", error);
+        }
+      }),
+    ]);
   }
 
   public async deinit() {
@@ -399,7 +406,13 @@ export class Scope {
       });
     }
 
-    await this.rootTelemetryClient?.finalize();
+    try {
+      await this.rootTelemetryClient?.finalize();
+    } catch (error) {
+      if (!this.quiet) {
+        console.warn("Telemetry finalization failed:", error);
+      }
+    }
   }
 
   public async destroyPendingDeletions() {

--- a/alchemy/src/scope.ts
+++ b/alchemy/src/scope.ts
@@ -222,9 +222,7 @@ export class Scope {
     await Promise.all([
       this.state.init?.(),
       this.telemetryClient.ready.catch((error) => {
-        if (!this.quiet) {
-          console.warn("Telemetry initialization failed:", error);
-        }
+        this.logger.warn("Telemetry initialization failed:", error);
       }),
     ]);
   }
@@ -406,13 +404,9 @@ export class Scope {
       });
     }
 
-    try {
-      await this.rootTelemetryClient?.finalize();
-    } catch (error) {
-      if (!this.quiet) {
-        console.warn("Telemetry finalization failed:", error);
-      }
-    }
+    await this.rootTelemetryClient?.finalize().catch((error) => {
+      this.logger.warn("Telemetry finalization failed:", error);
+    });
   }
 
   public async destroyPendingDeletions() {

--- a/alchemy/src/scope.ts
+++ b/alchemy/src/scope.ts
@@ -404,7 +404,7 @@ export class Scope {
       });
     }
 
-    await this.rootTelemetryClient?.finalize().catch((error) => {
+    await this.rootTelemetryClient?.finalize()?.catch((error) => {
       this.logger.warn("Telemetry finalization failed:", error);
     });
   }


### PR DESCRIPTION
Fixes #594

Added proper error handling to prevent telemetry failures from causing the entire alchemy system to fail.

## Changes
- Add error handling in scope.init() to catch telemetry initialization failures
- Add error handling in scope.finalize() to catch telemetry finalization failures
- Both methods now log warnings instead of throwing errors, allowing the system to continue functioning

Generated with [Claude Code](https://claude.ai/code)