### PR TITLE
feat(random): add RandomString resource and alchemy/random export

### DIFF
--- a/alchemy-web/src/content/docs/providers/random/random-string.md
+++ b/alchemy-web/src/content/docs/providers/random/random-string.md
@@ -1,0 +1,153 @@
+---
+title: RandomString
+description: Learn how to generate cryptographically secure random strings for API keys, tokens, and passwords using Alchemy.
+---
+
+The RandomString resource generates cryptographically secure random strings that can be used for API keys, tokens, passwords, or other security-sensitive values. The generated values are automatically wrapped as secrets to prevent accidental exposure in logs or console output.
+
+## Minimal Example
+
+Generate a default random string (32 bytes, hex encoded):
+
+```ts
+import { RandomString } from "alchemy/random";
+
+const apiKey = await RandomString("api-key");
+// Result: 64 character hex string (e.g., "a1b2c3d4...")
+```
+
+## Verification Codes
+
+Generate shorter random strings for verification codes:
+
+```ts
+import { RandomString } from "alchemy/random";
+
+const verificationCode = await RandomString("email-verification", {
+  length: 8,
+  encoding: "hex"
+});
+// Result: 16 character hex string
+```
+
+## Session Tokens
+
+Create base64-encoded random strings for session tokens:
+
+```ts
+import { RandomString } from "alchemy/random";
+
+const sessionToken = await RandomString("session-token", {
+  length: 48,
+  encoding: "base64"
+});
+// Result: ~64 character base64 string
+```
+
+## Integration with Other Resources
+
+Use RandomString to generate secure passwords for databases and other resources:
+
+```ts
+import { RandomString } from "alchemy/random";
+import { PostgresDatabase } from "alchemy/neon";
+
+const dbPassword = await RandomString("db-password", { 
+  length: 32 
+});
+
+const database = await PostgresDatabase("mydb", {
+  name: "production",
+  password: dbPassword.value
+});
+```
+
+## Multiple Secrets
+
+Generate multiple unique secrets for different purposes:
+
+```ts
+import { RandomString } from "alchemy/random";
+
+// JWT signing secret
+const jwtSecret = await RandomString("jwt-secret", { 
+  length: 64 
+});
+
+// Encryption key
+const encryptionKey = await RandomString("encryption-key", {
+  length: 32,
+  encoding: "base64"
+});
+
+// API key
+const apiKey = await RandomString("api-key", {
+  length: 32,
+  encoding: "hex"
+});
+```
+
+## Understanding Length and Encoding
+
+The `length` parameter specifies the number of random **bytes** to generate, not the final string length:
+
+- **Hex encoding**: Produces 2 characters per byte
+  - 32 bytes → 64 character string
+  - 16 bytes → 32 character string
+  
+- **Base64 encoding**: Produces approximately 1.33 characters per byte
+  - 32 bytes → ~43 character string
+  - 48 bytes → ~64 character string
+
+Choose your encoding based on your use case:
+- **Hex**: Use for API keys, tokens, and when you need URL-safe strings
+- **Base64**: Use when you need more entropy in fewer characters
+
+## State Management
+
+RandomString resources maintain their state between deployments. If you update a RandomString with the same `length` and `encoding`, it will return the existing value rather than generating a new one. This ensures:
+
+- API keys remain stable across deployments
+- Database passwords don't change unexpectedly
+- Session secrets maintain continuity
+
+To force regeneration of a secret, either:
+1. Change the resource ID
+2. Delete and recreate the resource
+3. Change the `length` or `encoding` parameters
+
+## Security Considerations
+
+- Values are generated using Node.js `crypto.randomBytes()` which provides cryptographically strong pseudo-random data
+- All generated values are automatically wrapped with `alchemy.secret()` to prevent accidental exposure
+- Values are encrypted at rest in the Alchemy state store
+- Never log or print the `.value` property directly - use Alchemy's secret handling mechanisms
+
+## Example: Complete Authentication Setup
+
+```ts
+import { RandomString } from "alchemy/random";
+import { Worker } from "alchemy/cloudflare";
+import { PostgresDatabase } from "alchemy/neon";
+
+// Generate all required secrets
+const jwtSecret = await RandomString("jwt-secret", { length: 64 });
+const sessionSecret = await RandomString("session-secret", { length: 32 });
+const dbPassword = await RandomString("db-password");
+
+// Create database with secure password
+const database = await PostgresDatabase("auth-db", {
+  name: "authentication",
+  password: dbPassword.value
+});
+
+// Create worker with secrets as environment variables
+const authWorker = await Worker("auth-api", {
+  entrypoint: "./src/auth.ts",
+  bindings: {
+    JWT_SECRET: jwtSecret.value,
+    SESSION_SECRET: sessionSecret.value,
+    DATABASE_URL: database.connectionUrl
+  }
+});
+```

--- a/alchemy-web/src/content/docs/providers/random/random-string.md
+++ b/alchemy-web/src/content/docs/providers/random/random-string.md
@@ -3,7 +3,7 @@ title: RandomString
 description: Learn how to generate cryptographically secure random strings for API keys, tokens, and passwords using Alchemy.
 ---
 
-The RandomString resource generates cryptographically secure random strings that can be used for API keys, tokens, passwords, or other security-sensitive values. The generated values are automatically wrapped as secrets to prevent accidental exposure in logs or console output.
+The RandomString resource generates cryptographically secure random strings that can be used for API keys, tokens, passwords, or other security-sensitive values. 
 
 ## Minimal Example
 

--- a/alchemy/package.json
+++ b/alchemy/package.json
@@ -93,6 +93,10 @@
       "bun": "./src/planetscale/index.ts",
       "import": "./lib/planetscale/index.js"
     },
+    "./random": {
+      "bun": "./src/random/index.ts",
+      "import": "./lib/random/index.js"
+    },
     "./sentry": {
       "bun": "./src/sentry/index.ts",
       "import": "./lib/sentry/index.js"

--- a/alchemy/src/random/index.ts
+++ b/alchemy/src/random/index.ts
@@ -1,0 +1,1 @@
+export * from "./random-string.ts";

--- a/alchemy/src/random/random-string.ts
+++ b/alchemy/src/random/random-string.ts
@@ -1,0 +1,126 @@
+import { alchemy } from "../alchemy.ts";
+import { Resource } from "../resource.ts";
+import type { Secret } from "../secret.ts";
+
+/**
+ * Properties for configuring a random string generation
+ */
+export interface RandomStringProps {
+  /**
+   * The number of random bytes to generate.
+   * The actual string length will depend on the encoding:
+   * - hex: length * 2 characters
+   * - base64: approximately length * 1.33 characters
+   * @default 32
+   */
+  length?: number;
+
+  /**
+   * The encoding format for the random string.
+   * - "hex": Hexadecimal encoding (0-9, a-f)
+   * - "base64": Base64 encoding (A-Z, a-z, 0-9, +, /)
+   * @default "hex"
+   */
+  encoding?: "hex" | "base64";
+}
+
+/**
+ * A cryptographically secure random string resource
+ */
+export interface RandomString extends Resource<"random::String"> {
+  /**
+   * The generated random string value, stored as a secret
+   */
+  value: Secret;
+
+  /**
+   * The length of the random string
+   */
+  length: number;
+
+  /**
+   * The encoding format of the random string
+   */
+  encoding: "hex" | "base64";
+}
+
+/**
+ * Generates a cryptographically secure random string that can be used
+ * for API keys, tokens, passwords, or other security-sensitive values.
+ * The generated value is automatically wrapped as a secret to prevent
+ * accidental exposure in logs or console output.
+ *
+ * @example
+ * // Generate a default random string (32 bytes, hex encoded)
+ * const apiKey = await RandomString("api-key");
+ * // Result: 64 character hex string (e.g., "a1b2c3d4...")
+ *
+ * @example
+ * // Generate a shorter random string for a verification code
+ * const verificationCode = await RandomString("email-verification", {
+ *   length: 8,
+ *   encoding: "hex"
+ * });
+ * // Result: 16 character hex string
+ *
+ * @example
+ * // Generate a base64-encoded random string for a session token
+ * const sessionToken = await RandomString("session-token", {
+ *   length: 48,
+ *   encoding: "base64"
+ * });
+ * // Result: ~64 character base64 string
+ *
+ * @example
+ * // Use with other resources that require secrets
+ * const database = await PostgresDatabase("mydb", {
+ *   name: "production",
+ *   password: (await RandomString("db-password")).value
+ * });
+ *
+ * @example
+ * // Generate multiple unique secrets
+ * const jwtSecret = await RandomString("jwt-secret", { length: 64 });
+ * const encryptionKey = await RandomString("encryption-key", {
+ *   length: 32,
+ *   encoding: "base64"
+ * });
+ *
+ * @param id - Unique identifier for this random string resource
+ * @param props - Configuration options for the random string generation
+ * @returns A RandomString resource containing the generated secret value
+ */
+export const RandomString = Resource(
+  "random::String",
+  async function (
+    _id: string,
+    props: RandomStringProps = {},
+  ): Promise<RandomString> {
+    if (this.phase === "delete") {
+      return this.destroy();
+    }
+    const length = props.length ?? 32;
+    const encoding = props.encoding ?? "hex";
+
+    if (
+      this.phase === "update" &&
+      this.props.length === length &&
+      this.props.encoding === encoding
+    ) {
+      // this is an update (input props changed)
+      // but the length and encoding did not change
+      // so, we can just return the existing output (no-op)
+      return this(this.output);
+    }
+    const crypto = await import("node:crypto");
+    return this({
+      length,
+      encoding,
+      value: alchemy.secret(
+        crypto
+          .randomBytes(props.length ?? 32)
+          .toString(props.encoding ?? "hex"),
+      ),
+    });
+  },
+);

--- a/alchemy/test/random/random-string.test.ts
+++ b/alchemy/test/random/random-string.test.ts
@@ -1,0 +1,256 @@
+import { describe, expect } from "vitest";
+import { alchemy } from "../../src/alchemy";
+import { destroy } from "../../src/destroy";
+import { RandomString } from "../../src/random/random-string";
+import { BRANCH_PREFIX } from "../util";
+// must import this or else alchemy.test won't exist
+import "../../src/test/vitest";
+
+const test = alchemy.test(import.meta, {
+  prefix: BRANCH_PREFIX,
+});
+
+describe("RandomString Resource", () => {
+  // Use BRANCH_PREFIX for deterministic, non-colliding resource names
+  const testRandomStringId = `${BRANCH_PREFIX}-random-string`;
+
+  test("create random string with default settings", async (scope) => {
+    let randomString: RandomString;
+    try {
+      // Create a test random string with defaults
+      randomString = await RandomString(testRandomStringId);
+
+      // Verify resource was created with defaults
+      expect(randomString).toBeDefined();
+      expect(randomString.value).toBeDefined();
+      expect(randomString.length).toBe(32); // default length
+      expect(randomString.encoding).toBe("hex"); // default encoding
+
+      // Verify the value is a secret (has unencrypted property)
+      expect(randomString.value.unencrypted).toBeDefined();
+
+      // Verify the actual string length (32 bytes * 2 for hex = 64 chars)
+      const stringValue = randomString.value.unencrypted;
+      expect(stringValue.length).toBe(64);
+      expect(stringValue).toMatch(/^[0-9a-f]+$/); // hex characters only
+    } catch (err) {
+      // log the error or else it's silently swallowed by destroy errors
+      console.log(err);
+      throw err;
+    } finally {
+      // Always clean up
+      await destroy(scope);
+    }
+  });
+
+  test("create random string with custom length", async (scope) => {
+    let randomString: RandomString;
+    try {
+      // Create a test random string with custom length
+      randomString = await RandomString(`${testRandomStringId}-custom-length`, {
+        length: 16,
+        encoding: "hex",
+      });
+
+      // Verify resource was created with custom settings
+      expect(randomString).toBeDefined();
+      expect(randomString.length).toBe(16);
+      expect(randomString.encoding).toBe("hex");
+
+      // Verify the actual string length (16 bytes * 2 for hex = 32 chars)
+      const stringValue = randomString.value.unencrypted;
+      expect(stringValue.length).toBe(32);
+      expect(stringValue).toMatch(/^[0-9a-f]+$/);
+    } catch (err) {
+      console.log(err);
+      throw err;
+    } finally {
+      await destroy(scope);
+    }
+  });
+
+  test("create random string with base64 encoding", async (scope) => {
+    let randomString: RandomString;
+    try {
+      // Create a test random string with base64 encoding
+      randomString = await RandomString(`${testRandomStringId}-base64`, {
+        length: 24,
+        encoding: "base64",
+      });
+
+      // Verify resource was created with base64 encoding
+      expect(randomString).toBeDefined();
+      expect(randomString.length).toBe(24);
+      expect(randomString.encoding).toBe("base64");
+
+      // Verify the value format (base64 characters)
+      const stringValue = randomString.value.unencrypted;
+      expect(stringValue).toMatch(/^[A-Za-z0-9+/]+=*$/); // base64 characters with optional padding
+
+      // Base64 encoding of 24 bytes should be 32 characters (24 * 4/3)
+      expect(stringValue.length).toBe(32);
+    } catch (err) {
+      console.log(err);
+      throw err;
+    } finally {
+      await destroy(scope);
+    }
+  });
+
+  test("update with same props (no-op)", async (scope) => {
+    let randomString1: RandomString;
+    let randomString2: RandomString;
+    try {
+      // Create initial random string
+      randomString1 = await RandomString(`${testRandomStringId}-noop`, {
+        length: 16,
+        encoding: "hex",
+      });
+
+      const originalValue = randomString1.value.unencrypted;
+      expect(originalValue).toBeDefined();
+      expect(originalValue.length).toBe(32); // 16 bytes * 2
+
+      // Update with same props - should be a no-op
+      randomString2 = await RandomString(`${testRandomStringId}-noop`, {
+        length: 16,
+        encoding: "hex",
+      });
+
+      const updatedValue = randomString2.value.unencrypted;
+
+      // Values should be identical (no-op update)
+      expect(updatedValue).toBe(originalValue);
+      expect(randomString2.length).toBe(16);
+      expect(randomString2.encoding).toBe("hex");
+    } catch (err) {
+      console.log(err);
+      throw err;
+    } finally {
+      await destroy(scope);
+    }
+  });
+
+  test("update with different length regenerates value", async (scope) => {
+    let randomString1: RandomString;
+    let randomString2: RandomString;
+    try {
+      // Create initial random string
+      randomString1 = await RandomString(`${testRandomStringId}-regen-length`, {
+        length: 16,
+        encoding: "hex",
+      });
+
+      const originalValue = randomString1.value.unencrypted;
+      expect(originalValue.length).toBe(32); // 16 bytes * 2
+
+      // Update with different length - should regenerate
+      randomString2 = await RandomString(`${testRandomStringId}-regen-length`, {
+        length: 32, // changed
+        encoding: "hex",
+      });
+
+      const updatedValue = randomString2.value.unencrypted;
+
+      // Values should be different (regenerated)
+      expect(updatedValue).not.toBe(originalValue);
+      expect(updatedValue.length).toBe(64); // 32 bytes * 2
+      expect(randomString2.length).toBe(32);
+    } catch (err) {
+      console.log(err);
+      throw err;
+    } finally {
+      await destroy(scope);
+    }
+  });
+
+  test("update with different encoding regenerates value", async (scope) => {
+    let randomString1: RandomString;
+    let randomString2: RandomString;
+    try {
+      // Create initial random string
+      randomString1 = await RandomString(
+        `${testRandomStringId}-regen-encoding`,
+        {
+          length: 24,
+          encoding: "hex",
+        },
+      );
+
+      const originalValue = randomString1.value.unencrypted;
+      expect(originalValue).toMatch(/^[0-9a-f]+$/);
+
+      // Update with different encoding - should regenerate
+      randomString2 = await RandomString(
+        `${testRandomStringId}-regen-encoding`,
+        {
+          length: 24,
+          encoding: "base64", // changed
+        },
+      );
+
+      const updatedValue = randomString2.value.unencrypted;
+
+      // Values should be different (regenerated) and in different format
+      expect(updatedValue).not.toBe(originalValue);
+      expect(updatedValue).toMatch(/^[A-Za-z0-9+/]+=*$/); // base64 format
+      expect(randomString2.encoding).toBe("base64");
+    } catch (err) {
+      console.log(err);
+      throw err;
+    } finally {
+      await destroy(scope);
+    }
+  });
+
+  test("multiple random strings have different values", async (scope) => {
+    let randomString1: RandomString;
+    let randomString2: RandomString;
+    try {
+      // Create two random strings with same settings but different IDs
+      randomString1 = await RandomString(`${testRandomStringId}-unique-1`, {
+        length: 16,
+        encoding: "hex",
+      });
+
+      randomString2 = await RandomString(`${testRandomStringId}-unique-2`, {
+        length: 16,
+        encoding: "hex",
+      });
+
+      const value1 = randomString1.value.unencrypted;
+      const value2 = randomString2.value.unencrypted;
+
+      // Values should be different (cryptographically random)
+      expect(value1).not.toBe(value2);
+      expect(value1.length).toBe(32);
+      expect(value2.length).toBe(32);
+    } catch (err) {
+      console.log(err);
+      throw err;
+    } finally {
+      await destroy(scope);
+    }
+  });
+
+  test("values are consistent across reads", async (scope) => {
+    let randomString: RandomString;
+    try {
+      // Create a random string
+      randomString = await RandomString(`${testRandomStringId}-consistent`);
+
+      const value1 = randomString.value.unencrypted;
+      const value2 = randomString.value.unencrypted;
+      const value3 = randomString.value.unencrypted;
+
+      // Multiple reads should return the same value
+      expect(value1).toBe(value2);
+      expect(value2).toBe(value3);
+    } catch (err) {
+      console.log(err);
+      throw err;
+    } finally {
+      await destroy(scope);
+    }
+  });
+});

--- a/alchemy/test/random/random-string.test.ts
+++ b/alchemy/test/random/random-string.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect } from "vitest";
-import { alchemy } from "../../src/alchemy";
-import { destroy } from "../../src/destroy";
-import { RandomString } from "../../src/random/random-string";
-import { BRANCH_PREFIX } from "../util";
+import { alchemy } from "../../src/alchemy.ts";
+import { destroy } from "../../src/destroy.ts";
+import { RandomString } from "../../src/random/random-string.ts";
+import { BRANCH_PREFIX } from "../util.ts";
 // must import this or else alchemy.test won't exist
-import "../../src/test/vitest";
+import "../../src/test/vitest.ts";
 
 const test = alchemy.test(import.meta, {
   prefix: BRANCH_PREFIX,


### PR DESCRIPTION
Generate a default random string (32 bytes, hex encoded):

```ts
import { RandomString } from "alchemy/random";

const apiKey = await RandomString("api-key");
// Result: 64 character hex string (e.g., "a1b2c3d4...")
```

## Verification Codes

Generate shorter random strings for verification codes:

```ts
import { RandomString } from "alchemy/random";

const verificationCode = await RandomString("email-verification", {
  length: 8,
  encoding: "hex"
});
// Result: 16 character hex string
```