### PR TITLE
fix: use --env-file-if-exists for alchemy deploy

### DIFF
--- a/alchemy/bin/services/execute-alchemy.ts
+++ b/alchemy/bin/services/execute-alchemy.ts
@@ -83,7 +83,7 @@ export async function execAlchemy(
     execArgs.push("--watch");
     args.push("--watch");
   }
-  if (envFile) execArgs.push(`--env-file ${envFile}`);
+  if (envFile) execArgs.push(`--env-file-if-exists ${envFile}`);
   if (dev) args.push("--dev");
 
   // Check for alchemy.run.ts or alchemy.run.js (if not provided)


### PR DESCRIPTION
Changes --env-file to --env-file-if-exists in execute-alchemy.ts to prevent errors in CI environments where .env files may not exist.

Fixes #844

Generated with [Claude Code](https://claude.ai/code)