### PR TITLE
feat(cloudflare): support cpu_ms limit on Worker

### DIFF
--- a/alchemy-web/src/content/docs/guides/cloudflare-worker.mdx
+++ b/alchemy-web/src/content/docs/guides/cloudflare-worker.mdx
@@ -215,8 +215,28 @@ const worker = await Worker("optimized-worker", {
 });
 ```
 
-:::tip
+:::note
 Learn more about [Smart Placement](https://developers.cloudflare.com/workers/configuration/smart-placement/) in the Cloudflare documentation.
+:::
+
+
+## CPU Time Limits
+
+Set the maximum CPU time in milliseconds that the worker can use:
+
+```ts
+
+const worker = await Worker("api", {
+  name: "api-worker",
+  entrypoint: "./src/api.ts",
+  limits: {
+    cpu_ms: 300_000,
+  },
+});
+```
+
+:::tip
+Learn more about [CPU Time Limits](https://developers.cloudflare.com/workers/platform/limits/#cpu-time) in the Cloudflare documentation.
 :::
 
 ## Cron Triggers

--- a/alchemy-web/src/content/docs/guides/cloudflare-worker.mdx
+++ b/alchemy-web/src/content/docs/guides/cloudflare-worker.mdx
@@ -220,12 +220,11 @@ Learn more about [Smart Placement](https://developers.cloudflare.com/workers/con
 :::
 
 
-## CPU Time Limits
+## CPU Time Limit
 
 Set the maximum CPU time in milliseconds that the worker can use:
 
 ```ts
-
 const worker = await Worker("api", {
   name: "api-worker",
   entrypoint: "./src/api.ts",

--- a/alchemy-web/src/content/docs/providers/cloudflare/worker.mdx
+++ b/alchemy-web/src/content/docs/providers/cloudflare/worker.mdx
@@ -217,7 +217,7 @@ const worker = await Worker("optimized-worker", {
 Learn more about [Smart Placement](https://developers.cloudflare.com/workers/configuration/smart-placement/) in the Cloudflare documentation.
 :::
 
-## CPU Time Limits
+## CPU Time Limit
 
 Set the maximum CPU time in milliseconds that the worker can use:
 

--- a/alchemy-web/src/content/docs/providers/cloudflare/worker.mdx
+++ b/alchemy-web/src/content/docs/providers/cloudflare/worker.mdx
@@ -213,8 +213,27 @@ const worker = await Worker("optimized-worker", {
 });
 ```
 
-:::tip
+:::note
 Learn more about [Smart Placement](https://developers.cloudflare.com/workers/configuration/smart-placement/) in the Cloudflare documentation.
+:::
+
+## CPU Time Limits
+
+Set the maximum CPU time in milliseconds that the worker can use:
+
+```ts
+
+const worker = await Worker("api", {
+  name: "api-worker",
+  entrypoint: "./src/api.ts",
+  limits: {
+    cpu_ms: 300_000,
+  },
+});
+```
+
+:::note
+Learn more about [CPU Time Limits](https://developers.cloudflare.com/workers/platform/limits/#cpu-time) in the Cloudflare documentation.
 :::
 
 ## Cron Triggers

--- a/alchemy/src/cloudflare/worker-metadata.ts
+++ b/alchemy/src/cloudflare/worker-metadata.ts
@@ -200,6 +200,9 @@ export interface WorkerMetadata {
   placement?: {
     mode: "smart";
   };
+  limits?: {
+    cpu_ms?: number;
+  };
 }
 
 export async function prepareWorkerMetadata(
@@ -343,6 +346,7 @@ export async function prepareWorkerMetadata(
       new_sqlite_classes: [],
     },
     placement: props.placement,
+    limits: props.limits,
   };
 
   const assetUploadResult = props.assetUploadResult;

--- a/alchemy/src/cloudflare/worker.ts
+++ b/alchemy/src/cloudflare/worker.ts
@@ -388,6 +388,16 @@ export interface BaseWorkerProps<
      */
     mode: "smart";
   };
+
+  limits?: {
+    /**
+     * The maximum CPU time in milliseconds that the worker can use.
+     *
+     * @see https://developers.cloudflare.com/workers/platform/limits/#cpu-time
+     * @default 30_000 (30 seconds)
+     */
+    cpu_ms?: number;
+  };
 }
 
 export interface InlineWorkerProps<
@@ -1127,6 +1137,8 @@ export const _Worker = Resource(
         crons: props.crons,
         // Include placement configuration in the output
         placement: props.placement,
+        // Include limits configuration in the output
+        limits: props.limits,
         // phantom property
         Env: undefined!,
       } as unknown as Worker<B>);
@@ -1421,6 +1433,8 @@ export const _Worker = Resource(
       version: props.version,
       // Include placement configuration in the output
       placement: props.placement,
+      // Include limits configuration in the output
+      limits: props.limits,
       // phantom property
       Env: undefined!,
     } as unknown as Worker<B>);

--- a/alchemy/src/cloudflare/wrangler.json.ts
+++ b/alchemy/src/cloudflare/wrangler.json.ts
@@ -149,6 +149,8 @@ export const WranglerJson = Resource(
             binding: props.assets.binding,
           }
         : undefined,
+      placement: worker.placement,
+      limits: worker.limits,
     };
 
     // Process bindings if they exist
@@ -217,6 +219,20 @@ export interface WranglerJsonSpec {
    * A list of flags that enable features from upcoming Workers runtime
    */
   compatibility_flags?: string[];
+
+  /**
+   * The placement mode for the worker
+   */
+  placement?: {
+    mode: "smart";
+  };
+
+  /**
+   * The CPU time limit for the worker
+   */
+  limits?: {
+    cpu_ms?: number;
+  };
 
   /**
    * Whether to enable a workers.dev URL for this worker

--- a/alchemy/test/cloudflare/test-helpers.ts
+++ b/alchemy/test/cloudflare/test-helpers.ts
@@ -8,13 +8,8 @@ export async function assertWorkerDoesNotExist(
   api: CloudflareApi,
   workerName: string,
 ) {
-  try {
-    const response = await api.get(
-      `/accounts/${api.accountId}/workers/scripts/${workerName}`,
-    );
-    expect(response.status).toEqual(404);
-  } catch {
-    // 404 is expected, so we can ignore it
-    return;
-  }
+  const response = await api.get(
+    `/accounts/${api.accountId}/workers/scripts/${workerName}`,
+  );
+  expect(response.status).toEqual(404);
 }

--- a/alchemy/test/cloudflare/wrangler-json.test.ts
+++ b/alchemy/test/cloudflare/wrangler-json.test.ts
@@ -676,4 +676,47 @@ describe("WranglerJson Resource", () => {
       await destroy(scope);
     }
   });
+
+  test("with smart placement and cpu_ms limit", async (scope) => {
+    const name = `${BRANCH_PREFIX}-test-worker-placement-limits`;
+    const tempDir = path.join(".out", "alchemy-placement-limits-test");
+    const entrypoint = path.join(tempDir, "worker.ts");
+
+    try {
+      // Create a temporary directory for the entrypoint file
+      await fs.rm(tempDir, { recursive: true, force: true });
+      await fs.mkdir(tempDir, { recursive: true });
+      await fs.writeFile(entrypoint, esmWorkerScript);
+
+      const { spec } = await WranglerJson(
+        `${BRANCH_PREFIX}-test-wrangler-json-placement-limits`,
+        {
+          worker: {
+            name,
+            format: "esm",
+            entrypoint,
+            placement: {
+              mode: "smart",
+            },
+            limits: {
+              cpu_ms: 60000,
+            },
+          },
+        },
+      );
+
+      expect(spec).toMatchObject({
+        name,
+        placement: {
+          mode: "smart",
+        },
+        limits: {
+          cpu_ms: 60000,
+        },
+      });
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+      await destroy(scope);
+    }
+  });
 });


### PR DESCRIPTION
Set the maximum CPU time in milliseconds that the worker can use:

```ts
const worker = await Worker("api", {
  name: "api-worker",
  entrypoint: "./src/api.ts",
  limits: {
    cpu_ms: 300_000,
  },
});
```