### PR TITLE
fix(cloudflare): correct wrangler.json assets config

### DIFF
--- a/alchemy/src/cloudflare/wrangler.json.ts
+++ b/alchemy/src/cloudflare/wrangler.json.ts
@@ -163,6 +163,9 @@ export const WranglerJson = Resource(
         ? {
             directory: toAbsolute(props.assets.directory),
             binding: props.assets.binding,
+            not_found_handling: props.worker.assets?.not_found_handling,
+            html_handling: props.worker.assets?.html_handling,
+            run_worker_first: props.worker.assets?.run_worker_first,
           }
         : undefined,
       placement: worker.placement,
@@ -417,6 +420,13 @@ export interface WranglerJsonSpec {
   assets?: {
     directory: string;
     binding: string;
+    not_found_handling?: "none" | "404-page" | "single-page-application";
+    html_handling?:
+      | "auto-trailing-slash"
+      | "drop-trailing-slash"
+      | "force-trailing-slash"
+      | "none";
+    run_worker_first?: boolean | string[];
   };
 
   /**


### PR DESCRIPTION
Our local asset handling doesn't match the remote behavior because we weren't writing the relevant configuration properties (`not-found_handling`, `html_handling`, and `run_worker_first`) to the generated `wrangler.jsonc`.

This fixes that to ensure parity.

Note: This is related to but not the same as #787. Seems like an Alchemy's behavior is the same as Wrangler with remote deployments — but our docs and examples aren't quite aligned with the expected behavior. We can update that in a separate PR.