### PR TITLE
fix(core): do not delete nested resources of a skipped resource

### DIFF
--- a/alchemy/src/apply.ts
+++ b/alchemy/src/apply.ts
@@ -115,6 +115,7 @@ async function _apply<Out extends Resource>(
         JSON.stringify(oldProps) === JSON.stringify(newProps) &&
         alwaysUpdate !== true
       ) {
+        scope.skip();
         if (!quiet) {
           logger.task(resource[ResourceFQN], {
             prefix: "skipped",

--- a/alchemy/test/scope.test.ts
+++ b/alchemy/test/scope.test.ts
@@ -7,7 +7,7 @@ import { File } from "../src/fs/file.js";
 import { Scope } from "../src/scope.js";
 import { BRANCH_PREFIX, createTestOptions, STATE_STORE_TYPES } from "./util.js";
 
-import { Resource } from "../src/resource.js";
+import { Resource, ResourceScope } from "../src/resource.js";
 import { serializeScope } from "../src/serde.js";
 import "../src/test/vitest.js";
 
@@ -180,6 +180,48 @@ describe.concurrent("Scope", () => {
             });
           } finally {
             await destroy(scope);
+          }
+        },
+      );
+      test(
+        "a skipped resource should not delete nested resources",
+        options,
+        async (scope) => {
+          const Outer = Resource(
+            `${storeType}-Outer`,
+            async function (this, _id: string) {
+              if (this.phase === "delete") {
+                return this.destroy();
+              }
+              await Inner("inner", { fileName: "test-inner" });
+              return this({});
+            },
+          );
+
+          let isDeleted = false;
+          const Inner = Resource(
+            `${storeType}-Inner`,
+            async function (this, _id: string) {
+              if (this.phase === "delete") {
+                isDeleted = true;
+                return this.destroy();
+              }
+              return this({});
+            },
+          );
+          try {
+            await Outer("outer");
+            expect(isDeleted).toBe(false);
+            // emulate a new process (destroy in memory scope)
+            scope.clear();
+            const outer = await Outer("outer");
+            // finalizing a scoped that was skipped should not delete nested resources
+            await outer[ResourceScope].finalize();
+            expect(isDeleted).toBe(false);
+          } finally {
+            console.log("destroy");
+            await destroy(scope);
+            // expect(isDeleted).toBe(true);
           }
         },
       );


### PR DESCRIPTION
Found a bug where finalizing a resource that had been skipped would delete all the nested resources mistakenly.

Probably have been lucky to not run into this because of `{alwaysUpdate :true}` on the `Worker` resource.