### PR TITLE
fix(cli): remove deprecation warning in execute-alchemy.ts

### DIFF
--- a/alchemy/bin/services/execute-alchemy.ts
+++ b/alchemy/bin/services/execute-alchemy.ts
@@ -160,8 +160,7 @@ export async function execAlchemy(
   });
 
   console.log(command);
-  const [cmd, ...cmdArgs] = command.split(" ");
-  const child = spawn(cmd, cmdArgs, {
+  const child = spawn(command, {
     cwd,
     shell: true,
     stdio: "inherit",


### PR DESCRIPTION
Don't split command by space when shell: true is used. The shell
handles command parsing when shell option is true, eliminating
the DEP0190 deprecation warning about security vulnerabilities.

Fixes #870

Generated with [Claude Code](https://claude.ai/code)