### PR TITLE
fix(github): add validation for missing GitHub token with helpful error message

### DIFF
--- a/alchemy/src/github/client.ts
+++ b/alchemy/src/github/client.ts
@@ -53,6 +53,27 @@ export async function createGitHubClient(
 ): Promise<Octokit> {
   const token = await getGitHubToken(options.token);
 
+  if (!token) {
+    logger.error(
+      "\n⚠️ GitHub token is required but not found. Please try one of the following:",
+    );
+    logger.error("1. Run 'gh auth login' to authenticate with the GitHub CLI");
+    logger.error(
+      "2. Set the GITHUB_TOKEN environment variable with a personal access token",
+    );
+    logger.error(
+      "3. Set the GITHUB_ACCESS_TOKEN environment variable (for actions with admin permissions)",
+    );
+    logger.error("4. Pass a token directly to the resource props");
+    logger.error(
+      "\nTo create a token, visit: https://github.com/settings/tokens",
+    );
+    logger.error(
+      "Required scopes: 'repo' for private repos or 'public_repo' for public repos\n",
+    );
+    throw new Error("GitHub token is required but not found");
+  }
+
   return new Octokit({
     auth: token,
   });

--- a/alchemy/src/github/client.ts
+++ b/alchemy/src/github/client.ts
@@ -150,10 +150,10 @@ export async function createAndVerifyGitHubClient(options: {
   quiet?: boolean;
 }): Promise<Octokit> {
   const octokit = await createGitHubClient({ token: options.token });
-  
+
   if (!options.quiet) {
     await verifyGitHubAuth(octokit, options.owner, options.repository);
   }
-  
+
   return octokit;
 }

--- a/alchemy/src/github/client.ts
+++ b/alchemy/src/github/client.ts
@@ -136,3 +136,24 @@ export async function verifyGitHubAuth(
     throw error;
   }
 }
+
+/**
+ * Create an authenticated Octokit client and verify repository access
+ *
+ * @param options Options for creating and verifying the client
+ * @returns An authenticated and verified Octokit client
+ */
+export async function createAndVerifyGitHubClient(options: {
+  token?: string;
+  owner: string;
+  repository: string;
+  quiet?: boolean;
+}): Promise<Octokit> {
+  const octokit = await createGitHubClient({ token: options.token });
+  
+  if (!options.quiet) {
+    await verifyGitHubAuth(octokit, options.owner, options.repository);
+  }
+  
+  return octokit;
+}

--- a/alchemy/src/github/comment.ts
+++ b/alchemy/src/github/comment.ts
@@ -2,7 +2,7 @@ import type { Context } from "../context.ts";
 import { Resource } from "../resource.ts";
 import type { Secret } from "../secret.ts";
 import { logger } from "../util/logger.ts";
-import { createGitHubClient, verifyGitHubAuth } from "./client.ts";
+import { createAndVerifyGitHubClient } from "./client.ts";
 
 /**
  * Properties for creating or updating a GitHub Comment
@@ -174,15 +174,13 @@ export const GitHubComment = Resource(
     _id: string,
     props: GitHubCommentProps,
   ): Promise<GitHubComment> {
-    // Create authenticated Octokit client - will automatically handle token resolution
-    const octokit = await createGitHubClient({
+    // Create authenticated Octokit client and verify repository access
+    const octokit = await createAndVerifyGitHubClient({
       token: props.token?.unencrypted,
+      owner: props.owner,
+      repository: props.repository,
+      quiet: this.quiet,
     });
-
-    // Verify authentication and permissions
-    if (!this.quiet) {
-      await verifyGitHubAuth(octokit, props.owner, props.repository);
-    }
 
     if (this.phase === "delete") {
       if (this.output?.commentId && props.allowDelete) {

--- a/alchemy/src/github/repository-environment.ts
+++ b/alchemy/src/github/repository-environment.ts
@@ -1,7 +1,7 @@
 import type { Context } from "../context.ts";
 import { Resource } from "../resource.ts";
 import { logger } from "../util/logger.ts";
-import { createGitHubClient, verifyGitHubAuth } from "./client.ts";
+import { createAndVerifyGitHubClient } from "./client.ts";
 
 /**
  * Properties for creating or updating a GitHub Repository Environment
@@ -177,15 +177,13 @@ export const RepositoryEnvironment = Resource(
     _id: string,
     props: RepositoryEnvironmentProps,
   ): Promise<RepositoryEnvironment> {
-    // Create authenticated Octokit client
-    const octokit = await createGitHubClient({
+    // Create authenticated Octokit client and verify repository access
+    const octokit = await createAndVerifyGitHubClient({
       token: props.token,
+      owner: props.owner,
+      repository: props.repository,
+      quiet: this.quiet,
     });
-
-    // Verify authentication and permissions
-    if (!this.quiet) {
-      await verifyGitHubAuth(octokit, props.owner, props.repository);
-    }
 
     if (this.phase === "delete") {
       if (this.output?.id) {

--- a/alchemy/src/github/repository-webhook.ts
+++ b/alchemy/src/github/repository-webhook.ts
@@ -1,7 +1,7 @@
 import type { Context } from "../context.ts";
 import { Resource } from "../resource.ts";
 import { logger } from "../util/logger.ts";
-import { createGitHubClient, verifyGitHubAuth } from "./client.ts";
+import { createAndVerifyGitHubClient } from "./client.ts";
 
 /**
  * Properties for creating or updating a GitHub Repository Webhook
@@ -147,15 +147,13 @@ export const RepositoryWebhook = Resource(
     _id: string,
     props: RepositoryWebhookProps,
   ): Promise<RepositoryWebhook> {
-    // Create authenticated Octokit client
-    const octokit = await createGitHubClient({
+    // Create authenticated Octokit client and verify repository access
+    const octokit = await createAndVerifyGitHubClient({
       token: props.token,
+      owner: props.owner,
+      repository: props.repository,
+      quiet: this.quiet,
     });
-
-    // Verify authentication and permissions
-    if (!this.quiet) {
-      await verifyGitHubAuth(octokit, props.owner, props.repository);
-    }
 
     if (this.phase === "delete") {
       if (this.output?.webhookId) {

--- a/alchemy/src/github/secret.ts
+++ b/alchemy/src/github/secret.ts
@@ -3,7 +3,7 @@ import type { Context } from "../context.ts";
 import { Resource } from "../resource.ts";
 import type { Secret } from "../secret.ts";
 import { logger } from "../util/logger.ts";
-import { createGitHubClient, verifyGitHubAuth } from "./client.ts";
+import { createAndVerifyGitHubClient } from "./client.ts";
 /**
  * Properties for creating or updating a GitHub Secret
  */
@@ -138,16 +138,14 @@ export const GitHubSecret = Resource(
     _id: string,
     props: GitHubSecretProps,
   ): Promise<GitHubSecretOutput> {
-    // Create authenticated Octokit client - will automatically handle token resolution
+    // Create authenticated Octokit client and verify repository access
     /// TODO: use fetch
-    const octokit = await createGitHubClient({
+    const octokit = await createAndVerifyGitHubClient({
       token: props.token?.unencrypted,
+      owner: props.owner,
+      repository: props.repository,
+      quiet: this.quiet,
     });
-
-    // Verify authentication and permissions
-    if (!this.quiet) {
-      await verifyGitHubAuth(octokit, props.owner, props.repository);
-    }
 
     // Determine if we're working with an environment secret or repository secret
     const isEnvironmentSecret = !!props.environment;


### PR DESCRIPTION
Fixes #617

Add validation in createGitHubClient() to check for null token and provide clear error message with specific guidance on how to fix the issue.

Fixes confusing "repository not found" errors when GITHUB_TOKEN is undefined. Now users get helpful error message with 4 specific solutions:
1. Run 'gh auth login' to authenticate with GitHub CLI
2. Set GITHUB_TOKEN environment variable 
3. Set GITHUB_ACCESS_TOKEN environment variable
4. Pass token directly to resource props

Generated with [Claude Code](https://claude.ai/code)