### PR TITLE
revert: "feat(aws): support aws endpoint environment variable"

### DIFF
--- a/alchemy/src/aws/account-id.ts
+++ b/alchemy/src/aws/account-id.ts
@@ -1,8 +1,6 @@
 import { GetCallerIdentityCommand, STSClient } from "@aws-sdk/client-sts";
 
-const sts = new STSClient({
-  endpoint: process.env.AWS_ENDPOINT,
-});
+const sts = new STSClient({});
 
 export type AccountId = string & {
   readonly __brand: "AccountId";

--- a/alchemy/src/aws/bucket.ts
+++ b/alchemy/src/aws/bucket.ts
@@ -130,9 +130,7 @@ export interface Bucket extends Resource<"s3::Bucket">, BucketProps {
 export const Bucket = Resource(
   "s3::Bucket",
   async function (this: Context<Bucket>, _id: string, props: BucketProps) {
-    const client = new S3Client({
-      endpoint: process.env.AWS_ENDPOINT,
-    });
+    const client = new S3Client({});
 
     if (this.phase === "delete") {
       await ignore(NoSuchBucket.name, () =>

--- a/alchemy/src/aws/function.ts
+++ b/alchemy/src/aws/function.ts
@@ -310,9 +310,7 @@ export interface Function extends Resource<"lambda::Function">, FunctionProps {
 export const Function = Resource(
   "lambda::Function",
   async function (this: Context<Function>, _id: string, props: FunctionProps) {
-    const client = new LambdaClient({
-      endpoint: process.env.AWS_ENDPOINT,
-    });
+    const client = new LambdaClient({});
     const region = await resolveRegion(client);
 
     if (this.phase === "delete") {

--- a/alchemy/src/aws/oidc/oidc-provider.ts
+++ b/alchemy/src/aws/oidc/oidc-provider.ts
@@ -126,7 +126,6 @@ export const OIDCProvider = Resource(
   ) {
     // Initialize AWS SDK client
     const client = new IAMClient({
-      endpoint: process.env.AWS_ENDPOINT,
       region: props.region,
     });
 

--- a/alchemy/src/aws/policy-attachment.ts
+++ b/alchemy/src/aws/policy-attachment.ts
@@ -69,9 +69,7 @@ export const PolicyAttachment = Resource(
     _id: string,
     props: PolicyAttachmentProps,
   ) {
-    const client = new IAMClient({
-      endpoint: process.env.AWS_ENDPOINT,
-    });
+    const client = new IAMClient({});
 
     if (this.phase === "delete") {
       await ignore(NoSuchEntityException.name, () =>

--- a/alchemy/src/aws/policy.ts
+++ b/alchemy/src/aws/policy.ts
@@ -233,9 +233,7 @@ export const Policy = Resource(
     _id: string,
     props: PolicyProps,
   ): Promise<Policy> {
-    const client = new IAMClient({
-      endpoint: process.env.AWS_ENDPOINT,
-    });
+    const client = new IAMClient({});
     const policyArn = `arn:aws:iam::${process.env.AWS_ACCOUNT_ID}:policy${props.path || "/"}${props.policyName}`;
 
     if (this.phase === "delete") {

--- a/alchemy/src/aws/queue.ts
+++ b/alchemy/src/aws/queue.ts
@@ -143,9 +143,7 @@ export const Queue = Resource(
     _id: string,
     props: QueueProps,
   ): Promise<Queue> {
-    const client = new SQSClient({
-      endpoint: process.env.AWS_ENDPOINT,
-    });
+    const client = new SQSClient({});
     // Don't automatically add .fifo suffix - user must include it in queueName
     const queueName = props.queueName;
 

--- a/alchemy/src/aws/role.ts
+++ b/alchemy/src/aws/role.ts
@@ -223,9 +223,7 @@ export const Role = Resource(
     _id: string,
     props: RoleProps,
   ): Promise<Role> {
-    const client = new IAMClient({
-      endpoint: process.env.AWS_ENDPOINT,
-    });
+    const client = new IAMClient({});
 
     if (this.phase === "delete") {
       try {

--- a/alchemy/src/aws/s3-state-store.ts
+++ b/alchemy/src/aws/s3-state-store.ts
@@ -66,7 +66,6 @@ export class S3StateStore implements StateStore {
     this.bucketName = options.bucketName ?? "alchemy-state";
 
     this.client = new S3Client({
-      endpoint: process.env.AWS_ENDPOINT,
       region: options.region,
     });
   }

--- a/alchemy/src/aws/ses.ts
+++ b/alchemy/src/aws/ses.ts
@@ -165,9 +165,7 @@ export const SES = Resource(
     props: SESProps,
   ): Promise<SES> {
     // Create SES client
-    const client = new SESv2Client({
-      endpoint: process.env.AWS_ENDPOINT,
-    });
+    const client = new SESv2Client({});
 
     // Resource ID is either based on the configuration set name or email identity
     // const id =

--- a/alchemy/src/aws/ssm-parameter.ts
+++ b/alchemy/src/aws/ssm-parameter.ts
@@ -179,9 +179,7 @@ export const SSMParameter = Resource(
     _id: string,
     props: SSMParameterProps,
   ): Promise<SSMParameter> {
-    const client = new SSMClient({
-      endpoint: process.env.AWS_ENDPOINT,
-    });
+    const client = new SSMClient({});
 
     if (this.phase === "delete") {
       try {

--- a/alchemy/src/aws/table.ts
+++ b/alchemy/src/aws/table.ts
@@ -143,9 +143,7 @@ export const Table = Resource(
     _id: string,
     props: TableProps,
   ): Promise<Table> {
-    const client = new DynamoDBClient({
-      endpoint: process.env.AWS_ENDPOINT,
-    });
+    const client = new DynamoDBClient({});
 
     if (this.phase === "delete") {
       await retry(async () => {


### PR DESCRIPTION
Turns out they actually support the feature, but the variable name is `AWS_ENDPOINT_URL` (not `AWS_ENDPOINT`). I couldn't find the docs or any references in the SDK V3 code. Sorry about the fuss.

Reverts sam-goodwin/alchemy#644.