### PR TITLE
fix(cloudflare): adopt Container when binding to a Worker

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -38,6 +38,7 @@ jobs:
         id: deploy
         run: |
           bun run build
+          bun install # to install the built `alchemy` CLI
           bun deploy:website
         env:
           ALCHEMY_PASSWORD: ${{ env.ALCHEMY_PASSWORD }}
@@ -71,6 +72,7 @@ jobs:
       - name: Cleanup Website Preview
         run: |
           bun run build
+          bun install # to install the built `alchemy` CLI
           bun deploy:website --destroy
         env:
           ALCHEMY_PASSWORD: ${{ env.ALCHEMY_PASSWORD }}


### PR DESCRIPTION
Closes #654 (we now stream stdout/stderr of `docker build`)
Closes #660 (fixed the adoption bug that was only present when creating Container and binding to a Worker. Previously we'd only tested adoption working with ContainerApplication resource directly)