### PR TITLE
fix(cloudflare): use queue name instead of queue id for queue consumers

### DIFF
--- a/alchemy/src/cloudflare/wrangler.json.ts
+++ b/alchemy/src/cloudflare/wrangler.json.ts
@@ -557,7 +557,7 @@ function processBindings(
   for (const eventSource of eventSources ?? []) {
     if (isQueueEventSource(eventSource)) {
       queues.consumers.push({
-        queue: eventSource.queue.id,
+        queue: eventSource.queue.name,
         max_batch_size: eventSource.settings?.batchSize,
         max_concurrency: eventSource.settings?.maxConcurrency,
         max_retries: eventSource.settings?.maxRetries,
@@ -566,7 +566,7 @@ function processBindings(
       });
     } else if (isQueue(eventSource)) {
       queues.consumers.push({
-        queue: eventSource.id,
+        queue: eventSource.name,
       });
     }
   }

--- a/alchemy/src/cloudflare/wrangler.json.ts
+++ b/alchemy/src/cloudflare/wrangler.json.ts
@@ -645,7 +645,6 @@ function processBindings(
         script_name: binding.scriptName,
       });
     } else if (binding.type === "d1") {
-      console.log("binding.dev", binding.dev);
       d1Databases.push({
         binding: bindingName,
         database_id: binding.id,


### PR DESCRIPTION
Fixes #739

Updated WranglerJson resource to use queue names instead of queue IDs for queue consumers in generated wrangler.json files.

## Changes
- Updated queue consumers to use `queue.name` instead of `queue.id`
- This ensures wrangler.json uses human-readable queue names
- Affects both QueueEventSource and direct Queue event sources

Generated with [Claude Code](https://claude.ai/code)