### PR TITLE
chore(tests): clean up some worker tests

### DIFF
--- a/alchemy/test/cloudflare/worker.test.ts
+++ b/alchemy/test/cloudflare/worker.test.ts
@@ -28,6 +28,10 @@ import { listWorkersInNamespace } from "../../src/cloudflare/dispatch-namespace.
 import { DispatchNamespace } from "../../src/cloudflare/index.ts";
 import "../../src/test/vitest.ts";
 
+const ENABLE_WFP_TESTS = process.env.CLOUDFLARE_ACCOUNT_ENABLE_WFP !== "false";
+const ENABLE_PAID_TESTS =
+  process.env.CLOUDFLARE_ACCOUNT_ENABLE_PAID !== "false";
+
 const test = alchemy.test(import.meta, {
   prefix: BRANCH_PREFIX,
 });
@@ -213,25 +217,27 @@ describe("Worker Resource", () => {
     }
   });
 
-  test("fails when creating worker with duplicate binding IDs", async (scope) => {
-    const workerName = `${BRANCH_PREFIX}-test-worker-duplicate-binding-ids`;
+  test.skipIf(!ENABLE_PAID_TESTS)(
+    "fails when creating worker with duplicate binding IDs",
+    async (scope) => {
+      const workerName = `${BRANCH_PREFIX}-test-worker-duplicate-binding-ids`;
 
-    try {
-      // Test 1: Duplicate DurableObjectNamespace IDs
-      const namespace1 = DurableObjectNamespace("duplicate-id", {
-        className: "Counter1",
-        scriptName: workerName,
-      });
+      try {
+        // Test 1: Duplicate DurableObjectNamespace IDs
+        const namespace1 = DurableObjectNamespace("duplicate-id", {
+          className: "Counter1",
+          scriptName: workerName,
+        });
 
-      const namespace2 = DurableObjectNamespace("duplicate-id", {
-        className: "Counter2",
-        scriptName: workerName,
-      });
+        const namespace2 = DurableObjectNamespace("duplicate-id", {
+          className: "Counter2",
+          scriptName: workerName,
+        });
 
-      // Try to create a worker with duplicate binding IDs
-      const duplicateBindingsWorker = Worker(workerName, {
-        name: workerName,
-        script: `
+        // Try to create a worker with duplicate binding IDs
+        const duplicateBindingsWorker = Worker(workerName, {
+          name: workerName,
+          script: `
           export class Counter1 {}
           export class Counter2 {}
           export default {
@@ -240,29 +246,29 @@ describe("Worker Resource", () => {
             }
           };
         `,
-        format: "esm",
-        bindings: {
-          NAMESPACE1: namespace1,
-          NAMESPACE2: namespace2, // Same ID as namespace1
-        },
-      });
+          format: "esm",
+          bindings: {
+            NAMESPACE1: namespace1,
+            NAMESPACE2: namespace2, // Same ID as namespace1
+          },
+        });
 
-      await expect(duplicateBindingsWorker).rejects.toThrow(
-        "Duplicate binding ID 'duplicate-id' found for bindings 'NAMESPACE1' and 'NAMESPACE2'. Container and DurableObjectNamespace bindings must have unique IDs.",
-      );
+        await expect(duplicateBindingsWorker).rejects.toThrow(
+          "Duplicate binding ID 'duplicate-id' found for bindings 'NAMESPACE1' and 'NAMESPACE2'. Container and DurableObjectNamespace bindings must have unique IDs.",
+        );
 
-      const container = await Container("duplicate-id", {
-        className: "ContainerClass",
-        scriptName: workerName,
-        build: {
-          dockerfile: "Dockerfile",
-          context: path.join(import.meta.dirname, "container"),
-        },
-      });
+        const container = await Container("duplicate-id", {
+          className: "ContainerClass",
+          scriptName: workerName,
+          build: {
+            dockerfile: "Dockerfile",
+            context: path.join(import.meta.dirname, "container"),
+          },
+        });
 
-      const mixedDuplicateWorker = Worker(workerName, {
-        name: workerName,
-        script: `
+        const mixedDuplicateWorker = Worker(workerName, {
+          name: workerName,
+          script: `
           export class Counter1 {}
           export class ContainerClass {}
           export default {
@@ -271,26 +277,29 @@ describe("Worker Resource", () => {
             }
           };
         `,
-        format: "esm",
-        bindings: {
-          NAMESPACE1: namespace1,
-          CONTAINER: container, // Same ID as namespace1
-        },
-      });
+          format: "esm",
+          bindings: {
+            NAMESPACE1: namespace1,
+            CONTAINER: container, // Same ID as namespace1
+          },
+        });
 
-      await expect(mixedDuplicateWorker).rejects.toThrow(
-        "Duplicate binding ID 'duplicate-id' found for bindings 'NAMESPACE1' and 'CONTAINER'. Container and DurableObjectNamespace bindings must have unique IDs.",
-      );
-    } finally {
-      await destroy(scope);
-    }
-  });
+        await expect(mixedDuplicateWorker).rejects.toThrow(
+          "Duplicate binding ID 'duplicate-id' found for bindings 'NAMESPACE1' and 'CONTAINER'. Container and DurableObjectNamespace bindings must have unique IDs.",
+        );
+      } finally {
+        await destroy(scope);
+      }
+    },
+  );
 
-  test("create and delete worker with multiple bindings", async (scope) => {
-    const workerName = `${BRANCH_PREFIX}-test-worker-multi-bindings-multi-1`;
+  test.skipIf(!ENABLE_PAID_TESTS)(
+    "create and delete worker with multiple bindings",
+    async (scope) => {
+      const workerName = `${BRANCH_PREFIX}-test-worker-multi-bindings-multi-1`;
 
-    // Sample ESM worker script with multiple bindings
-    const multiBindingsWorkerScript = `
+      // Sample ESM worker script with multiple bindings
+      const multiBindingsWorkerScript = `
   export class Counter {
     constructor(state, env) {
       this.state = state;
@@ -329,59 +338,63 @@ describe("Worker Resource", () => {
   };
 `;
 
-    // Create a Durable Object namespace
-    const counterNamespace = DurableObjectNamespace("test-counter-namespace", {
-      className: "Counter",
-      scriptName: workerName,
-    });
-
-    // Create a KV namespace
-    const testKv = await KVNamespace("test-kv-namespace", {
-      title: `${BRANCH_PREFIX} Test KV Namespace 1`,
-      adopt: true,
-      values: [
+      // Create a Durable Object namespace
+      const counterNamespace = DurableObjectNamespace(
+        "test-counter-namespace",
         {
-          key: "testKey",
-          value: "initial-value",
+          className: "Counter",
+          scriptName: workerName,
         },
-      ],
-    });
+      );
 
-    let worker: Worker | undefined;
-
-    try {
-      // First create the worker without bindings
-      worker = await Worker(workerName, {
-        name: workerName,
-        script: multiBindingsWorkerScript,
-        format: "esm",
+      // Create a KV namespace
+      const testKv = await KVNamespace("test-kv-namespace", {
+        title: `${BRANCH_PREFIX} Test KV Namespace 1`,
         adopt: true,
+        values: [
+          {
+            key: "testKey",
+            value: "initial-value",
+          },
+        ],
       });
 
-      expect(worker.id).toBeTruthy();
-      expect(worker.name).toEqual(workerName);
+      let worker: Worker | undefined;
 
-      // Update the worker with all bindings
-      worker = await Worker(workerName, {
-        name: workerName,
-        script: multiBindingsWorkerScript,
-        format: "esm",
-        bindings: {
-          COUNTER: counterNamespace,
-          TEST_KV: testKv,
-          API_KEY: "test-api-key-value",
-        },
-        adopt: true,
-      });
+      try {
+        // First create the worker without bindings
+        worker = await Worker(workerName, {
+          name: workerName,
+          script: multiBindingsWorkerScript,
+          format: "esm",
+          adopt: true,
+        });
 
-      expect(worker.id).toBeTruthy();
-      expect(worker.name).toEqual(workerName);
-      expect(worker.bindings).toBeDefined();
-    } finally {
-      await destroy(scope);
-      await assertWorkerDoesNotExist(api, workerName);
-    }
-  });
+        expect(worker.id).toBeTruthy();
+        expect(worker.name).toEqual(workerName);
+
+        // Update the worker with all bindings
+        worker = await Worker(workerName, {
+          name: workerName,
+          script: multiBindingsWorkerScript,
+          format: "esm",
+          bindings: {
+            COUNTER: counterNamespace,
+            TEST_KV: testKv,
+            API_KEY: "test-api-key-value",
+          },
+          adopt: true,
+        });
+
+        expect(worker.id).toBeTruthy();
+        expect(worker.name).toEqual(workerName);
+        expect(worker.bindings).toBeDefined();
+      } finally {
+        await destroy(scope);
+        await assertWorkerDoesNotExist(api, workerName);
+      }
+    },
+  );
 
   // Add a new test for environment variables
   test("create and test worker with environment variables", async (scope) => {
@@ -1369,7 +1382,7 @@ describe("Worker Resource", () => {
         adopt: true,
       });
 
-      const worker2 = await Worker("worker1", {
+      const worker2 = await Worker("worker2", {
         name: workerName2,
         bindings: {
           TARGET_WORKER: WorkerRef<{
@@ -1518,18 +1531,20 @@ describe("Worker Resource", () => {
     }
   });
 
-  test("adopt worker with existing migration tag", async (scope) => {
-    const scriptName = `${BRANCH_PREFIX}-test-worker-adopt-migration`;
+  test.skipIf(!ENABLE_PAID_TESTS)(
+    "adopt worker with existing migration tag",
+    async (scope) => {
+      const scriptName = `${BRANCH_PREFIX}-test-worker-adopt-migration`;
 
-    try {
-      await deleteWorker(api, {
-        scriptName,
-      });
+      try {
+        await deleteWorker(api, {
+          scriptName,
+        });
 
-      const formData = new FormData();
-      formData.append(
-        "worker.js",
-        `
+        const formData = new FormData();
+        formData.append(
+          "worker.js",
+          `
           export class MyDO {}
           export default {
             async fetch(request, env, ctx) {
@@ -1537,47 +1552,47 @@ describe("Worker Resource", () => {
             }
           };
         `,
-      );
-      formData.append(
-        "metadata",
-        new Blob([
-          JSON.stringify({
-            compatibility_date: "2025-05-18",
-            bindings: [
-              {
-                type: "durable_object_namespace",
-                class_name: "MyDO",
-                name: "MY_DO",
+        );
+        formData.append(
+          "metadata",
+          new Blob([
+            JSON.stringify({
+              compatibility_date: "2025-05-18",
+              bindings: [
+                {
+                  type: "durable_object_namespace",
+                  class_name: "MyDO",
+                  name: "MY_DO",
+                },
+              ],
+              observability: {
+                enabled: true,
               },
-            ],
-            observability: {
-              enabled: true,
-            },
-            main_module: "worker.js",
-            migrations: {
-              new_tag: "v1",
-              old_tag: undefined,
-              new_classes: ["MyDO"],
-              deleted_classes: [],
-              renamed_classes: [],
-              transferred_classes: [],
-              new_sqlite_classes: [],
-            } satisfies SingleStepMigration,
-          }),
-        ]),
-      );
+              main_module: "worker.js",
+              migrations: {
+                new_tag: "v1",
+                old_tag: undefined,
+                new_classes: ["MyDO"],
+                deleted_classes: [],
+                renamed_classes: [],
+                transferred_classes: [],
+                new_sqlite_classes: [],
+              } satisfies SingleStepMigration,
+            }),
+          ]),
+        );
 
-      // Put the worker with migration tag v1
-      await api.post(
-        `/accounts/${api.accountId}/workers/scripts/${scriptName}/versions`,
-        formData,
-      );
+        // Put the worker with migration tag v1
+        await api.post(
+          `/accounts/${api.accountId}/workers/scripts/${scriptName}/versions`,
+          formData,
+        );
 
-      // Now adopt the worker using the Worker resource
-      await Worker(scriptName, {
-        name: scriptName,
-        adopt: true,
-        script: `
+        // Now adopt the worker using the Worker resource
+        await Worker(scriptName, {
+          name: scriptName,
+          adopt: true,
+          script: `
           export class MyDO2 {}
           export default {
             async fetch(request, env, ctx) {
@@ -1585,19 +1600,19 @@ describe("Worker Resource", () => {
             }
           };
         `,
-        format: "esm",
-        bindings: {
-          MY_DO: DurableObjectNamespace("test-counter-migration", {
-            className: "MyDO2",
-            scriptName: scriptName,
-          }),
-        },
-      });
+          format: "esm",
+          bindings: {
+            MY_DO: DurableObjectNamespace("test-counter-migration", {
+              className: "MyDO2",
+              scriptName: scriptName,
+            }),
+          },
+        });
 
-      await Worker(scriptName, {
-        name: scriptName,
-        adopt: true,
-        script: `
+        await Worker(scriptName, {
+          name: scriptName,
+          adopt: true,
+          script: `
           export class MyDO3 {}
           export default {
             async fetch(request, env, ctx) {
@@ -1605,19 +1620,20 @@ describe("Worker Resource", () => {
             }
           };
         `,
-        format: "esm",
-        bindings: {
-          MY_DO: DurableObjectNamespace("test-counter-migration", {
-            className: "MyDO3",
-            scriptName: scriptName,
-          }),
-        },
-      });
-    } finally {
-      await destroy(scope);
-      await assertWorkerDoesNotExist(api, scriptName);
-    }
-  });
+          format: "esm",
+          bindings: {
+            MY_DO: DurableObjectNamespace("test-counter-migration", {
+              className: "MyDO3",
+              scriptName: scriptName,
+            }),
+          },
+        });
+      } finally {
+        await destroy(scope);
+        await assertWorkerDoesNotExist(api, scriptName);
+      }
+    },
+  );
 
   test("create worker with url false and verify no workers.dev subdomain", async (scope) => {
     const workerName = `${BRANCH_PREFIX}-test-worker-no-url`;
@@ -2028,7 +2044,7 @@ describe("Worker Resource", () => {
     ).toBeFalsy();
   }
 
-  test("rename wfp worker", async (scope) => {
+  test.skipIf(!ENABLE_WFP_TESTS)("rename wfp worker", async (scope) => {
     const originalWorkerName = `${BRANCH_PREFIX}-test-wfp-worker-rename-1`;
     const newWorkerName = `${BRANCH_PREFIX}-test-wfp-worker-rename-2`;
     const namespaceName = `${BRANCH_PREFIX}-rename-wfp-worker`;

--- a/bun.lock
+++ b/bun.lock
@@ -5043,6 +5043,8 @@
 
     "ajv-keywords/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
 
+    "alchemy/@types/node": ["@types/node@24.0.14", "", { "dependencies": { "undici-types": "~7.8.0" } }, "sha512-4zXMWD91vBLGRtHK3YbIoFMia+1nqEz72coM42C5ETjnNCa/heoj7NT1G67iAfOqMmcfhuCZ4uNpyz8EjlAejw=="],
+
     "alchemy/braintrust": ["braintrust@0.0.201", "", { "dependencies": { "@ai-sdk/provider": "^1.0.1", "@braintrust/core": "0.0.86", "@next/env": "^14.2.3", "@vercel/functions": "^1.0.2", "ai": "^3.2.16", "argparse": "^2.0.1", "chalk": "^4.1.2", "cli-progress": "^3.12.0", "cors": "^2.8.5", "dotenv": "^16.4.5", "esbuild": "^0.25.3", "eventsource-parser": "^1.1.2", "express": "^4.21.2", "graceful-fs": "^4.2.11", "http-errors": "^2.0.0", "minimatch": "^9.0.3", "mustache": "^4.2.0", "pluralize": "^8.0.0", "simple-git": "^3.21.0", "slugify": "^1.6.6", "source-map": "^0.7.4", "uuid": "^9.0.1", "zod": "^3.22.4", "zod-to-json-schema": "^3.22.5" }, "bin": { "braintrust": "dist/cli.js" } }, "sha512-qH4esyOskiQ25OzbmlnPMVKEImDuFANEuYknNEsgS2f3M7t5SfbZxdelbYWcFPbUwQO3TR3XktszWcc3+oAZKg=="],
 
     "alchemy/glob": ["glob@10.4.5", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg=="],


### PR DESCRIPTION
- adds option to skip tests that required paid cloudflare accounts
- fixes `can bind to a worker referenced by name`
- runs formatting on the worker tests file (was this not formatted by biome before?)