### PR TITLE
feat(cloudflare): Zone Bot Management

### DIFF
--- a/alchemy-web/src/content/docs/providers/cloudflare/zone.md
+++ b/alchemy-web/src/content/docs/providers/cloudflare/zone.md
@@ -51,7 +51,7 @@ const fastZone = await Zone("fast-zone", {
 });
 ```
 
-## Development Mode
+## Bot Management
 
 Configure a zone for development with specific features enabled.
 
@@ -63,5 +63,32 @@ const devZone = await Zone("dev-zone", {
     websockets: "on",
     hotlinkProtection: "on",
   },
+  botManagement: {
+    fightMode: true,
+    aiBotsProtection: "block",
+    crawlerProtection: "enabled",
+    enableJs: true,
+    isRobotsTxtManaged: true,
+    optimizeWordpress: false,
+    suppressSessionScore: false,
+  },
 });
 ```
+
+### Bot Management options
+
+- **fightMode**: Enable/disable Bot Fight Mode (maps to `fight_mode`).
+- **aiBotsProtection**: AI bot behavior: `block` or `none` (maps to `ai_bots_protection`).
+- **crawlerProtection**: Enable/disable crawler protection: `enabled` or `disabled` (maps to `crawler_protection`).
+- **enableJs**: Require JavaScript challenges (maps to `enable_js`).
+- **isRobotsTxtManaged**: Manage robots.txt via Cloudflare (maps to `is_robots_txt_managed`).
+- **optimizeWordpress**: Optimize protections for WordPress (maps to `optimize_wordpress`).
+- **suppressSessionScore**: Suppress session score collection (maps to `suppress_session_score`).
+
+Advanced plans may also use Super Bot Fight Mode settings:
+
+- **sbfmLikelyAutomated**: Action for likely automated traffic: `allow` | `block` | `challenge` (maps to `sbfm_likely_automated`).
+- **sbfmDefinitelyAutomated**: Action for definitely automated traffic: `allow` | `block` | `challenge` (maps to `sbfm_definitely_automated`).
+- **sbfmVerifiedBots**: Handling for verified bots: `allow` | `challenge` (maps to `sbfm_verified_bots`).
+- **sbfmStaticResourceProtection**: Protect static resources (maps to `sbfm_static_resource_protection`).
+- **autoUpdateModel**: Automatically update detection model (maps to `auto_update_model`).

--- a/alchemy/src/apply.ts
+++ b/alchemy/src/apply.ts
@@ -92,7 +92,8 @@ async function _apply<Out extends Resource>(
           [DestroyStrategy]: provider.options?.destroyStrategy ?? "sequential",
         },
         // deps: [...deps],
-        props,
+        // there are no "old props" on initialization
+        props: undefined,
       };
       await scope.state.set(resource[ResourceID], state);
     }

--- a/alchemy/src/cloudflare/zone-bot-management.ts
+++ b/alchemy/src/cloudflare/zone-bot-management.ts
@@ -1,0 +1,147 @@
+import type { CloudflareApi } from "./api";
+
+export type BotManagement =
+  | BotFightModeConfiguration
+  | SuperBotFightModeDefinitelyConfiguration
+  | SuperBotFightModeLikelyConfiguration
+  | SubscriptionConfiguration;
+
+/**
+ * Bot Management configuration types
+ * See Cloudflare API: https://developers.cloudflare.com/api/resources/bot_management/methods/update/
+ */
+/**
+ * Action to apply to traffic classified by Super Bot Fight Mode.
+ * Maps to Cloudflare API values for SBFM: sbfm_* fields.
+ */
+export type SbfmAction = "allow" | "block" | "challenge";
+
+/**
+ * Bot Fight Mode plan configuration.
+ * Maps to Cloudflare API: fight_mode, ai_bots_protection, crawler_protection,
+ * enable_js, is_robots_txt_managed, optimize_wordpress, suppress_session_score
+ */
+export interface BotFightModeConfiguration {
+  /** Enable or disable Bot Fight Mode (fight_mode) */
+  fightMode?: boolean;
+  /** Configure AI bot protection behavior (ai_bots_protection): "block" or "none" */
+  aiBotsProtection?: "block" | "none";
+  /** Enable or disable crawler protection (crawler_protection): "enabled" or "disabled" */
+  crawlerProtection?: "enabled" | "disabled";
+  /** Require JavaScript challenges for suspicious traffic (enable_js) */
+  enableJs?: boolean;
+  /** Manage robots.txt via Cloudflare (is_robots_txt_managed) */
+  isRobotsTxtManaged?: boolean;
+  /** Optimize protections for WordPress (optimize_wordpress) */
+  optimizeWordpress?: boolean;
+  /** Suppress session score collection (suppress_session_score) */
+  suppressSessionScore?: boolean;
+}
+
+/**
+ * Super Bot Fight Mode Likely plan configuration.
+ * Maps to Cloudflare API: sbfm_likely_automated, sbfm_verified_bots,
+ * sbfm_static_resource_protection, optimize_wordpress, suppress_session_score, fight_mode
+ */
+export interface SuperBotFightModeLikelyConfiguration {
+  /** Action for likely automated traffic (sbfm_likely_automated) */
+  sbfmLikelyAutomated?: SbfmAction;
+  /** Handling for verified bots (sbfm_verified_bots): "allow" or "challenge" */
+  sbfmVerifiedBots?: "allow" | "challenge";
+  /** Protect static resources from automated requests (sbfm_static_resource_protection) */
+  sbfmStaticResourceProtection?: boolean;
+  /** Optimize protections for WordPress (optimize_wordpress) */
+  optimizeWordpress?: boolean;
+  /** Suppress session score collection (suppress_session_score) */
+  suppressSessionScore?: boolean;
+  /** Enable or disable legacy Bot Fight Mode setting if applicable (fight_mode) */
+  fightMode?: boolean;
+}
+
+/**
+ * Super Bot Fight Mode Definitely plan configuration.
+ * Maps to Cloudflare API: sbfm_definitely_automated, sbfm_verified_bots,
+ * sbfm_static_resource_protection, optimize_wordpress, suppress_session_score, fight_mode
+ */
+export interface SuperBotFightModeDefinitelyConfiguration {
+  /** Action for definitely automated traffic (sbfm_definitely_automated) */
+  sbfmDefinitelyAutomated?: SbfmAction;
+  /** Handling for verified bots (sbfm_verified_bots): "allow" or "challenge" */
+  sbfmVerifiedBots?: "allow" | "challenge";
+  /** Protect static resources from automated requests (sbfm_static_resource_protection) */
+  sbfmStaticResourceProtection?: boolean;
+  /** Optimize protections for WordPress (optimize_wordpress) */
+  optimizeWordpress?: boolean;
+  /** Suppress session score collection (suppress_session_score) */
+  suppressSessionScore?: boolean;
+  /** Enable or disable legacy Bot Fight Mode setting if applicable (fight_mode) */
+  fightMode?: boolean;
+}
+
+/**
+ * Bot Management for Enterprise subscription configuration.
+ * Extends base Bot Fight Mode options, adds model auto-update control.
+ * Maps to Cloudflare API: auto_update_model
+ */
+export interface SubscriptionConfiguration extends BotFightModeConfiguration {
+  /** Automatically update Bot Management model (auto_update_model) */
+  autoUpdateModel?: boolean;
+}
+
+/**
+ * Helper function to update Bot Management configuration for a zone
+ * Maps high-level options to Cloudflare API fields
+ */
+export async function updateBotManagement(
+  api: CloudflareApi,
+  zoneId: string,
+  botManagement: BotManagement | undefined,
+  oldBotManagement: BotManagement | undefined,
+): Promise<void> {
+  const payload = createUpdateBotManagementPayload(botManagement);
+  const oldPayload = createUpdateBotManagementPayload(oldBotManagement);
+  if (JSON.stringify(payload) === JSON.stringify(oldPayload)) {
+    return;
+  }
+  const response = await api.put(`/zones/${zoneId}/bot_management`, payload);
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(
+      `Failed to update bot management settings: ${response.status} ${response.statusText}\n${body}`,
+    );
+  }
+}
+
+const createUpdateBotManagementPayload = (props: BotManagement | undefined) =>
+  props === undefined
+    ? {}
+    : {
+        fight_mode: (props as BotFightModeConfiguration).fightMode,
+        ai_bots_protection: (props as BotFightModeConfiguration)
+          .aiBotsProtection,
+        crawler_protection: (props as BotFightModeConfiguration)
+          .crawlerProtection,
+        enable_js: (props as BotFightModeConfiguration).enableJs,
+        is_robots_txt_managed: (props as BotFightModeConfiguration)
+          .isRobotsTxtManaged,
+        auto_update_model: (props as SubscriptionConfiguration).autoUpdateModel,
+        optimize_wordpress: (props as BotFightModeConfiguration)
+          .optimizeWordpress,
+        suppress_session_score: (props as BotFightModeConfiguration)
+          .suppressSessionScore,
+        sbfm_likely_automated: (props as SuperBotFightModeLikelyConfiguration)
+          .sbfmLikelyAutomated,
+        sbfm_definitely_automated: (
+          props as SuperBotFightModeDefinitelyConfiguration
+        ).sbfmDefinitelyAutomated,
+        sbfm_verified_bots: (
+          props as
+            | SuperBotFightModeLikelyConfiguration
+            | SuperBotFightModeDefinitelyConfiguration
+        ).sbfmVerifiedBots,
+        sbfm_static_resource_protection: (
+          props as
+            | SuperBotFightModeLikelyConfiguration
+            | SuperBotFightModeDefinitelyConfiguration
+        ).sbfmStaticResourceProtection,
+      };

--- a/alchemy/src/cloudflare/zone.ts
+++ b/alchemy/src/cloudflare/zone.ts
@@ -7,6 +7,10 @@ import {
   type CloudflareApi,
   type CloudflareApiOptions,
 } from "./api.ts";
+import {
+  updateBotManagement,
+  type BotManagement,
+} from "./zone-bot-management.ts";
 import type {
   AlwaysUseHTTPSValue,
   AutomaticHTTPSRewritesValue,
@@ -167,6 +171,11 @@ export interface ZoneProps extends CloudflareApiOptions {
      */
     minTlsVersion?: MinTLSVersionValue;
   };
+
+  /**
+   * Cloudflare Bot Management settings
+   */
+  botManagement?: BotManagement;
 }
 
 /**
@@ -314,7 +323,7 @@ export interface Zone extends Resource<"cloudflare::Zone">, ZoneData {}
 export const Zone = Resource(
   "cloudflare::Zone",
   async function (
-    this: Context<Zone>,
+    this: Context<Zone, ZoneProps>,
     _id: string,
     props: ZoneProps,
   ): Promise<Zone> {
@@ -407,6 +416,14 @@ export const Zone = Resource(
     // TODO(michael): do we need this?
     // https://github.com/sam-goodwin/alchemy/issues/681
     await new Promise((resolve) => setTimeout(resolve, 2000));
+
+    // Update Bot Management configuration if provided
+    await updateBotManagement(
+      api,
+      zoneData.id,
+      props.botManagement,
+      this.props?.botManagement,
+    );
 
     return this({
       id: zoneData.id,

--- a/alchemy/test/cloudflare/zone.test.ts
+++ b/alchemy/test/cloudflare/zone.test.ts
@@ -46,6 +46,15 @@ describe.skipIf(!process.env.ALL_TESTS)("Zone Resource", () => {
           hotlinkProtection: "on",
           developmentMode: "off",
         },
+        botManagement: {
+          fightMode: true,
+          aiBotsProtection: "block",
+          crawlerProtection: "enabled",
+          enableJs: true,
+          isRobotsTxtManaged: true,
+          optimizeWordpress: false,
+          suppressSessionScore: false,
+        },
       });
 
       expect(zone.id).toBeTruthy();
@@ -78,6 +87,14 @@ describe.skipIf(!process.env.ALL_TESTS)("Zone Resource", () => {
 
       const responseData: any = await getResponse.json();
       expect(responseData.result.name).toEqual(testDomain);
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+
+      // Verify bot management settings
+      const botResponse = await api.get(`/zones/${zone.id}/bot_management`);
+      expect(botResponse.status).toEqual(200);
+      const botData: any = await botResponse.json();
+      console.log(botData);
+      expect(botData.result.fight_mode).toEqual(true);
 
       // Update the zone with different settings
       zone = await Zone(testDomain, {


### PR DESCRIPTION
## Bot Management

Configure a zone for development with specific features enabled.

```ts
const devZone = await Zone("dev-zone", {
  name: "dev.example.com",
  settings: {
    developmentMode: "on",
    websockets: "on",
    hotlinkProtection: "on",
  },
  botManagement: {
    fightMode: true,
    aiBotsProtection: "block",
    crawlerProtection: "enabled",
    enableJs: true,
    isRobotsTxtManaged: true,
    optimizeWordpress: false,
    suppressSessionScore: false,
  },
});
```

Also fixed a bug where `this.props` pointed to the new props on initialization