### PR TITLE
fix(core): support multiple instances of alchemy in a monorepo environment

### DIFF
--- a/alchemy/src/resource.ts
+++ b/alchemy/src/resource.ts
@@ -5,16 +5,23 @@ import { Scope as _Scope, type Scope } from "./scope.ts";
 
 declare global {
   var ALCHEMY_PROVIDERS: Map<ResourceKind, Provider<string, any>>;
+  var ALCHEMY_HANDLERS: Map<ResourceKind, ResourceLifecycleHandler>;
   var ALCHEMY_DYNAMIC_RESOURCE_RESOLVERS: DynamicResourceResolver[];
 }
 
 export const PROVIDERS: Map<
   ResourceKind,
-  Provider<string, any>
+  Provider<string, ResourceLifecycleHandler>
 > = (globalThis.ALCHEMY_PROVIDERS ??= new Map<
   ResourceKind,
-  Provider<string, any>
+  Provider<string, ResourceLifecycleHandler>
 >());
+const HANDLERS: Map<ResourceKind, ResourceLifecycleHandler> =
+  (globalThis.ALCHEMY_HANDLERS ??= new Map<
+    ResourceKind,
+    ResourceLifecycleHandler
+  >());
+
 const DYNAMIC_RESOURCE_RESOLVERS: DynamicResourceResolver[] =
   (globalThis.ALCHEMY_DYNAMIC_RESOURCE_RESOLVERS ??= []);
 
@@ -132,10 +139,20 @@ export function Resource<
   const Type extends ResourceKind,
   F extends ResourceLifecycleHandler,
 >(type: Type, ...args: [Partial<ProviderOptions>, F] | [F]): Handler<F> {
-  if (PROVIDERS.has(type)) {
-    throw new Error(`Resource ${type} already exists`);
-  }
   const [options, handler] = args.length === 2 ? args : [undefined, args[0]];
+  if (PROVIDERS.has(type)) {
+    // We want Alchemy to work in a PNPM monorepo environment unfortunately,
+    // global registries do not work because PNPM's symlinks result in multiple
+    // instances of alchemy being loaded even if the package version is the
+    // same (peers do not fix this).
+    // MITIGATION: to ensure that most cases of accidental double-registration
+    // are caught, we're going to check the handler's toString() to see if it's
+    // the same as the previous handler. if it is, we're going to overwrite it.
+    if (HANDLERS.get(type)!.toString() !== handler.toString()) {
+      throw new Error(`Resource ${type} already exists`);
+    }
+  }
+  HANDLERS.set(type, handler);
 
   type Out = Awaited<ReturnType<F>>;
 

--- a/alchemy/src/resource.ts
+++ b/alchemy/src/resource.ts
@@ -11,10 +11,10 @@ declare global {
 
 export const PROVIDERS: Map<
   ResourceKind,
-  Provider<string, ResourceLifecycleHandler>
+  Provider<string, any>
 > = (globalThis.ALCHEMY_PROVIDERS ??= new Map<
   ResourceKind,
-  Provider<string, ResourceLifecycleHandler>
+  Provider<string, any>
 >());
 const HANDLERS: Map<ResourceKind, ResourceLifecycleHandler> =
   (globalThis.ALCHEMY_HANDLERS ??= new Map<


### PR DESCRIPTION
We used to error if you tried to register a Resource with the same type name, e.g. `cloudflare::Worker`. Unfortunately, we also register each Resource on `globalThis` which means that if there are two instances of `alchemy` in your dependencies, it will fail.

It was originally assumed that proper peer dependencies would resolve this and that it was indicative of a user-side configuration error. But, we recently learned that in a PNPM monorepo, even if all the versions are aligned, PNPM will create different symlinks to the same package version.

From the perspective of Node/Bun/etc. a module's identity is its file path and it does not follow symlinks eagerly. So even in a perfectly aligned monorepo with all the same alchemy versions, there would still be duplicate instances. 

To support this, we now allow double registration IFF the functions are the same. Since it is impossible to truly tell if the functions are the same, we apply a heuristic of calling `toString()` on the resource lifecycle handler and erroring if it is different.