### PR TITLE
chore: update broken Cloudflare API Token documentation link

### DIFF
--- a/alchemy-web/src/content/docs/providers/cloudflare/account-api-token.md
+++ b/alchemy-web/src/content/docs/providers/cloudflare/account-api-token.md
@@ -3,7 +3,7 @@ title: AccountApiToken
 description: Learn how to create and manage Cloudflare Account API Tokens using Alchemy for secure access to the Cloudflare API.
 ---
 
-Creates a [Cloudflare API Token](https://developers.cloudflare.com/api/tokens/) with specified permissions and access controls.
+Creates a [Cloudflare API Token](https://developers.cloudflare.com/fundamentals/api/get-started/create-token/) with specified permissions and access controls.
 
 ## Minimal Example
 


### PR DESCRIPTION
Update broken link from https://developers.cloudflare.com/api/tokens/ to https://developers.cloudflare.com/fundamentals/api/get-started/create-token/

Fixes #788

Generated with [Claude Code](https://claude.ai/code)