### PR TITLE
fix(cloudflare): handle symlink directories in Worker Assets

### DIFF
--- a/alchemy/src/cloudflare/assets.ts
+++ b/alchemy/src/cloudflare/assets.ts
@@ -172,8 +172,7 @@ async function getFilesRecursively(
       }
       if (
         file.isDirectory() ||
-        (file.isSymbolicLink() &&
-          (await fs.stat(filePath).then((stats) => stats.isDirectory())))
+        (file.isSymbolicLink() && (await fs.stat(filePath)).isDirectory())
       ) {
         result.push(...(await getFilesRecursively(filePath, ignoreMatcher)));
       } else {

--- a/alchemy/src/cloudflare/assets.ts
+++ b/alchemy/src/cloudflare/assets.ts
@@ -170,16 +170,12 @@ async function getFilesRecursively(
       if (ignoreMatcher.ignores(file.name)) {
         return;
       }
-      if (file.isDirectory()) {
+      if (
+        file.isDirectory() ||
+        (file.isSymbolicLink() &&
+          (await fs.stat(filePath).then((stats) => stats.isDirectory())))
+      ) {
         result.push(...(await getFilesRecursively(filePath, ignoreMatcher)));
-      } else if (file.isSymbolicLink()) {
-        // For symlinks, we need to stat the target to see if it's a directory
-        const stats = await fs.stat(filePath);
-        if (stats.isDirectory()) {
-          result.push(...(await getFilesRecursively(filePath, ignoreMatcher)));
-        } else {
-          result.push(filePath);
-        }
       } else {
         result.push(filePath);
       }


### PR DESCRIPTION
Found a bug when using sylinks in an astro site. We were treating a symlinked directory as a file and breaking with "invalid read operation on directory" and also skipping assets.