### PR TITLE
feat(cloudflare): allow local connection string for hyperdrive

### DIFF
--- a/alchemy-web/src/content/docs/providers/cloudflare/hyperdrive.md
+++ b/alchemy-web/src/content/docs/providers/cloudflare/hyperdrive.md
@@ -14,21 +14,33 @@ import { Hyperdrive } from "alchemy/cloudflare";
 
 const db = await Hyperdrive("my-postgres-db", {
   name: "my-postgres-db",
-  origin: {
-    database: "postgres",
-    host: "database.example.com",
-    password: alchemy.secret("your-password"),
-    port: 5432,
-    user: "postgres",
+  origin: "postgresql://user:password@ep-example-host-1234.us-east-1.aws.neon.tech/mydb?sslmode=require",
+});
+```
+
+:::tip
+Your origin can be a string, secret, or an object containing connection parameters.
+:::
+
+## With Local Origin
+
+If you want to use a local database for development, you can set the `dev.origin` property.
+
+This will be used by Miniflare to connect to the local database.
+
+```ts
+const db = await Hyperdrive("my-postgres-db", {
+  name: "my-postgres-db",
+  origin: "postgresql://user:password@ep-example-host-1234.us-east-1.aws.neon.tech/mydb?sslmode=require",
+  dev: {
+    origin: "postgres://user:password@localhost:5432/postgres",
   },
 });
 ```
 
-## With Local Connection String
+## With Explicit Origin Object
 
-If you want to use a local database for development, you can set the `localConnectionString` property.
-
-This will be used by Miniflare to connect to the local database.
+If you'd prefer to set parameters explicitly, you can use an object.
 
 ```ts
 const db = await Hyperdrive("my-postgres-db", {
@@ -36,15 +48,16 @@ const db = await Hyperdrive("my-postgres-db", {
   origin: {
     database: "postgres",
     host: "database.example.com",
-    password: alchemy.secret("your-password"),
+    password: "password",
     port: 5432,
     user: "postgres",
   },
-  localConnectionString: alchemy.secret(
-    "postgres://user:password@localhost:5432/postgres",
-  ),
 });
 ```
+
+:::tip
+Your password can be a string or a secret. If you provide a string, Alchemy will convert it to a secret for you.
+:::
 
 ## With Caching Disabled
 
@@ -56,7 +69,7 @@ const noCacheDb = await Hyperdrive("no-cache-db", {
   origin: {
     database: "postgres",
     host: "database.example.com",
-    password: alchemy.secret(process.env.DB_PASSWORD),
+    password: alchemy.secret.env.DB_PASSWORD,
     port: 5432,
     user: "postgres",
   },
@@ -76,7 +89,7 @@ const secureDb = await Hyperdrive("secure-db", {
   origin: {
     database: "postgres",
     host: "database.example.com",
-    password: alchemy.secret(process.env.DB_PASSWORD),
+    password: alchemy.secret.env.DB_PASSWORD,
     port: 5432,
     user: "postgres",
   },
@@ -99,7 +112,7 @@ const accessDb = await Hyperdrive("access-db", {
     database: "postgres",
     host: "database.example.com",
     access_client_id: "client-id",
-    access_client_secret: alchemy.secret(process.env.ACCESS_CLIENT_SECRET),
+    access_client_secret: alchemy.secret.env.ACCESS_CLIENT_SECRET,
     port: 5432,
     user: "postgres",
   },

--- a/alchemy-web/src/content/docs/providers/cloudflare/hyperdrive.md
+++ b/alchemy-web/src/content/docs/providers/cloudflare/hyperdrive.md
@@ -24,6 +24,28 @@ const db = await Hyperdrive("my-postgres-db", {
 });
 ```
 
+## With Local Connection String
+
+If you want to use a local database for development, you can set the `localConnectionString` property.
+
+This will be used by Miniflare to connect to the local database.
+
+```ts
+const db = await Hyperdrive("my-postgres-db", {
+  name: "my-postgres-db",
+  origin: {
+    database: "postgres",
+    host: "database.example.com",
+    password: alchemy.secret("your-password"),
+    port: 5432,
+    user: "postgres",
+  },
+  localConnectionString: alchemy.secret(
+    "postgres://user:password@localhost:5432/postgres",
+  ),
+});
+```
+
 ## With Caching Disabled
 
 Create a Hyperdrive connection with caching disabled.

--- a/alchemy/src/cloudflare/hyperdrive.ts
+++ b/alchemy/src/cloudflare/hyperdrive.ts
@@ -148,6 +148,11 @@ export interface HyperdriveProps extends CloudflareApiOptions {
    * @internal
    */
   hyperdriveId?: string;
+
+  /**
+   * Local connection string, if you want to use a local database for development
+   */
+  localConnectionString?: Secret;
 }
 
 /**
@@ -356,6 +361,7 @@ export const Hyperdrive = Resource(
       origin: props.origin, // Keep the original origin with secrets
       caching: apiResource.caching,
       mtls: apiResource.mtls,
+      localConnectionString: props.localConnectionString,
       type: "hyperdrive",
     });
   },
@@ -388,3 +394,16 @@ function prepareRequestBody(props: HyperdriveProps): any {
 
   return requestBody;
 }
+
+export const formatHyperdriveLocalConnectionString = (
+  hyperdrive: Hyperdrive,
+) => {
+  if (hyperdrive.localConnectionString) {
+    return hyperdrive.localConnectionString.unencrypted;
+  }
+  const password =
+    "password" in hyperdrive.origin
+      ? hyperdrive.origin.password.unencrypted
+      : hyperdrive.origin.access_client_secret.unencrypted;
+  return `${hyperdrive.origin.scheme || "postgres"}://${hyperdrive.origin.user}:${password}@${hyperdrive.origin.host}:${hyperdrive.origin.port || 5432}/${hyperdrive.origin.database}`;
+};

--- a/alchemy/src/cloudflare/hyperdrive.ts
+++ b/alchemy/src/cloudflare/hyperdrive.ts
@@ -162,6 +162,10 @@ export interface HyperdriveProps extends CloudflareApiOptions {
   hyperdriveId?: string;
 
   dev?: {
+    /**
+     * The database connection origin configuration for local development
+     * @default origin
+     */
     origin?: HyperdriveOriginInput;
   };
 }
@@ -277,7 +281,6 @@ export interface Hyperdrive
  *   }
  * });
  */
-
 export async function Hyperdrive(
   id: string,
   props: HyperdriveProps,
@@ -296,6 +299,10 @@ export async function Hyperdrive(
   });
 }
 
+/**
+ * Internal properties for creating or updating a Cloudflare Hyperdrive config.
+ * @internal
+ */
 interface InternalHyperdriveProps extends CloudflareApiOptions {
   name: string;
   hyperdriveId?: string;
@@ -303,7 +310,14 @@ interface InternalHyperdriveProps extends CloudflareApiOptions {
   caching?: HyperdriveCaching;
   mtls?: HyperdriveMtls;
   dev: {
+    /**
+     * Connection string for local development
+     */
     origin: Secret;
+    /**
+     * Set when `Scope.local` is true to force update
+     * @internal
+     */
     force?: boolean;
   };
 }

--- a/alchemy/src/cloudflare/hyperdrive.ts
+++ b/alchemy/src/cloudflare/hyperdrive.ts
@@ -479,7 +479,7 @@ function prepareRequestBody(props: InternalHyperdriveProps): any {
  */
 export const normalizeHyperdriveOrigin = (
   input: HyperdriveOriginInput,
-): HyperdrivePublicOrigin | HyperdriveOriginWithAccess => {
+): Required<HyperdrivePublicOrigin> | Required<HyperdriveOriginWithAccess> => {
   const origin = Secret.unwrap(input);
   if (typeof origin === "string") {
     const url = new URL(origin);
@@ -533,12 +533,14 @@ const normalizePort = (
 };
 
 const toConnectionString = (
-  origin: HyperdrivePublicOrigin | HyperdriveOriginWithAccess,
+  origin:
+    | Required<HyperdrivePublicOrigin>
+    | Required<HyperdriveOriginWithAccess>,
 ) => {
   const password = Secret.unwrap(
     "password" in origin ? origin.password : origin.access_client_secret,
   );
   return new Secret(
-    `${origin.scheme || "postgres"}://${origin.user}:${password}@${origin.host}:${origin.port || 5432}/${origin.database}`,
+    `${origin.scheme}://${origin.user}:${password}@${origin.host}:${origin.port}/${origin.database}`,
   );
 };

--- a/alchemy/src/cloudflare/hyperdrive.ts
+++ b/alchemy/src/cloudflare/hyperdrive.ts
@@ -192,7 +192,14 @@ export interface Hyperdrive
    */
   origin: HyperdrivePublicOrigin | HyperdriveOriginWithAccess;
 
+  /**
+   * Local development configuration
+   * @internal
+   */
   dev: {
+    /**
+     * The connection string to use for local development
+     */
     origin: Secret;
   };
 
@@ -310,14 +317,7 @@ interface InternalHyperdriveProps extends CloudflareApiOptions {
   caching?: HyperdriveCaching;
   mtls?: HyperdriveMtls;
   dev: {
-    /**
-     * Connection string for local development
-     */
     origin: Secret;
-    /**
-     * Set when `Scope.local` is true to force update
-     * @internal
-     */
     force?: boolean;
   };
 }

--- a/alchemy/src/cloudflare/miniflare/build-worker-options.ts
+++ b/alchemy/src/cloudflare/miniflare/build-worker-options.ts
@@ -9,6 +9,7 @@ import {
   type WorkerBindingSpec,
 } from "../bindings.ts";
 import { isQueueEventSource, type EventSource } from "../event-source.ts";
+import { formatHyperdriveLocalConnectionString } from "../hyperdrive.ts";
 import type { WorkerBundle, WorkerBundleSource } from "../worker-bundle.ts";
 import type { AssetsConfig } from "../worker.ts";
 import { createRemoteProxyWorker } from "./remote-binding-proxy.ts";
@@ -165,7 +166,9 @@ export const buildWorkerOptions = async (
         break;
       }
       case "hyperdrive": {
-        throw new Error("Hyperdrive bindings are not supported in local mode");
+        (options.hyperdrives ??= {})[key] =
+          formatHyperdriveLocalConnectionString(binding);
+        break;
       }
       case "images": {
         if (isRemoteBinding(binding)) {

--- a/alchemy/src/cloudflare/miniflare/build-worker-options.ts
+++ b/alchemy/src/cloudflare/miniflare/build-worker-options.ts
@@ -9,7 +9,6 @@ import {
   type WorkerBindingSpec,
 } from "../bindings.ts";
 import { isQueueEventSource, type EventSource } from "../event-source.ts";
-import { formatHyperdriveLocalConnectionString } from "../hyperdrive.ts";
 import type { WorkerBundle, WorkerBundleSource } from "../worker-bundle.ts";
 import type { AssetsConfig } from "../worker.ts";
 import { createRemoteProxyWorker } from "./remote-binding-proxy.ts";
@@ -166,8 +165,7 @@ export const buildWorkerOptions = async (
         break;
       }
       case "hyperdrive": {
-        (options.hyperdrives ??= {})[key] =
-          formatHyperdriveLocalConnectionString(binding);
+        (options.hyperdrives ??= {})[key] = binding.dev.origin.unencrypted;
         break;
       }
       case "images": {

--- a/alchemy/src/cloudflare/wrangler.json.ts
+++ b/alchemy/src/cloudflare/wrangler.json.ts
@@ -450,7 +450,11 @@ export interface WranglerJsonSpec {
   /**
    * Hyperdrive bindings
    */
-  hyperdrive?: { binding: string; id: string; localConnectionString?: string }[];
+  hyperdrive?: {
+    binding: string;
+    id: string;
+    localConnectionString?: string;
+  }[];
 
   /**
    * Pipelines

--- a/alchemy/src/cloudflare/wrangler.json.ts
+++ b/alchemy/src/cloudflare/wrangler.json.ts
@@ -450,7 +450,7 @@ export interface WranglerJsonSpec {
   /**
    * Hyperdrive bindings
    */
-  hyperdrive?: { binding: string; id: string; localConnectionString: string }[];
+  hyperdrive?: { binding: string; id: string; localConnectionString?: string }[];
 
   /**
    * Pipelines

--- a/alchemy/src/cloudflare/wrangler.json.ts
+++ b/alchemy/src/cloudflare/wrangler.json.ts
@@ -13,7 +13,6 @@ import {
 import type { DurableObjectNamespace } from "./durable-object-namespace.ts";
 import type { EventSource } from "./event-source.ts";
 import { isQueueEventSource } from "./event-source.ts";
-import { formatHyperdriveLocalConnectionString } from "./hyperdrive.ts";
 import { isQueue } from "./queue.ts";
 import type { Worker, WorkerProps } from "./worker.ts";
 
@@ -564,7 +563,7 @@ function processBindings(
   const hyperdrive: {
     binding: string;
     id: string;
-    localConnectionString: string;
+    localConnectionString?: string;
   }[] = [];
   const pipelines: { binding: string; pipeline: string }[] = [];
   const secretsStoreSecrets: {
@@ -741,7 +740,9 @@ function processBindings(
       hyperdrive.push({
         binding: bindingName,
         id: binding.hyperdriveId,
-        localConnectionString: formatHyperdriveLocalConnectionString(binding),
+        localConnectionString: writeSecrets
+          ? binding.dev.origin.unencrypted
+          : undefined,
       });
     } else if (binding.type === "pipeline") {
       pipelines.push({

--- a/alchemy/src/cloudflare/wrangler.json.ts
+++ b/alchemy/src/cloudflare/wrangler.json.ts
@@ -13,6 +13,7 @@ import {
 import type { DurableObjectNamespace } from "./durable-object-namespace.ts";
 import type { EventSource } from "./event-source.ts";
 import { isQueueEventSource } from "./event-source.ts";
+import { formatHyperdriveLocalConnectionString } from "./hyperdrive.ts";
 import { isQueue } from "./queue.ts";
 import type { Worker, WorkerProps } from "./worker.ts";
 
@@ -737,14 +738,10 @@ function processBindings(
         binding: bindingName,
       };
     } else if (binding.type === "hyperdrive") {
-      const password =
-        "password" in binding.origin
-          ? binding.origin.password.unencrypted
-          : binding.origin.access_client_secret.unencrypted;
       hyperdrive.push({
         binding: bindingName,
         id: binding.hyperdriveId,
-        localConnectionString: `${binding.origin.scheme || "postgres"}://${binding.origin.user}:${password}@${binding.origin.host}:${binding.origin.port || 5432}/${binding.origin.database}`,
+        localConnectionString: formatHyperdriveLocalConnectionString(binding),
       });
     } else if (binding.type === "pipeline") {
       pipelines.push({

--- a/alchemy/src/secret.ts
+++ b/alchemy/src/secret.ts
@@ -70,12 +70,26 @@ export class Secret<T = string> {
   ) {
     globalSecrets[name] = this;
   }
+
+  /**
+   * Ensures that a value is wrapped in a Secret.
+   */
+  static wrap<T>(value: T | Secret<T>): Secret<T> {
+    return isSecret<T>(value) ? value : new Secret(value);
+  }
+
+  /**
+   * Unwraps a Secret if it is wrapped, otherwise returns the value.
+   */
+  static unwrap<T, U = T>(value: T | Secret<U>): T | U {
+    return isSecret<U>(value) ? value.unencrypted : value;
+  }
 }
 
 /**
  * Type guard to check if a value is a Secret wrapper
  */
-export function isSecret(binding: any): binding is Secret {
+export function isSecret<T = string>(binding: any): binding is Secret<T> {
   return (
     binding instanceof Secret ||
     (typeof binding === "object" && binding?.type === "secret")


### PR DESCRIPTION
Example usage:

```ts
const db = await Hyperdrive("my-postgres-db", {
  name: "my-postgres-db",
  origin: "postgresql://user:password@ep-example-host-1234.us-east-1.aws.neon.tech/mydb?sslmode=require",
  dev: {
    origin: "postgres://user:password@localhost:5432/postgres",
  },
});
```