### PR TITLE
fix(sqlite): include drizzle folder in NPM package

### DIFF
--- a/alchemy/package.json
+++ b/alchemy/package.json
@@ -27,6 +27,7 @@
   "homepage": "https://alchemy.run",
   "files": [
     "bin",
+    "drizzle",
     "lib",
     "src",
     "templates",


### PR DESCRIPTION
The D1StateStore was failing with "ENOENT: no such file or directory, scandir '.../alchemy/drizzle'" because the drizzle folder containing SQL migrations wasn't included in the published NPM package.

Added "drizzle" to the files array in package.json to ensure migration files are included when the package is published.

Fixes #623

Generated with [Claude Code](https://claude.ai/code)