### PR TITLE
fix(core): replace should use old resource state when deleting

### DIFF
--- a/alchemy/src/destroy.ts
+++ b/alchemy/src/destroy.ts
@@ -118,7 +118,20 @@ export async function destroy<Type extends string>(
       fqn: instance[ResourceFQN],
       seq: instance[ResourceSeq],
       props: options?.replace?.props ?? state.props,
-      state,
+      state: options?.replace?.output
+        ? {
+            output: options.replace.output,
+            status: "deleting",
+            oldProps: options.replace.props,
+            data: {},
+            kind: instance[ResourceKind],
+            id: instance[ResourceID],
+            fqn: instance[ResourceFQN],
+            seq: instance[ResourceSeq],
+            props: options.replace.props,
+          }
+        : state,
+      // TODO(sam|michael): should this always be false or !!options?.replace
       isReplacement: false,
       replace: () => {
         throw new Error("Cannot replace a resource that is being deleted");

--- a/bun.lock
+++ b/bun.lock
@@ -5029,6 +5029,8 @@
 
     "ajv-keywords/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
 
+    "alchemy/@types/node": ["@types/node@24.0.15", "", { "dependencies": { "undici-types": "~7.8.0" } }, "sha512-oaeTSbCef7U/z7rDeJA138xpG3NuKc64/rZ2qmUFkFJmnMsAPaluIifqyWd8hSSMxyP9oie3dLAqYPblag9KgA=="],
+
     "alchemy/braintrust": ["braintrust@0.0.201", "", { "dependencies": { "@ai-sdk/provider": "^1.0.1", "@braintrust/core": "0.0.86", "@next/env": "^14.2.3", "@vercel/functions": "^1.0.2", "ai": "^3.2.16", "argparse": "^2.0.1", "chalk": "^4.1.2", "cli-progress": "^3.12.0", "cors": "^2.8.5", "dotenv": "^16.4.5", "esbuild": "^0.25.3", "eventsource-parser": "^1.1.2", "express": "^4.21.2", "graceful-fs": "^4.2.11", "http-errors": "^2.0.0", "minimatch": "^9.0.3", "mustache": "^4.2.0", "pluralize": "^8.0.0", "simple-git": "^3.21.0", "slugify": "^1.6.6", "source-map": "^0.7.4", "uuid": "^9.0.1", "zod": "^3.22.4", "zod-to-json-schema": "^3.22.5" }, "bin": { "braintrust": "dist/cli.js" } }, "sha512-qH4esyOskiQ25OzbmlnPMVKEImDuFANEuYknNEsgS2f3M7t5SfbZxdelbYWcFPbUwQO3TR3XktszWcc3+oAZKg=="],
 
     "alchemy/glob": ["glob@10.4.5", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg=="],


### PR DESCRIPTION
Replace had a bug where it would pass in the old resource state so `this.output.??` would refer to the new resource instead of the old resource.