### PR TITLE
feat(cloudflare): default source_map to true for Workers

### DIFF
--- a/alchemy-web/src/content/docs/guides/cloudflare-worker.mdx
+++ b/alchemy-web/src/content/docs/guides/cloudflare-worker.mdx
@@ -120,6 +120,31 @@ And register `env.ts` in your `tsconfig.json`'s `types`.
 See [Bindings](/concepts/bindings) for more information.
 :::
 
+## Source Maps
+
+Control whether source maps are uploaded with your worker for debugging:
+
+```ts
+import { Worker } from "alchemy/cloudflare";
+
+const worker = await Worker("api", {
+  name: "api-worker",
+  entrypoint: "./src/api.ts",
+  sourceMap: true, // Upload source maps (default: true)
+});
+
+// Disable source maps for production builds
+const prodWorker = await Worker("prod-api", {
+  name: "prod-api-worker",
+  entrypoint: "./src/api.ts",
+  sourceMap: false, // Don't upload source maps
+});
+```
+
+:::note
+Source maps are enabled by default (`sourceMap: true`) and help with debugging by mapping minified code back to your original source files in the Cloudflare dashboard.
+:::
+
 ## Static Assets
 
 Serve static files from a directory:

--- a/alchemy-web/src/content/docs/providers/cloudflare/worker.mdx
+++ b/alchemy-web/src/content/docs/providers/cloudflare/worker.mdx
@@ -118,6 +118,31 @@ And register `env.ts` in your `tsconfig.json`'s `types`.
 See [Bindings](/concepts/bindings) for more information.
 :::
 
+## Source Maps
+
+Control whether source maps are uploaded with your worker for debugging:
+
+```ts
+import { Worker } from "alchemy/cloudflare";
+
+const worker = await Worker("api", {
+  name: "api-worker",
+  entrypoint: "./src/api.ts",
+  sourceMap: true, // Upload source maps (default: true)
+});
+
+// Disable source maps for production builds
+const prodWorker = await Worker("prod-api", {
+  name: "prod-api-worker",
+  entrypoint: "./src/api.ts",
+  sourceMap: false, // Don't upload source maps
+});
+```
+
+:::note
+Source maps are enabled by default (`sourceMap: true`) and help with debugging by mapping minified code back to your original source files in the Cloudflare dashboard.
+:::
+
 ## Static Assets
 
 Serve static files from a directory:

--- a/alchemy/src/cloudflare/bundle/bundle-worker-dev.ts
+++ b/alchemy/src/cloudflare/bundle/bundle-worker-dev.ts
@@ -58,6 +58,7 @@ export async function createWorkerDevContext<B extends Bindings>(
     platform: "node",
     minify: false,
     bundle: true,
+    sourcemap: props.uploadSourceMaps !== false, // Default to true, can be overridden by bundle config
     ...props.bundle,
     write: false, // We want the result in memory for hot reloading
     conditions: ["workerd", "worker", "import", "module", "browser"],

--- a/alchemy/src/cloudflare/bundle/bundle-worker-dev.ts
+++ b/alchemy/src/cloudflare/bundle/bundle-worker-dev.ts
@@ -58,7 +58,7 @@ export async function createWorkerDevContext<B extends Bindings>(
     platform: "node",
     minify: false,
     bundle: true,
-    sourcemap: props.uploadSourceMaps !== false, // Default to true, can be overridden by bundle config
+    sourcemap: props.sourceMap !== false, // Default to true, can be overridden by bundle config
     ...props.bundle,
     write: false, // We want the result in memory for hot reloading
     conditions: ["workerd", "worker", "import", "module", "browser"],

--- a/alchemy/src/cloudflare/bundle/bundle-worker.ts
+++ b/alchemy/src/cloudflare/bundle/bundle-worker.ts
@@ -45,7 +45,7 @@ export async function bundleWorkerScript<B extends Bindings>(
             "**/*.js",
             "**/*.mjs",
             "**/*.wasm",
-            ...(props.uploadSourceMaps !== false ? ["**/*.js.map"] : []),
+            ...(props.sourceMap !== false ? ["**/*.js.map"] : []),
           ],
         },
       ]
@@ -96,7 +96,7 @@ export async function bundleWorkerScript<B extends Bindings>(
       target: "esnext",
       platform: "node",
       minify: false,
-      sourcemap: props.uploadSourceMaps !== false, // Default to true, can be overridden by bundle config
+      sourcemap: props.sourceMap !== false, // Default to true, can be overridden by bundle config
       ...(props.bundle || {}),
       conditions: ["workerd", "worker", "import", "module", "browser"],
       mainFields: ["module", "main"],

--- a/alchemy/src/cloudflare/bundle/bundle-worker.ts
+++ b/alchemy/src/cloudflare/bundle/bundle-worker.ts
@@ -45,7 +45,7 @@ export async function bundleWorkerScript<B extends Bindings>(
             "**/*.js",
             "**/*.mjs",
             "**/*.wasm",
-            ...(props.uploadSourceMaps ? ["**/*.js.map"] : []),
+            ...(props.uploadSourceMaps !== false ? ["**/*.js.map"] : []),
           ],
         },
       ]
@@ -96,6 +96,7 @@ export async function bundleWorkerScript<B extends Bindings>(
       target: "esnext",
       platform: "node",
       minify: false,
+      sourcemap: props.uploadSourceMaps !== false, // Default to true, can be overridden by bundle config
       ...(props.bundle || {}),
       conditions: ["workerd", "worker", "import", "module", "browser"],
       mainFields: ["module", "main"],

--- a/alchemy/src/cloudflare/worker.ts
+++ b/alchemy/src/cloudflare/worker.ts
@@ -383,7 +383,7 @@ export interface EntrypointWorkerProps<
    *
    * @default true
    */
-  uploadSourceMaps?: boolean;
+  sourceMap?: boolean;
 
   /**
    * Rules for adding additional files to the bundle.

--- a/alchemy/src/cloudflare/worker.ts
+++ b/alchemy/src/cloudflare/worker.ts
@@ -381,7 +381,7 @@ export interface EntrypointWorkerProps<
   /**
    * Whether to upload source maps for the worker script.
    *
-   * @default false
+   * @default true
    */
   uploadSourceMaps?: boolean;
 


### PR DESCRIPTION
Default source maps to true for Workers so users have to opt out instead of opt in.

Closes #609

BREAKING CHANGE: rename `uploadSourceMaps` to `sourceMap`

Generated with [Claude Code](https://claude.ai/code)