### PR TITLE
fix(cloudflare): alchemy svelte plugin is a no-op when run within the svelte language server

### DIFF
--- a/alchemy/src/cloudflare/sveltekit/plugin.ts
+++ b/alchemy/src/cloudflare/sveltekit/plugin.ts
@@ -1,7 +1,20 @@
 import adapter, { type AdapterOptions } from "@sveltejs/adapter-cloudflare";
+import type { Adapter } from "@sveltejs/kit";
 import { getPlatformProxyOptions } from "../cloudflare-env-proxy.ts";
 
-export default (options?: AdapterOptions) => {
+const isSvelteLanguageServer = !!process.argv.find((arg) => arg.includes(
+  "svelte-language-server",
+));
+
+export default (options?: AdapterOptions): Adapter => {
+  if (isSvelteLanguageServer) {
+    // the svelte language server runs from the root and therefore may be running in a different cwd than the `Website.cwd`
+    // for now, we work around this by returning a noop adapter to avoid breaking svelte intellisense
+    return {
+      adapt() {},
+      name: "alchemy-noop",
+    };
+  }
   const { platformProxy: proxyOptions, ...config } = options ?? {};
   const platformProxy = getPlatformProxyOptions(proxyOptions);
   return adapter({

--- a/alchemy/src/cloudflare/sveltekit/plugin.ts
+++ b/alchemy/src/cloudflare/sveltekit/plugin.ts
@@ -2,9 +2,9 @@ import adapter, { type AdapterOptions } from "@sveltejs/adapter-cloudflare";
 import type { Adapter } from "@sveltejs/kit";
 import { getPlatformProxyOptions } from "../cloudflare-env-proxy.ts";
 
-const isSvelteLanguageServer = !!process.argv.find((arg) => arg.includes(
-  "svelte-language-server",
-));
+const isSvelteLanguageServer = !!process.argv.find((arg) =>
+  arg.includes("svelte-language-server"),
+);
 
 export default (options?: AdapterOptions): Adapter => {
   if (isSvelteLanguageServer) {


### PR DESCRIPTION
The svelte language server always runs from the root of the workspace.

So, if you have a Website in `apps/web`, for example, the `svelte.config.js` will be evaluated from the root of the project instead of `apps/web`.

However, `alchemy dev` will run within `apps/web` and the `alchemy()` svelte plugin assumes to be run within the right directory to discover the .alchemy folder.

For now, we work around this by just returning a no-op adapter. I don't think our plugin is needed for the svelte language server intellisense to work.