### PR TITLE
Add `.gitattributes` To Vendor Non-TS Files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+*.astro linguist-vendored
+*.css linguist-vendored
+*.js linguist-vendored
+*.mdx linguist-vendored
+Dockerfile linguist-vendored
+Dockerfile.* linguist-vendored


### PR DESCRIPTION
This is a tremendously meaningful PR. Of the utmost importance. It's in fact crucial to the project's success.

---

This change should get the repo's language overview from this...

<img width="273" height="171" alt="Screenshot 2025-08-07 at 10 26 03 PM" src="https://github.com/user-attachments/assets/340c66a7-8bbf-400a-9413-98856be8be6d" />

... to this...

<img width="329" height="108" alt="Screenshot 2025-08-07 at 6 53 51 PM" src="https://github.com/user-attachments/assets/2512b724-7de4-43b8-b3f9-3e3d2fa34cf3" />
