### PR TITLE
feat(aws): support aws endpoint environment variable

### DIFF
--- a/alchemy/src/aws/account-id.ts
+++ b/alchemy/src/aws/account-id.ts
@@ -1,6 +1,8 @@
 import { GetCallerIdentityCommand, STSClient } from "@aws-sdk/client-sts";
 
-const sts = new STSClient({});
+const sts = new STSClient({
+  endpoint: process.env.AWS_ENDPOINT,
+});
 
 export type AccountId = string & {
   readonly __brand: "AccountId";

--- a/alchemy/src/aws/bucket.ts
+++ b/alchemy/src/aws/bucket.ts
@@ -130,7 +130,9 @@ export interface Bucket extends Resource<"s3::Bucket">, BucketProps {
 export const Bucket = Resource(
   "s3::Bucket",
   async function (this: Context<Bucket>, _id: string, props: BucketProps) {
-    const client = new S3Client({});
+    const client = new S3Client({
+      endpoint: process.env.AWS_ENDPOINT,
+    });
 
     if (this.phase === "delete") {
       await ignore(NoSuchBucket.name, () =>

--- a/alchemy/src/aws/function.ts
+++ b/alchemy/src/aws/function.ts
@@ -310,7 +310,9 @@ export interface Function extends Resource<"lambda::Function">, FunctionProps {
 export const Function = Resource(
   "lambda::Function",
   async function (this: Context<Function>, _id: string, props: FunctionProps) {
-    const client = new LambdaClient({});
+    const client = new LambdaClient({
+      endpoint: process.env.AWS_ENDPOINT,
+    });
     const region = await resolveRegion(client);
 
     if (this.phase === "delete") {

--- a/alchemy/src/aws/oidc/oidc-provider.ts
+++ b/alchemy/src/aws/oidc/oidc-provider.ts
@@ -126,6 +126,7 @@ export const OIDCProvider = Resource(
   ) {
     // Initialize AWS SDK client
     const client = new IAMClient({
+      endpoint: process.env.AWS_ENDPOINT,
       region: props.region,
     });
 

--- a/alchemy/src/aws/policy-attachment.ts
+++ b/alchemy/src/aws/policy-attachment.ts
@@ -69,7 +69,9 @@ export const PolicyAttachment = Resource(
     _id: string,
     props: PolicyAttachmentProps,
   ) {
-    const client = new IAMClient({});
+    const client = new IAMClient({
+      endpoint: process.env.AWS_ENDPOINT,
+    });
 
     if (this.phase === "delete") {
       await ignore(NoSuchEntityException.name, () =>

--- a/alchemy/src/aws/policy.ts
+++ b/alchemy/src/aws/policy.ts
@@ -233,7 +233,9 @@ export const Policy = Resource(
     _id: string,
     props: PolicyProps,
   ): Promise<Policy> {
-    const client = new IAMClient({});
+    const client = new IAMClient({
+      endpoint: process.env.AWS_ENDPOINT,
+    });
     const policyArn = `arn:aws:iam::${process.env.AWS_ACCOUNT_ID}:policy${props.path || "/"}${props.policyName}`;
 
     if (this.phase === "delete") {

--- a/alchemy/src/aws/queue.ts
+++ b/alchemy/src/aws/queue.ts
@@ -143,7 +143,9 @@ export const Queue = Resource(
     _id: string,
     props: QueueProps,
   ): Promise<Queue> {
-    const client = new SQSClient({});
+    const client = new SQSClient({
+      endpoint: process.env.AWS_ENDPOINT,
+    });
     // Don't automatically add .fifo suffix - user must include it in queueName
     const queueName = props.queueName;
 

--- a/alchemy/src/aws/role.ts
+++ b/alchemy/src/aws/role.ts
@@ -223,7 +223,9 @@ export const Role = Resource(
     _id: string,
     props: RoleProps,
   ): Promise<Role> {
-    const client = new IAMClient({});
+    const client = new IAMClient({
+      endpoint: process.env.AWS_ENDPOINT,
+    });
 
     if (this.phase === "delete") {
       try {

--- a/alchemy/src/aws/s3-state-store.ts
+++ b/alchemy/src/aws/s3-state-store.ts
@@ -66,6 +66,7 @@ export class S3StateStore implements StateStore {
     this.bucketName = options.bucketName ?? "alchemy-state";
 
     this.client = new S3Client({
+      endpoint: process.env.AWS_ENDPOINT,
       region: options.region,
     });
   }

--- a/alchemy/src/aws/ses.ts
+++ b/alchemy/src/aws/ses.ts
@@ -165,7 +165,9 @@ export const SES = Resource(
     props: SESProps,
   ): Promise<SES> {
     // Create SES client
-    const client = new SESv2Client({});
+    const client = new SESv2Client({
+      endpoint: process.env.AWS_ENDPOINT,
+    });
 
     // Resource ID is either based on the configuration set name or email identity
     // const id =

--- a/alchemy/src/aws/ssm-parameter.ts
+++ b/alchemy/src/aws/ssm-parameter.ts
@@ -179,7 +179,9 @@ export const SSMParameter = Resource(
     _id: string,
     props: SSMParameterProps,
   ): Promise<SSMParameter> {
-    const client = new SSMClient({});
+    const client = new SSMClient({
+      endpoint: process.env.AWS_ENDPOINT,
+    });
 
     if (this.phase === "delete") {
       try {

--- a/alchemy/src/aws/table.ts
+++ b/alchemy/src/aws/table.ts
@@ -143,7 +143,9 @@ export const Table = Resource(
     _id: string,
     props: TableProps,
   ): Promise<Table> {
-    const client = new DynamoDBClient({});
+    const client = new DynamoDBClient({
+      endpoint: process.env.AWS_ENDPOINT,
+    });
 
     if (this.phase === "delete") {
       await retry(async () => {

--- a/examples/aws-app/.env.local
+++ b/examples/aws-app/.env.local
@@ -1,4 +1,0 @@
-AWS_ENDPOINT=http://localhost:4566
-AWS_REGION=us-east-1
-# AWS_ACCESS_KEY_ID=test
-# AWS_SECRET_ACCESS_KEY=test

--- a/examples/aws-app/.env.local
+++ b/examples/aws-app/.env.local
@@ -1,0 +1,4 @@
+AWS_ENDPOINT=http://localhost:4566
+AWS_REGION=us-east-1
+# AWS_ACCESS_KEY_ID=test
+# AWS_SECRET_ACCESS_KEY=test


### PR DESCRIPTION
All Alchemy resources for AWS will use the `AWS_ENDPOINT`, if available, and pass it to the relevant AWS SDK clients.