### PR TITLE
feat(core): configure parallel delete on Scope and Provider

### DIFF
--- a/alchemy-web/src/content/docs/concepts/resource.mdx
+++ b/alchemy-web/src/content/docs/concepts/resource.mdx
@@ -166,6 +166,29 @@ return this.create({/* updated properties */});
 ```
 :::
 
+## Destroy Strategy
+
+By default, Alchemy will destroy resources in a sequential order. You can change this behavior for a Resource by passing the `destroyStrategy` option to the Resource constructor.
+
+```ts
+const Database = Resource(
+  "neon::Database",
+  { destroyStrategy: "parallel" },
+  async function(this: Context<Database>, id: string, props: DatabaseProps): Promise<Database> {
+    if (this.phase === "delete") {
+      return this.destroy();
+    }
+    // these sub-resources will be deleted in parallel during the Database resource deletion
+    await SubResource("sub-resource", {});
+    await OtherResource("other-resource", {});
+  }
+);
+```
+
+:::tip
+You can also set the `destroyStrategy` option globally or within a Scope using `alchemy.run`. See [Scope](/concepts/scope#destroy-strategy) for more details.
+:::
+
 ## Adoption
 
 When creating a resource, Alchemy will fail if a resource with the same name already exists. Resource adoption allows you to opt in to using the pre-existing resource instead.

--- a/alchemy-web/src/content/docs/concepts/scope.md
+++ b/alchemy-web/src/content/docs/concepts/scope.md
@@ -180,3 +180,25 @@ describe("Worker Resource", () => {
 ```
 
 For more details on testing with Alchemy, see [Testing in Alchemy](/concepts/testing).
+
+## Destroy Strategy
+
+By default, Alchemy will destroy scopes in a sequential order. You can change this behavior by passing the `destroyStrategy` option to the Scope constructor.
+
+```typescript
+const app = await alchemy("my-app", {
+  destroyStrategy: "parallel"
+});
+```
+
+You can also set the `destroyStrategy` option on the `alchemy.run` function.
+
+```typescript
+await alchemy.run("my-app", {
+  destroyStrategy: "parallel"
+}, async (scope) => {
+  // resources will be deleted in parallel during scope deletion/finalization
+  await Resource("resource1", {});
+  await Resource("resource2", {});
+});
+```

--- a/alchemy/src/alchemy.ts
+++ b/alchemy/src/alchemy.ts
@@ -2,15 +2,15 @@ import fs from "node:fs/promises";
 import path from "node:path";
 
 import { ReplacedSignal } from "./apply.ts";
-import { DestroyedSignal, destroy } from "./destroy.ts";
+import { DestroyStrategy, DestroyedSignal, destroy } from "./destroy.ts";
 import { env } from "./env.ts";
 import {
-  type PendingResource,
   ResourceFQN,
   ResourceID,
   ResourceKind,
   ResourceScope,
   ResourceSeq,
+  type PendingResource,
 } from "./resource.ts";
 import { isRuntime } from "./runtime/global.ts";
 import { DEFAULT_STAGE, Scope } from "./scope.ts";
@@ -360,6 +360,12 @@ export interface AlchemyOptions {
    */
   parent?: Scope;
   /**
+   * The strategy to use when destroying resources.
+   *
+   * @default "sequential"
+   */
+  destroyStrategy?: DestroyStrategy;
+  /**
    * If true, will not print any Create/Update/Delete messages.
    *
    * @default false
@@ -451,6 +457,7 @@ async function run<T>(
         [ResourceKind]: Scope.KIND,
         [ResourceScope]: _scope,
         [ResourceSeq]: seq,
+        [DestroyStrategy]: options?.destroyStrategy ?? "sequential",
       } as const;
       const resource = {
         kind: Scope.KIND,

--- a/alchemy/src/apply.ts
+++ b/alchemy/src/apply.ts
@@ -1,6 +1,6 @@
 import { alchemy } from "./alchemy.ts";
 import { context } from "./context.ts";
-import { destroy } from "./destroy.ts";
+import { destroy, DestroyStrategy } from "./destroy.ts";
 import {
   PROVIDERS,
   ResourceFQN,
@@ -92,6 +92,7 @@ async function _apply<Out extends Resource>(
           [ResourceKind]: resource[ResourceKind],
           [ResourceScope]: scope,
           [ResourceSeq]: resource[ResourceSeq],
+          [DestroyStrategy]: provider.options?.destroyStrategy ?? "sequential",
         },
         // deps: [...deps],
         props,
@@ -199,6 +200,7 @@ async function _apply<Out extends Resource>(
         {
           isResource: true,
           parent: scope,
+          destroyStrategy: provider.options?.destroyStrategy ?? "sequential",
         },
         async (scope) => {
           options?.resolveInnerScope?.(scope);
@@ -216,7 +218,7 @@ async function _apply<Out extends Resource>(
         if (error.force) {
           await destroy(resource, {
             quiet: scope.quiet,
-            strategy: "sequential",
+            strategy: resource[DestroyStrategy] ?? "sequential",
             replace: {
               props: state.oldProps,
               output: resource,

--- a/alchemy/src/aws/s3-state-store.ts
+++ b/alchemy/src/aws/s3-state-store.ts
@@ -9,7 +9,7 @@ import {
 } from "@aws-sdk/client-s3";
 import { ResourceScope } from "../resource.ts";
 import type { Scope } from "../scope.ts";
-import { serialize, deserialize } from "../serde.ts";
+import { deserialize, serialize } from "../serde.ts";
 import type { State, StateStore } from "../state.ts";
 import { ignore } from "../util/ignore.ts";
 import { retry } from "./retry.ts";
@@ -55,7 +55,7 @@ export class S3StateStore implements StateStore {
    */
   constructor(
     public readonly scope: Scope,
-    private readonly options: S3StateStoreOptions = {},
+    options: S3StateStoreOptions = {},
   ) {
     // Use the scope's chain to build the prefix, similar to how FileSystemStateStore builds its directory
     const scopePath = scope.chain.join("/");

--- a/alchemy/src/destroy.ts
+++ b/alchemy/src/destroy.ts
@@ -16,9 +16,13 @@ import { logger } from "./util/logger.ts";
 
 export class DestroyedSignal extends Error {}
 
+export type DestroyStrategy = "sequential" | "parallel";
+
+export const DestroyStrategy = Symbol.for("alchemy::DestroyStrategy");
+
 export interface DestroyOptions {
   quiet?: boolean;
-  strategy?: "sequential" | "parallel";
+  strategy?: DestroyStrategy;
   replace?: {
     props?: ResourceProps | undefined;
     output?: Resource<string>;
@@ -40,7 +44,7 @@ export async function destroy<Type extends string>(
   if (isScopeArgs(args)) {
     const [scope] = args;
     const options = {
-      strategy: "sequential",
+      strategy: scope.destroyStrategy ?? "sequential",
       ...(args[1] ?? {}),
     } satisfies DestroyOptions;
 
@@ -147,6 +151,7 @@ export async function destroy<Type extends string>(
           // TODO(sam): this is an awful hack to differentiate between naked scopes and resources
           isResource: instance[ResourceKind] !== "alchemy::Scope",
           parent: scope,
+          destroyStrategy: instance[DestroyStrategy] ?? "sequential",
         },
         async (scope) => {
           nestedScope = options?.replace?.props == null ? scope : undefined;
@@ -164,13 +169,17 @@ export async function destroy<Type extends string>(
       }
     }
 
+    const destroyOptions = {
+      ...options,
+      strategy: instance[DestroyStrategy] ?? "sequential",
+    };
     if (nestedScope) {
-      await destroy(nestedScope, options);
+      await destroy(nestedScope, destroyOptions);
     }
 
     if (options?.replace == null) {
       if (nestedScope) {
-        await destroy(nestedScope, options);
+        await destroy(nestedScope, destroyOptions);
       }
       await scope.deleteResource(instance[ResourceID]);
     } else {

--- a/alchemy/src/resource.ts
+++ b/alchemy/src/resource.ts
@@ -1,5 +1,6 @@
 import { apply } from "./apply.ts";
 import type { Context } from "./context.ts";
+import { DestroyStrategy } from "./destroy.ts";
 import { Scope as _Scope, type Scope } from "./scope.ts";
 
 declare global {
@@ -59,6 +60,13 @@ export interface ProviderOptions {
    * If true, the resource will be updated even if the inputs have not changed.
    */
   alwaysUpdate: boolean;
+
+  /**
+   * The strategy to use when destroying the resource.
+   *
+   * @default "sequential"
+   */
+  destroyStrategy?: DestroyStrategy;
 }
 
 export type ResourceProps = {
@@ -81,6 +89,7 @@ export interface PendingResource<Out = unknown> extends Promise<Out> {
   [ResourceFQN]: ResourceFQN;
   [ResourceScope]: Scope;
   [ResourceSeq]: number;
+  [DestroyStrategy]: DestroyStrategy;
   [InnerResourceScope]: Promise<Scope>;
 }
 
@@ -90,6 +99,7 @@ export interface Resource<Kind extends ResourceKind = ResourceKind> {
   [ResourceFQN]: ResourceFQN;
   [ResourceScope]: Scope;
   [ResourceSeq]: number;
+  [DestroyStrategy]: DestroyStrategy;
 }
 
 // helper for semantic syntax highlighting (color as a type/class instead of function/value)
@@ -167,6 +177,7 @@ export function Resource<
       [ResourceFQN]: scope.fqn(resourceID),
       [ResourceSeq]: seq,
       [ResourceScope]: scope,
+      [DestroyStrategy]: options?.destroyStrategy ?? "sequential",
       [InnerResourceScope]: new Promise<Scope>((resolve) => {
         resolveInnerScope = resolve;
       }),

--- a/alchemy/src/test/options.ts
+++ b/alchemy/src/test/options.ts
@@ -1,3 +1,4 @@
+import type { DestroyStrategy } from "../destroy.ts";
 import type { StateStoreType } from "../state.ts";
 
 /**
@@ -31,4 +32,11 @@ export interface TestOptions {
    * Prefix to use for the scope to isolate tests and environments.
    */
   prefix?: string;
+
+  /**
+   * The strategy to use when destroying resources.
+   *
+   * @default "sequential"
+   */
+  destroyStrategy?: DestroyStrategy;
 }

--- a/alchemy/src/util/safe-fetch.ts
+++ b/alchemy/src/util/safe-fetch.ts
@@ -15,13 +15,10 @@ export async function safeFetch(
         dispatcher: await dispatcher(),
       } as RequestInit);
     } catch (err: any) {
+      console.log("err", err);
       latestErr = err;
       const shouldRetry =
-        err?.code === "UND_ERR_SOCKET" ||
-        err?.code === "ECONNRESET" ||
-        err?.code === "UND_ERR_CONNECT_TIMEOUT" ||
-        err?.code === "EPIPE" ||
-        err?.name === "FetchError";
+        isTransientNetworkError(err) || isTransientNetworkError(err.cause);
 
       if (!shouldRetry || attempt === retries) {
         throw err;
@@ -32,6 +29,16 @@ export async function safeFetch(
     }
   }
   throw latestErr;
+}
+
+function isTransientNetworkError(err: any) {
+  return (
+    err?.code === "UND_ERR_SOCKET" ||
+    err?.code === "ECONNRESET" ||
+    err?.code === "UND_ERR_CONNECT_TIMEOUT" ||
+    err?.code === "EPIPE" ||
+    err?.name === "FetchError"
+  );
 }
 
 let agent:

--- a/alchemy/test/cloudflare/pipeline.test.ts
+++ b/alchemy/test/cloudflare/pipeline.test.ts
@@ -438,18 +438,11 @@ describe("Pipeline Resource", () => {
         );
 
         const responseData: any = await sendResponse.json();
-        console.log(responseData);
 
         expect(sendResponse.status).toEqual(200);
         expect(responseData.success).toEqual(true);
         expect(responseData.message).toEqual("Records sent to pipeline");
         expect(responseData.count).toEqual(2);
-
-        // Note: We can't easily verify the records were written to R2 in a test
-        // because it might take time for the batching and delivery to complete.
-        // In a real application, you'd have monitoring or a way to query the destination.
-
-        console.log("Records sent to pipeline:", responseData);
       }
     } finally {
       // wait 10s for pipeline to flush

--- a/alchemy/test/cloudflare/rate-limit.test.ts
+++ b/alchemy/test/cloudflare/rate-limit.test.ts
@@ -1,6 +1,5 @@
 import { describe } from "vitest";
 import { alchemy } from "../../src/alchemy.ts";
-import { createCloudflareApi } from "../../src/cloudflare/api.ts";
 import { RateLimit } from "../../src/cloudflare/rate-limit.ts";
 import { Worker } from "../../src/cloudflare/worker.ts";
 import { BRANCH_PREFIX } from "../util.ts";
@@ -12,8 +11,6 @@ import "../../src/test/vitest.ts";
 const test = alchemy.test(import.meta, {
   prefix: BRANCH_PREFIX,
 });
-
-const api = await createCloudflareApi();
 
 describe("RateLimit", () => {
   test("end-to-end rate limiting with worker binding", async (scope) => {

--- a/bun.lock
+++ b/bun.lock
@@ -5029,6 +5029,8 @@
 
     "ajv-keywords/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
 
+    "alchemy/@types/bun": ["@types/bun@1.2.19", "", { "dependencies": { "bun-types": "1.2.19" } }, "sha512-d9ZCmrH3CJ2uYKXQIUuZ/pUnTqIvLDS0SK7pFmbx8ma+ziH/FRMoAq5bYpRG7y+w1gl+HgyNZbtqgMq4W4e2Lg=="],
+
     "alchemy/@types/node": ["@types/node@24.0.15", "", { "dependencies": { "undici-types": "~7.8.0" } }, "sha512-oaeTSbCef7U/z7rDeJA138xpG3NuKc64/rZ2qmUFkFJmnMsAPaluIifqyWd8hSSMxyP9oie3dLAqYPblag9KgA=="],
 
     "alchemy/braintrust": ["braintrust@0.0.201", "", { "dependencies": { "@ai-sdk/provider": "^1.0.1", "@braintrust/core": "0.0.86", "@next/env": "^14.2.3", "@vercel/functions": "^1.0.2", "ai": "^3.2.16", "argparse": "^2.0.1", "chalk": "^4.1.2", "cli-progress": "^3.12.0", "cors": "^2.8.5", "dotenv": "^16.4.5", "esbuild": "^0.25.3", "eventsource-parser": "^1.1.2", "express": "^4.21.2", "graceful-fs": "^4.2.11", "http-errors": "^2.0.0", "minimatch": "^9.0.3", "mustache": "^4.2.0", "pluralize": "^8.0.0", "simple-git": "^3.21.0", "slugify": "^1.6.6", "source-map": "^0.7.4", "uuid": "^9.0.1", "zod": "^3.22.4", "zod-to-json-schema": "^3.22.5" }, "bin": { "braintrust": "dist/cli.js" } }, "sha512-qH4esyOskiQ25OzbmlnPMVKEImDuFANEuYknNEsgS2f3M7t5SfbZxdelbYWcFPbUwQO3TR3XktszWcc3+oAZKg=="],
@@ -5838,6 +5840,8 @@
     "ajv-formats/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "ajv-keywords/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "alchemy/@types/bun/bun-types": ["bun-types@1.2.19", "", { "dependencies": { "@types/node": "*" }, "peerDependencies": { "@types/react": "^19" } }, "sha512-uAOTaZSPuYsWIXRpj7o56Let0g/wjihKCkeRqUBhlLVM/Bt+Fj9xTo+LhC1OV1XDaGkz4hNC80et5xgy+9KTHQ=="],
 
     "alchemy/braintrust/@braintrust/core": ["@braintrust/core@0.0.86", "", { "dependencies": { "@asteasolutions/zod-to-openapi": "^6.3.1", "uuid": "^9.0.1", "zod": "^3.22.4" } }, "sha512-kysTnKjizQl4EQGbLDK91Ao8UKMG111NgB+Stu88df9X2KHW5UpI63rShiucaVQt168fvr3UfRJbzfZ/t068bw=="],
 


### PR DESCRIPTION
By default, Alchemy will destroy scopes in a sequential order. You can configure the default behavior for the whole `alchemy` app, Scope (`alchemy.run`) or for a specific `Resource `:

```typescript
const app = await alchemy("my-app", {
  destroyStrategy: "parallel"
});

await alchemy.run("my-app", {
  destroyStrategy: "parallel"
}, async (scope) => {
  // resources will be deleted in parallel during scope deletion/finalization
  await Resource("resource1", {});
  await Resource("resource2", {});
});

const Database = Resource(
  "neon::Database",
  { destroyStrategy: "parallel" },
  async function(this: Context<Database>, id: string, props: DatabaseProps): Promise<Database> {
    if (this.phase === "delete") {
      return this.destroy();
    }
    // these sub-resources will be deleted in parallel during the Database resource deletion
    await SubResource("sub-resource", {});
    await OtherResource("other-resource", {});
  }
);
```