### PR TITLE
fix(cloudflare): use glob instead of fs.glob for node 20 compatibility

### DIFF
--- a/alchemy/src/cloudflare/d1-migrations.ts
+++ b/alchemy/src/cloudflare/d1-migrations.ts
@@ -1,3 +1,4 @@
+import { glob } from "glob";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { logger } from "../util/logger.ts";
@@ -159,11 +160,9 @@ async function migrateLegacySchema(
 export async function listMigrationsFiles(
   migrationsDir: string,
 ): Promise<Array<{ id: string; sql: string }>> {
-  const entries = await Array.fromAsync(
-    fs.glob("**/*.sql", {
-      cwd: migrationsDir,
-    }),
-  );
+  const entries = await glob("**/*.sql", {
+    cwd: migrationsDir,
+  });
 
   const sqlFiles = entries.sort((a: string, b: string) => {
     const aNum = getPrefix(a);

--- a/alchemy/src/cloudflare/worker-bundle.ts
+++ b/alchemy/src/cloudflare/worker-bundle.ts
@@ -1,4 +1,5 @@
 import esbuild from "esbuild";
+import { globIterate } from "glob";
 import { err, ok, type Result } from "neverthrow";
 import fs from "node:fs/promises";
 import path from "pathe";
@@ -222,7 +223,7 @@ export namespace WorkerBundleSource {
       const fileNames = new Set<string>();
       await Promise.all(
         this.globs.map(async (glob) => {
-          for await (const file of fs.glob(glob, { cwd: this.root })) {
+          for await (const file of globIterate(glob, { cwd: this.root })) {
             fileNames.add(file);
           }
         }),


### PR DESCRIPTION
Right now we use fs.glob in two places where we should've used the `glob` package for compatibility with Node.js 20. This is a quick fix.