### PR TITLE
fix(cli): ensure exit code 0 for sigint

### DIFF
--- a/alchemy/bin/services/execute-alchemy.ts
+++ b/alchemy/bin/services/execute-alchemy.ts
@@ -157,7 +157,7 @@ export async function execAlchemy(
   }
   process.on("SIGINT", async () => {
     await exitPromise;
-    process.exit(child.exitCode ?? 0);
+    process.exit(formatExitCode(child.exitCode));
   });
 
   console.log(command);
@@ -173,5 +173,10 @@ export async function execAlchemy(
   });
   const exitPromise = once(child, "exit");
   await exitPromise.catch(() => {});
-  process.exit(child.exitCode ?? 0);
+  process.exit(formatExitCode(child.exitCode));
 }
+
+const formatExitCode = (exitCode: number | null) => {
+  if (exitCode === null || exitCode === 130) return 0;
+  return exitCode;
+};

--- a/alchemy/bin/services/execute-alchemy.ts
+++ b/alchemy/bin/services/execute-alchemy.ts
@@ -157,7 +157,7 @@ export async function execAlchemy(
   }
   process.on("SIGINT", async () => {
     await exitPromise;
-    process.exit(formatExitCode(child.exitCode));
+    process.exit(sanitizeExitCode(child.exitCode));
   });
 
   console.log(command);
@@ -173,10 +173,14 @@ export async function execAlchemy(
   });
   const exitPromise = once(child, "exit");
   await exitPromise.catch(() => {});
-  process.exit(formatExitCode(child.exitCode));
+  process.exit(sanitizeExitCode(child.exitCode));
 }
 
-const formatExitCode = (exitCode: number | null) => {
+/**
+ * If exit code is 130 (SIGINT) or null, return 0.
+ * Otherwise, return the exit code.
+ */
+const sanitizeExitCode = (exitCode: number | null) => {
   if (exitCode === null || exitCode === 130) return 0;
   return exitCode;
 };


### PR DESCRIPTION
When you Ctrl + C out of the CLI, sometimes it shows an error even when it's a clean exit. This handles that by rewriting exit code 130 to 0.