### PR TITLE
fix(cloudflare): register durable object bindings for websites

### DIFF
--- a/alchemy/src/cloudflare/miniflare/build-worker-options.ts
+++ b/alchemy/src/cloudflare/miniflare/build-worker-options.ts
@@ -69,9 +69,10 @@ export const buildWorkerOptions = async (
     name: input.name,
     compatibilityDate: input.compatibilityDate,
     compatibilityFlags: input.compatibilityFlags,
-    // TODO: Setting `proxy: true` here causes the following error when connecting via a websocket:
-    // workerd/io/worker.c++:2164: info: uncaught exception; source = Uncaught (in promise); stack = TypeError: Invalid URL string.
     unsafeDirectSockets: [
+      // This matches the Wrangler configuration by exposing the default handler (e.g. `export default { fetch }`).
+      // However, unlike Wrangler, we set `proxy: false` to avoid the following error when connecting via a websocket:
+      // workerd/io/worker.c++:2164: info: uncaught exception; source = Uncaught (in promise); stack = TypeError: Invalid URL string.
       {
         entrypoint: "default",
         proxy: false,
@@ -169,6 +170,8 @@ export const buildWorkerOptions = async (
           scriptName: binding.scriptName,
           useSQLite: binding.sqlite,
         };
+        // This matches Wrangler configuration for exposing durable objects as an entrypoint.
+        // See https://github.com/cloudflare/workers-sdk/blob/ae0c806087c203da6a3d7da450e8fabe0d81c987/packages/wrangler/src/dev/miniflare/index.ts#L1266
         options.unsafeDirectSockets!.push({
           entrypoint: binding.className,
           serviceName: binding.scriptName,

--- a/alchemy/src/cloudflare/miniflare/build-worker-options.ts
+++ b/alchemy/src/cloudflare/miniflare/build-worker-options.ts
@@ -71,7 +71,12 @@ export const buildWorkerOptions = async (
     compatibilityFlags: input.compatibilityFlags,
     // TODO: Setting `proxy: true` here causes the following error when connecting via a websocket:
     // workerd/io/worker.c++:2164: info: uncaught exception; source = Uncaught (in promise); stack = TypeError: Invalid URL string.
-    unsafeDirectSockets: [{ proxy: false }],
+    unsafeDirectSockets: [
+      {
+        entrypoint: "default",
+        proxy: false,
+      },
+    ],
     containerEngine: {
       localDocker: {
         socketPath:
@@ -164,6 +169,11 @@ export const buildWorkerOptions = async (
           scriptName: binding.scriptName,
           useSQLite: binding.sqlite,
         };
+        options.unsafeDirectSockets!.push({
+          entrypoint: binding.className,
+          serviceName: binding.scriptName,
+          proxy: true,
+        });
         break;
       }
       case "hyperdrive": {

--- a/alchemy/src/cloudflare/miniflare/miniflare-controller.ts
+++ b/alchemy/src/cloudflare/miniflare/miniflare-controller.ts
@@ -79,10 +79,13 @@ export class MiniflareController {
         workers: [],
         defaultPersistRoot: path.resolve(DEFAULT_PERSIST_PATH),
         unsafeDevRegistryPath: miniflare.getDefaultDevRegistryPath(),
-        unsafeDevRegistryDurableObjectProxy: true,
         log: process.env.DEBUG
           ? new miniflare.Log(miniflare.LogLevel.DEBUG)
           : undefined,
+
+        // This is required to allow websites and other separate processes
+        // to detect Alchemy-managed Durable Objects via the Wrangler dev registry.
+        unsafeDevRegistryDurableObjectProxy: true,
       };
       for (const worker of this.options.values()) {
         options.workers.push(worker);

--- a/alchemy/src/cloudflare/miniflare/miniflare-controller.ts
+++ b/alchemy/src/cloudflare/miniflare/miniflare-controller.ts
@@ -79,6 +79,7 @@ export class MiniflareController {
         workers: [],
         defaultPersistRoot: path.resolve(DEFAULT_PERSIST_PATH),
         unsafeDevRegistryPath: miniflare.getDefaultDevRegistryPath(),
+        unsafeDevRegistryDurableObjectProxy: true,
         log: process.env.DEBUG
           ? new miniflare.Log(miniflare.LogLevel.DEBUG)
           : undefined,


### PR DESCRIPTION
Updates our Miniflare controller to properly register Durable Objects in the Wrangler dev registry so the binding can be accessed from a website.