### PR TITLE
fix(cloudflare): overwrite NODE_ENV when running vite dev

### DIFF
--- a/alchemy/src/cloudflare/website.ts
+++ b/alchemy/src/cloudflare/website.ts
@@ -388,6 +388,9 @@ async function runDevCommand(
           return [];
         }),
       ),
+      // NOTE: we must set this to ensure the user does not accidentally set `NODE_ENV=production`
+      // which breaks `vite dev` (it won't, for example, re-write `process.env.TSS_APP_BASE` in the `.js` client side bundle)
+      NODE_ENV: "development",
     },
     stdio: "pipe",
   });


### PR DESCRIPTION
If a user set `NODE_ENV=production` in their `TanStackStart` website's `bindings`, then `alchemy dev` would pass it to `vite dev` which breaks the client side bundle.

When trying to resolve the RPC client for a `createServerFn`, for some reason the `process.env.TSS_APP_BASE` was still present in the client side bundle, which would then error with the following message:
```
ReferenceError: process is not defined
```

This change sets `NODE_ENV=development` when running the dev command for a website.

Question: should we set it `development` for all cases, or only when the user accidentally sets it as `production`? OR should we just fatal?