### PR TITLE
fix(cloudflare): don't require r2 access credentials to auto-empty bucket

### DIFF
--- a/alchemy-web/src/content/docs/providers/cloudflare/bucket.md
+++ b/alchemy-web/src/content/docs/providers/cloudflare/bucket.md
@@ -42,6 +42,30 @@ const publicBucket = await R2Bucket("public-assets", {
   name: "public-assets",
   allowPublicAccess: true,
 });
+console.log(publicBucket.domain); // [random-id].r2.dev
+```
+
+This enables the `r2.dev` domain for the bucket. This URL is rate-limited and not recommended for production use.
+
+## With CORS
+
+Create a bucket with CORS rules:
+
+```ts
+import { R2Bucket } from "alchemy/cloudflare";
+
+const corsBucket = await R2Bucket("cors-bucket", {
+  name: "cors-bucket",
+  cors: [
+    {
+      allowed: {
+        origins: ["https://example.com"],
+        methods: ["GET", "POST", "PUT", "DELETE", "HEAD"],
+        headers: ["*"],
+      },
+    },
+  ],
+});
 ```
 
 ## With Auto-Emptying

--- a/alchemy/src/cloudflare/api-response.ts
+++ b/alchemy/src/cloudflare/api-response.ts
@@ -1,3 +1,5 @@
+import { CloudflareApiError } from "./api-error.ts";
+
 /**
  * Cloudflare API response format
  */
@@ -15,7 +17,7 @@ export interface CloudflareApiResponse<T> {
   /**
    * Error details if success is false
    */
-  errors: CloudflareApiError[];
+  errors: CloudflareApiErrorPayload[];
 
   /**
    * Response messages
@@ -37,7 +39,7 @@ export interface CloudflareApiResponse<T> {
 /**
  * Cloudflare API error format
  */
-export interface CloudflareApiError {
+export interface CloudflareApiErrorPayload {
   /**
    * Error code
    */
@@ -89,8 +91,10 @@ export async function extractCloudflareResult<T>(
   if (json.success) {
     return json.result;
   } else {
-    const error = new Error(
+    const error = new CloudflareApiError(
       `Failed to ${label} (${response.status} ${response.statusText}):\n${json.errors.map((e) => `- [${e.code}] ${e.message}${e.documentation_url ? ` (${e.documentation_url})` : ""}`).join("\n")}`,
+      response,
+      json.errors,
     );
     Error.captureStackTrace(error, extractCloudflareResult);
     Object.assign(error, {

--- a/alchemy/src/cloudflare/bucket.ts
+++ b/alchemy/src/cloudflare/bucket.ts
@@ -1,18 +1,23 @@
-import { AwsClient } from "aws4fetch";
 import type { Context } from "../context.ts";
 import { Resource, ResourceKind } from "../resource.ts";
 import { bind } from "../runtime/bind.ts";
-import type { Secret } from "../secret.ts";
-import { logger } from "../util/logger.ts";
 import { withExponentialBackoff } from "../util/retry.ts";
 import { CloudflareApiError, handleApiError } from "./api-error.ts";
-import { type CloudflareApi, createCloudflareApi } from "./api.ts";
+import {
+  extractCloudflareError,
+  extractCloudflareResult,
+} from "./api-response.ts";
+import {
+  createCloudflareApi,
+  type CloudflareApi,
+  type CloudflareApiOptions,
+} from "./api.ts";
 import type { Bound } from "./bound.ts";
 
 /**
  * Properties for creating or updating an R2 Bucket
  */
-export interface BucketProps {
+export interface BucketProps extends CloudflareApiOptions {
   /**
    * Name of the bucket
    * Names can only contain lowercase letters (a-z), numbers (0-9), and hyphens (-)
@@ -27,6 +32,12 @@ export interface BucketProps {
    * Indicates the primary geographical location data will be accessed from
    */
   locationHint?: string;
+
+  /**
+   * Optional storage class for the bucket
+   * Indicates the storage class for the bucket
+   */
+  storageClass?: "Standard" | "InfrequentAccess";
 
   /**
    * Optional jurisdiction for the bucket
@@ -53,36 +64,6 @@ export interface BucketProps {
    * @default false
    */
   empty?: boolean;
-
-  /**
-   * API Token to use for the bucket
-   */
-  apiToken?: Secret;
-
-  /**
-   * API Key to use for the bucket
-   */
-  apiKey?: Secret;
-
-  /**
-   * Email to use for the bucket
-   */
-  email?: string;
-
-  /**
-   * Account ID to use for the bucket
-   */
-  accountId?: string;
-
-  /**
-   * Access Key to use for the bucket
-   */
-  accessKey?: Secret;
-
-  /**
-   * Secret Access Key to use for the bucket
-   */
-  secretAccessKey?: Secret;
 
   /**
    * Whether to adopt an existing bucket
@@ -204,126 +185,82 @@ const R2BucketResource = Resource(
   ): Promise<R2BucketResource> {
     const api = await createCloudflareApi(props);
     const bucketName = props.name || this.id;
+    const allowPublicAccess = props.allowPublicAccess === true;
 
-    if (this.phase === "delete") {
-      if (props.delete !== false) {
-        if (props.empty) {
-          logger.log("Emptying R2 bucket:", bucketName);
-          const r2Client = await createR2Client({
-            ...props,
-            accountId: api.accountId,
-            accessKeyId: props.accessKey ?? this.output.accessKey,
-            secretAccessKey:
-              props.secretAccessKey ?? this.output.secretAccessKey,
-          });
-          // Empty the bucket first by deleting all objects
-          await emptyBucket(r2Client, bucketName, props.jurisdiction);
-        }
-
-        await deleteBucket(api, bucketName, props);
-      }
-
-      // Return void (a deleted bucket has no content)
-      return this.destroy();
-    }
-    if (this.phase === "create") {
-      try {
-        await createBucket(api, bucketName, props);
-      } catch (err) {
-        if (err instanceof CloudflareApiError && err.status === 409) {
-          if (!props.adopt) {
+    switch (this.phase) {
+      case "create": {
+        const bucket = await createBucket(api, bucketName, props).catch(
+          async (err) => {
+            if (
+              err instanceof CloudflareApiError &&
+              err.status === 409 &&
+              props.adopt
+            ) {
+              return await getBucket(api, bucketName, props);
+            }
             throw err;
-          }
-        } else {
-          throw err;
+          },
+        );
+        await updatePublicAccess(
+          api,
+          bucketName,
+          allowPublicAccess,
+          props.jurisdiction,
+        );
+        return this({
+          name: bucketName,
+          location: bucket.location,
+          creationDate: new Date(bucket.creation_date),
+          jurisdiction: bucket.jurisdiction,
+          allowPublicAccess,
+          type: "r2_bucket",
+          accountId: api.accountId,
+          dev: props.dev,
+        });
+      }
+      case "update": {
+        if (bucketName !== this.output.name) {
+          throw new Error(
+            `Cannot update R2Bucket name after creation. Bucket name is immutable. Before: ${this.output.name}, After: ${bucketName}`,
+          );
         }
+        if (allowPublicAccess !== this.output.allowPublicAccess) {
+          await updatePublicAccess(
+            api,
+            bucketName,
+            allowPublicAccess,
+            props.jurisdiction,
+          );
+        }
+        return this({
+          ...this.output,
+          allowPublicAccess,
+          dev: props.dev,
+        });
+      }
+      case "delete": {
+        if (props.delete !== false) {
+          if (props.empty) {
+            await emptyBucket(api, bucketName, props);
+          }
+          await deleteBucket(api, bucketName, props);
+        }
+        return this.destroy();
       }
     }
-
-    if (this.phase === "update" && bucketName !== this.output.name) {
-      throw new Error(
-        `Cannot update R2Bucket name after creation. Bucket name is immutable. Before: ${this.output.name}, After: ${bucketName}`,
-      );
-    }
-
-    await updatePublicAccess(
-      api,
-      bucketName,
-      props.allowPublicAccess === true,
-      props.jurisdiction,
-    );
-
-    return this({
-      name: bucketName,
-      location: props.locationHint || "default",
-      creationDate: new Date(),
-      jurisdiction: props.jurisdiction || "default",
-      type: "r2_bucket",
-      accountId: api.accountId,
-      dev: props.dev,
-    });
   },
 );
 
 /**
- * Configuration for R2 client to connect to Cloudflare R2
+ * The bucket information returned from the Cloudflare REST API
+ * @see https://developers.cloudflare.com/api/node/resources/r2/subresources/buckets/models/bucket/#(schema)
  */
-export interface R2ClientConfig {
-  accountId: string;
-  accessKeyId?: Secret;
-  secretAccessKey?: Secret;
-  jurisdiction?: string;
-}
-
-type R2Client = AwsClient & { accountId: string };
-
-/**
- * Creates an aws4fetch client configured for Cloudflare R2
- *
- * @see https://developers.cloudflare.com/r2/examples/aws/aws-sdk-js-v3/
- */
-export function createR2Client(config?: R2ClientConfig): Promise<R2Client> {
-  const accountId = config?.accountId ?? process.env.CLOUDFLARE_ACCOUNT_ID;
-  const accessKeyId =
-    config?.accessKeyId?.unencrypted || process.env.R2_ACCESS_KEY_ID;
-  const secretAccessKey =
-    config?.secretAccessKey?.unencrypted || process.env.R2_SECRET_ACCESS_KEY;
-
-  if (!accountId) {
-    throw new Error("CLOUDFLARE_ACCOUNT_ID environment variable is required");
-  }
-
-  if (!accessKeyId || !secretAccessKey) {
-    throw new Error(
-      "R2_ACCESS_KEY_ID and R2_SECRET_ACCESS_KEY environment variables are required",
-    );
-  }
-
-  // Create aws4fetch client with Cloudflare R2 endpoint
-  const client: any = new AwsClient({
-    accessKeyId,
-    secretAccessKey,
-    service: "s3",
-    region: "auto",
-  });
-  client.accountId = accountId;
-  return client;
-}
-
-interface CloudflareBucketResponse {
-  /**
-   * The bucket information returned from the Cloudflare REST API
-   * @see https://developers.cloudflare.com/api/node/resources/r2/subresources/buckets/models/bucket/#(schema)
-   */
-  result: {
-    creation_date: string;
-    location?: "apac" | "eeur" | "enam" | "weur" | "wnam" | "oc";
-    name: string;
-    storage_class?: "Standard" | "InfrequentAccess";
-  };
-  success: boolean;
-  errors: Array<{ code: number; message: string }>;
-  messages: string[];
+interface CloudflareBucket {
+  creation_date: string;
+  location: "apac" | "eeur" | "enam" | "weur" | "wnam" | "oc";
+  name: string;
+  storage_class: "Standard" | "InfrequentAccess";
+  jurisdiction: "default" | "eu" | "fedramp";
 }
 
 /**
@@ -334,24 +271,14 @@ interface CloudflareBucketResponse {
  * @returns Modified headers object
  */
 export function withJurisdiction(
-  headers: Record<string, string>,
-  props: BucketProps | { jurisdiction?: string } | string | undefined,
+  props: { jurisdiction?: string },
+  headers: Record<string, string> = {},
 ): Record<string, string> {
-  // Clone the headers object to avoid modifying the original
-  const result = { ...headers };
-
-  let jurisdiction: string | undefined;
-  if (typeof props === "string") {
-    jurisdiction = props;
-  } else if (props && "jurisdiction" in props) {
-    jurisdiction = props.jurisdiction;
+  if (props.jurisdiction && props.jurisdiction !== "default") {
+    headers["cf-r2-jurisdiction"] = props.jurisdiction;
   }
 
-  if (jurisdiction && jurisdiction !== "default") {
-    result["cf-r2-jurisdiction"] = jurisdiction;
-  }
-
-  return result;
+  return headers;
 }
 
 /**
@@ -361,28 +288,12 @@ export async function getBucket(
   api: CloudflareApi,
   bucketName: string,
   props: BucketProps = {},
-): Promise<CloudflareBucketResponse> {
-  const headers = withJurisdiction({}, props);
-  const getResponse = await api.get(
-    `/accounts/${api.accountId}/r2/buckets/${bucketName}`,
-    { headers },
-  );
-
-  if (!getResponse.ok) {
-    return await handleApiError(getResponse, "get", "R2 bucket", bucketName);
-  }
-
-  if (getResponse.status === 200) {
-    return (await getResponse.json()) as CloudflareBucketResponse;
-  }
-
-  const errorData: any = await getResponse.json().catch(() => ({
-    errors: [{ message: getResponse.statusText }],
-  }));
-
-  throw new CloudflareApiError(
-    `Error getting R2 bucket '${bucketName}': ${errorData.errors?.[0]?.message || getResponse.statusText}`,
-    getResponse,
+): Promise<CloudflareBucket> {
+  return await extractCloudflareResult<CloudflareBucket>(
+    `get R2 bucket "${bucketName}"`,
+    api.get(`/accounts/${api.accountId}/r2/buckets/${bucketName}`, {
+      headers: withJurisdiction(props),
+    }),
   );
 }
 
@@ -393,34 +304,21 @@ export async function createBucket(
   api: CloudflareApi,
   bucketName: string,
   props: BucketProps = {},
-): Promise<CloudflareBucketResponse> {
-  // Create new R2 bucket
-  const createPayload: any = {
-    name: bucketName,
-  };
-
-  if (props.locationHint) {
-    createPayload.location_hint = props.locationHint;
-  }
-
-  const headers = withJurisdiction({}, props);
-
-  const createResponse = await api.post(
-    `/accounts/${api.accountId}/r2/buckets`,
-    createPayload,
-    { headers },
+): Promise<CloudflareBucket> {
+  return await extractCloudflareResult<CloudflareBucket>(
+    `create R2 bucket "${bucketName}"`,
+    api.post(
+      `/accounts/${api.accountId}/r2/buckets`,
+      {
+        name: bucketName,
+        locationHint: props.locationHint,
+        storageClass: props.storageClass,
+      },
+      {
+        headers: withJurisdiction(props),
+      },
+    ),
   );
-
-  if (!createResponse.ok) {
-    return await handleApiError(
-      createResponse,
-      "creating",
-      "R2 bucket",
-      bucketName,
-    );
-  }
-
-  return (await createResponse.json()) as CloudflareBucketResponse;
 }
 
 /**
@@ -430,168 +328,24 @@ export async function deleteBucket(
   api: CloudflareApi,
   bucketName: string,
   props: BucketProps,
-): Promise<void> {
-  // Delete R2 bucket
-  const headers = withJurisdiction({}, props);
-
-  const deleteResponse = await api.delete(
-    `/accounts/${api.accountId}/r2/buckets/${bucketName}`,
-    { headers },
-  );
-
-  if (!deleteResponse.ok && deleteResponse.status !== 404) {
-    const errorData: any = await deleteResponse.json().catch(() => ({
-      errors: [{ message: deleteResponse.statusText }],
-    }));
-    throw new CloudflareApiError(
-      `Error deleting R2 bucket '${bucketName}': ${errorData.errors?.[0]?.message || deleteResponse.statusText}`,
-      deleteResponse,
-    );
-  }
-}
-
-/**
- * List objects in an R2 bucket
- *
- * @param r2 R2Client instance
- * @param bucketName Name of the bucket
- * @param continuationToken Optional token for pagination
- * @param jurisdiction Optional jurisdiction for the bucket
- * @returns Object containing the list of objects and the next continuation token
- */
-export async function listObjects(
-  r2: R2Client,
-  bucketName: string,
-  continuationToken?: string,
-  jurisdiction?: string,
-): Promise<{ objects: { Key: string }[]; continuationToken?: string }> {
-  // List objects in the bucket
-  const url = new URL(
-    `https://${r2.accountId}.r2.cloudflarestorage.com/${bucketName}`,
-  );
-  if (continuationToken) {
-    url.searchParams.set("continuation-token", continuationToken);
-  }
-  url.searchParams.set("list-type", "2");
-
-  const headers = withJurisdiction({}, jurisdiction);
-
-  const listResponse = await r2.fetch(url.toString(), { headers });
-  if (!listResponse.ok) {
-    throw new CloudflareApiError(
-      `Failed to list objects: ${listResponse.statusText}`,
-      listResponse,
-    );
-  }
-
-  const responseText = await listResponse.text();
-
-  // Extract objects from XML response using regex
-  const keyRegex = /<Key>([^<]+)<\/Key>/g;
-  const objects: { Key: string }[] = [];
-  let match;
-  while ((match = keyRegex.exec(responseText)) !== null) {
-    objects.push({ Key: match[1] });
-  }
-
-  // Get continuation token if present using regex
-  const tokenMatch =
-    /<NextContinuationToken>([^<]+)<\/NextContinuationToken>/.exec(
-      responseText,
-    );
-  const nextContinuationToken = tokenMatch ? tokenMatch[1] : undefined;
-
-  return { objects, continuationToken: nextContinuationToken };
-}
-
-/**
- * Helper function to empty a bucket by deleting all objects
- */
-export async function emptyBucket(
-  r2: R2Client,
-  bucketName: string,
-  jurisdiction?: string,
-): Promise<void> {
-  let continuationToken: string | undefined;
-  let totalDeleted = 0;
-
+) {
   try {
-    do {
-      logger.log(`Listing objects in bucket ${bucketName}`);
-      // List objects in the bucket
-      const { objects, continuationToken: nextToken } = await listObjects(
-        r2,
-        bucketName,
-        continuationToken,
-        jurisdiction,
-      );
-
-      continuationToken = nextToken;
-
-      logger.log(`Found ${objects.length} objects in bucket ${bucketName}`);
-
-      // Delete objects in batches
-      if (objects.length > 0) {
-        // Process delete in batches of 1000 (S3 limit)
-        for (let i = 0; i < objects.length; i += 1000) {
-          const batch = objects.slice(i, i + 1000);
-
-          // Create DeleteObjects request XML
-          const deleteXml = `
-            <Delete>
-              ${batch.map((obj) => `<Object><Key>${obj.Key}</Key></Object>`).join("")}
-            </Delete>
-          `;
-
-          const deleteUrl = new URL(
-            `https://${r2.accountId}.r2.cloudflarestorage.com/${bucketName}?delete`,
-          );
-
-          logger.log(
-            `Deleting ${batch.length} objects from bucket ${bucketName}`,
-          );
-
-          const headers = withJurisdiction(
-            { "Content-Type": "application/xml" },
-            jurisdiction,
-          );
-
-          const deleteResponse = await r2.fetch(deleteUrl.toString(), {
-            method: "POST",
-            body: deleteXml,
-            headers,
-          });
-
-          if (!deleteResponse.ok) {
-            throw new CloudflareApiError(
-              `Failed to delete objects: ${deleteResponse.statusText}`,
-              deleteResponse,
-            );
-          }
-
-          totalDeleted += batch.length;
-        }
-      }
-    } while (continuationToken);
-
-    logger.log(
-      `Successfully emptied bucket ${bucketName}, deleted ${totalDeleted} objects total`,
+    await extractCloudflareResult(
+      `delete R2 bucket "${bucketName}"`,
+      api.delete(`/accounts/${api.accountId}/r2/buckets/${bucketName}`, {
+        headers: withJurisdiction(props),
+      }),
     );
   } catch (error) {
     if (error instanceof CloudflareApiError && error.status === 404) {
-      // the bucket was not found
       return;
     }
-    logger.error(`Failed to empty bucket ${bucketName}:`, error);
     throw error;
   }
 }
 
 /**
- * Update public access setting for a bucket
- *
- * This operation is not available through the S3 API for R2,
- * so we still use the Cloudflare API directly.
+ * Update the public access setting for a bucket
  */
 export async function updatePublicAccess(
   api: CloudflareApi,
@@ -599,8 +353,6 @@ export async function updatePublicAccess(
   allowPublicAccess: boolean,
   jurisdiction?: string,
 ): Promise<void> {
-  const headers = withJurisdiction({}, jurisdiction);
-
   await withExponentialBackoff(
     async () => {
       const response = await api.put(
@@ -608,7 +360,7 @@ export async function updatePublicAccess(
         {
           enabled: allowPublicAccess,
         },
-        { headers },
+        { headers: withJurisdiction({ jurisdiction }) },
       );
 
       if (!response.ok) {
@@ -627,76 +379,72 @@ export async function updatePublicAccess(
 }
 
 /**
- * Set CORS configuration for a bucket using aws4fetch
+ * Delete all objects in a bucket
  */
-export async function setCorsConfiguration(
-  r2: R2Client,
+async function emptyBucket(
+  api: CloudflareApi,
   bucketName: string,
-  allowedOrigins: string[] = ["*"],
-  allowedMethods: string[] = ["GET", "HEAD", "PUT", "POST", "DELETE"],
-  allowedHeaders: string[] = ["*"],
-  maxAgeSeconds = 3600,
-  jurisdiction?: string,
-): Promise<void> {
-  try {
-    // Construct CORS XML configuration
-    const corsXml = `
-      <CORSConfiguration>
-        <CORSRule>
-          ${allowedOrigins.map((origin) => `<AllowedOrigin>${origin}</AllowedOrigin>`).join("")}
-          ${allowedMethods.map((method) => `<AllowedMethod>${method}</AllowedMethod>`).join("")}
-          ${allowedHeaders.map((header) => `<AllowedHeader>${header}</AllowedHeader>`).join("")}
-          <ExposeHeader>ETag</ExposeHeader>
-          <MaxAgeSeconds>${maxAgeSeconds}</MaxAgeSeconds>
-        </CORSRule>
-      </CORSConfiguration>
-    `;
-
-    const url = new URL(
-      `https://${r2.accountId}.r2.cloudflarestorage.com/${bucketName}?cors`,
+  props: BucketProps,
+) {
+  let batch: Promise<unknown>[] = [];
+  for await (const key of listObjects(api, bucketName, props)) {
+    batch.push(
+      extractCloudflareResult(
+        `delete R2 object "${key}"`,
+        api.delete(
+          `/accounts/${api.accountId}/r2/buckets/${bucketName}/objects/${key}`,
+          { headers: withJurisdiction(props) },
+        ),
+      ),
     );
-
-    const headers = withJurisdiction(
-      { "Content-Type": "application/xml" },
-      jurisdiction,
-    );
-
-    const response = await r2.fetch(url.toString(), {
-      method: "PUT",
-      body: corsXml,
-      headers,
-    });
-
-    if (!response.ok) {
-      throw new CloudflareApiError(
-        `Failed to set CORS configuration: ${response.statusText}`,
-        response,
-      );
+    if (batch.length >= 10) {
+      // this is an arbitary batch size, open to feedback
+      await Promise.all(batch);
+      batch = [];
     }
-
-    logger.log(`Successfully set CORS configuration for bucket ${bucketName}`);
-  } catch (error) {
-    logger.error(
-      `Failed to set CORS configuration for bucket ${bucketName}:`,
-      error,
-    );
-    throw error;
   }
+  await Promise.all(batch);
 }
 
 /**
- * Information about an R2 bucket returned by list operations
+ * Returns an async iterable of all object keys in a bucket,
+ * handling pagination automatically.
  */
-export interface R2BucketInfo {
-  /**
-   * Name of the bucket
-   */
-  Name: string;
-
-  /**
-   * Creation date of the bucket
-   */
-  CreationDate: Date;
+export async function* listObjects(
+  api: CloudflareApi,
+  bucketName: string,
+  props: { jurisdiction?: string },
+  cursor?: string,
+): AsyncGenerator<string> {
+  const params = new URLSearchParams({
+    per_page: "1000",
+  });
+  if (cursor) {
+    params.set("cursor", cursor);
+  }
+  const response = await api.get(
+    `/accounts/${api.accountId}/r2/buckets/${bucketName}/objects?${params.toString()}`,
+    { headers: withJurisdiction(props) },
+  );
+  if (!response.ok) {
+    throw new Error(
+      `Failed to list objects in bucket "${bucketName}": ${await extractCloudflareError(response)}`,
+    );
+  }
+  const json: {
+    result: { key: string }[];
+    result_info?: {
+      cursor: string;
+      is_truncated: boolean;
+      per_page: number;
+    };
+  } = await response.json();
+  for (const object of json.result) {
+    yield object.key;
+  }
+  if (json.result_info?.is_truncated && json.result_info.cursor) {
+    yield* listObjects(api, bucketName, props, json.result_info.cursor);
+  }
 }
 
 /**
@@ -715,7 +463,7 @@ export async function listBuckets(
     direction?: "asc" | "desc";
     jurisdiction?: string;
   } = {},
-): Promise<R2BucketInfo[]> {
+) {
   // Build query parameters
   const params = new URLSearchParams();
 
@@ -738,39 +486,14 @@ export async function listBuckets(
   // Build URL with query parameters
   const path = `/accounts/${api.accountId}/r2/buckets${params.toString() ? `?${params.toString()}` : ""}`;
 
-  // Set jurisdiction header if provided
-  const headers = withJurisdiction({}, options.jurisdiction);
-
   // Make the API request
-  const response = await api.get(path, { headers });
-
-  if (!response.ok) {
-    throw new CloudflareApiError(
-      `Failed to list buckets: ${response.statusText}`,
-      response,
-    );
-  }
-
-  const data = (await response.json()) as {
-    success: boolean;
-    errors?: Array<{ code: number; message: string }>;
-    result?: {
-      buckets: Array<{
-        name: string;
-        creation_date: string;
-        location?: string;
-      }>;
-    };
-  };
-
-  if (!data.success) {
-    const errorMessage = data.errors?.[0]?.message || "Unknown error";
-    throw new Error(`Failed to list buckets: ${errorMessage}`);
-  }
-
-  // Transform API response to R2BucketInfo objects
-  return (data.result?.buckets || []).map((bucket) => ({
-    Name: bucket.name,
-    CreationDate: new Date(bucket.creation_date),
-  }));
+  const result = await extractCloudflareResult<{
+    buckets: { name: string; creation_date: string }[];
+  }>(
+    "list R2 buckets",
+    api.get(path, {
+      headers: withJurisdiction(options),
+    }),
+  );
+  return result.buckets;
 }

--- a/alchemy/test/cloudflare/bucket.test.ts
+++ b/alchemy/test/cloudflare/bucket.test.ts
@@ -19,6 +19,7 @@ import "../../src/test/vitest.ts";
 const test = alchemy.test(import.meta, {
   prefix: BRANCH_PREFIX,
 });
+const r2Client = createR2Client();
 
 describe("R2 Bucket Resource", async () => {
   // Use BRANCH_PREFIX for deterministic, non-colliding resource names
@@ -40,6 +41,7 @@ describe("R2 Bucket Resource", async () => {
         adopt: true,
       });
       expect(bucket.name).toEqual(testId);
+      expect(bucket.domain).toBeUndefined();
 
       // Check if bucket exists by getting it explicitly
       const gotBucket = await getBucket(api, testId);
@@ -50,6 +52,7 @@ describe("R2 Bucket Resource", async () => {
         name: testId,
         allowPublicAccess: true,
       });
+      expect(bucket.domain).toBeDefined();
 
       const publicAccessResponse = await api.get(
         `/accounts/${api.accountId}/r2/buckets/${testId}/domains/managed`,
@@ -108,24 +111,14 @@ describe("R2 Bucket Resource", async () => {
       });
       expect(bucket.name).toEqual(bucketName);
 
-      // Get R2 client
-      const r2Client = createR2Client();
-
-      // Upload a test file to the bucket
-      const testContent = "This is test file content";
       const testKey = "test-file.txt";
-
-      // Put object with jurisdiction header
-      const putUrl = new URL(
-        `https://${r2Client.accountId}.r2.cloudflarestorage.com/${bucketName}/${testKey}`,
-      );
-      const putHeaders = withJurisdiction(bucket, {
-        "Content-Type": "text/plain",
-      });
-      const putResponse = await r2Client.fetch(putUrl.toString(), {
-        method: "PUT",
-        body: testContent,
-        headers: putHeaders,
+      const testContent = "This is test file content";
+      const putResponse = await putObject(bucket, {
+        headers: {
+          "Content-Type": "text/plain",
+        },
+        key: testKey,
+        value: testContent,
       });
       expect(putResponse.status).toEqual(200);
 
@@ -134,17 +127,10 @@ describe("R2 Bucket Resource", async () => {
       expect(keys.length).toBeGreaterThan(0);
       expect(keys).toContain(testKey);
 
-      // For extra verification, directly fetch the file content
-      const getUrl = new URL(
-        `https://${r2Client.accountId}.r2.cloudflarestorage.com/${bucketName}/${testKey}`,
-      );
-      const getHeaders = withJurisdiction(bucket, {});
-      const getResponse = await r2Client.fetch(getUrl.toString(), {
-        headers: getHeaders,
+      const getResponse = await getObject(bucket, {
+        key: testKey,
       });
       expect(getResponse.status).toEqual(200);
-
-      // Get content
       const content = await getResponse.text();
       expect(content).toEqual(testContent);
 
@@ -241,6 +227,63 @@ describe("R2 Bucket Resource", async () => {
       await destroy(scope);
     }
   });
+
+  test("bucket with CORS rules", async (scope) => {
+    const bucketName = `${BRANCH_PREFIX.toLowerCase()}-test-bucket-with-cors`;
+
+    try {
+      const bucket = await R2Bucket(bucketName, {
+        name: bucketName,
+        adopt: true,
+        allowPublicAccess: true,
+        empty: true,
+        cors: [
+          {
+            allowed: {
+              methods: ["GET"],
+              origins: ["*"],
+            },
+          },
+        ],
+      });
+      expect(bucket.allowPublicAccess).toEqual(true);
+      expect(bucket.domain).toBeDefined();
+      expect(bucket.cors).toEqual([
+        {
+          allowed: {
+            methods: ["GET"],
+            origins: ["*"],
+          },
+        },
+      ]);
+
+      const putResponse = await putObject(bucket, {
+        key: "test-file.txt",
+        value: "This is test file content",
+      });
+      expect(putResponse.status).toEqual(200);
+
+      await new Promise((resolve) => setTimeout(resolve, 1000)); // wait for CORS to propagate
+
+      const getResponse = await fetch(
+        `https://${bucket.domain}/test-file.txt`,
+        {
+          method: "OPTIONS",
+          headers: {
+            Origin: "https://example.com",
+          },
+        },
+      );
+      expect(getResponse.headers.get("Access-Control-Allow-Origin")).toEqual(
+        "*",
+      );
+      expect(getResponse.headers.get("Access-Control-Allow-Methods")).toEqual(
+        "GET",
+      );
+    } finally {
+      await destroy(scope);
+    }
+  });
 });
 
 /**
@@ -274,6 +317,38 @@ function createR2Client() {
   });
   Object.assign(client, { accountId });
   return client as typeof client & { accountId: string };
+}
+
+async function putObject(
+  bucket: R2Bucket,
+  props: {
+    key: string;
+    value: BodyInit;
+    headers?: Record<string, string>;
+  },
+) {
+  const url = new URL(
+    `https://${r2Client.accountId}.r2.cloudflarestorage.com/${bucket.name}/${props.key}`,
+  );
+  return await r2Client.fetch(url, {
+    method: "PUT",
+    headers: withJurisdiction(bucket, props.headers),
+    body: props.value,
+  });
+}
+
+async function getObject(
+  bucket: R2Bucket,
+  props: {
+    key: string;
+  },
+) {
+  const url = new URL(
+    `https://${r2Client.accountId}.r2.cloudflarestorage.com/${bucket.name}/${props.key}`,
+  );
+  return await r2Client.fetch(url, {
+    headers: withJurisdiction(bucket),
+  });
 }
 
 async function assertBucketDeleted(bucket: R2Bucket, attempt = 0) {

--- a/alchemy/test/cloudflare/pipeline.test.ts
+++ b/alchemy/test/cloudflare/pipeline.test.ts
@@ -344,8 +344,6 @@ describe("Pipeline Resource", () => {
       // Create an R2 bucket
       bucket = await R2Bucket("worker-bucket", {
         name: bucketName,
-        accessKey: accessKeyId,
-        secretAccessKey: secretAccessKey,
         adopt: true,
         delete: true,
         empty: true,

--- a/alchemy/test/runtime/app.ts
+++ b/alchemy/test/runtime/app.ts
@@ -11,8 +11,6 @@ const app = await alchemy("my-bootstrap-ap", {
 });
 
 const bucket = await R2Bucket("my-bootstrap-bucket", {
-  accessKey: await alchemy.secret.env.R2_ACCESS_KEY_ID,
-  secretAccessKey: await alchemy.secret.env.R2_SECRET_ACCESS_KEY,
   empty: true,
 });
 

--- a/alchemy/test/state/r2-rest-state-store.test.ts
+++ b/alchemy/test/state/r2-rest-state-store.test.ts
@@ -24,7 +24,7 @@ describe("R2RestStateStore", async () => {
       const defaultBucketName = "alchemy-state";
       const bucket = await getBucket(api, defaultBucketName);
 
-      expect(bucket.result.name).toEqual(defaultBucketName);
+      expect(bucket.name).toEqual(defaultBucketName);
     } finally {
       await destroy(scope);
     }

--- a/bun.lock
+++ b/bun.lock
@@ -1503,7 +1503,7 @@
 
     "@sindresorhus/is": ["@sindresorhus/is@7.0.2", "", {}, "sha512-d9xRovfKNz1SKieM0qJdO+PQonjnnIfSNWfHYnBSJ9hkjm0ZPw6HlxscDXYstp3z+7V2GOFHc+J0CYrYTjqCJw=="],
 
-    "@sindresorhus/merge-streams": ["@sindresorhus/merge-streams@4.0.0", "", {}, "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ=="],
+    "@sindresorhus/merge-streams": ["@sindresorhus/merge-streams@2.3.0", "", {}, "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg=="],
 
     "@smithy/abort-controller": ["@smithy/abort-controller@4.0.4", "", { "dependencies": { "@smithy/types": "^4.3.1", "tslib": "^2.6.2" } }, "sha512-gJnEjZMvigPDQWHrW3oPrFhQtkrgqBkyjj3pCIdF3A5M6vsZODG93KNlfJprv6bp4245bdT32fsHK4kkH3KYDA=="],
 
@@ -5145,6 +5145,8 @@
 
     "espree/acorn": ["acorn@8.15.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
 
+    "execa/@sindresorhus/merge-streams": ["@sindresorhus/merge-streams@4.0.0", "", {}, "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ=="],
+
     "expand-range/fill-range": ["fill-range@2.2.4", "", { "dependencies": { "is-number": "^2.1.0", "isobject": "^2.0.0", "randomatic": "^3.0.0", "repeat-element": "^1.1.2", "repeat-string": "^1.5.2" } }, "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q=="],
 
     "express/cookie": ["cookie@0.7.1", "", {}, "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w=="],
@@ -5182,8 +5184,6 @@
     "glob-base/is-glob": ["is-glob@2.0.1", "", { "dependencies": { "is-extglob": "^1.0.0" } }, "sha512-a1dBeB19NXsf/E0+FHqkagizel/LQw2DjSQpvQrj3zT+jYPpaUCryPnrQajXKFLCMuf4I6FhRpaGtw4lPrG6Eg=="],
 
     "global-directory/ini": ["ini@4.1.1", "", {}, "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g=="],
-
-    "globby/@sindresorhus/merge-streams": ["@sindresorhus/merge-streams@2.3.0", "", {}, "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg=="],
 
     "gray-matter/js-yaml": ["js-yaml@3.14.1", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g=="],
 

--- a/examples/cloudflare-worker-bootstrap/index.ts
+++ b/examples/cloudflare-worker-bootstrap/index.ts
@@ -16,8 +16,6 @@ const ReceiveRequest = type({
 
 const bucket = await R2Bucket("bucket", {
   name: `${app.name}-${app.stage}-bucket`,
-  accessKey: await alchemy.secret.env.R2_ACCESS_KEY_ID,
-  secretAccessKey: await alchemy.secret.env.R2_SECRET_ACCESS_KEY,
   adopt: true,
   empty: true,
 });


### PR DESCRIPTION
We currently use the S3-compatible API to empty an R2 bucket before deleting it. This PR switches to the REST API so you don't need to provide specialized credentials. Closes #723.

Also:
- Cleaned up some dead code
- We weren't returning the R2.dev subdomain if enabled, so I added that
- We had a function to set CORS rules but it wasn't being called anywhere - fixed that