### PR TITLE
feat(cloudflare): add nodejs_compat_populate_process_env to node preset

### DIFF
--- a/alchemy/src/cloudflare/compatibility-presets.ts
+++ b/alchemy/src/cloudflare/compatibility-presets.ts
@@ -13,7 +13,7 @@ export const COMPATIBILITY_PRESETS = {
    * Node.js compatibility preset
    * Enables Node.js APIs and runtime compatibility
    */
-  node: ["nodejs_compat"],
+  node: ["nodejs_compat", "nodejs_compat_populate_process_env"],
 } as const;
 
 export type CompatibilityPreset = keyof typeof COMPATIBILITY_PRESETS;


### PR DESCRIPTION
Include nodejs_compat_populate_process_env in the Cloudflare Worker "node" compatibility preset to enable process.env population in Node.js mode.

Fixes #761

Generated with [Claude Code](https://claude.ai/code)