### PR TITLE
fix(cli): adapt CI workflows to the user's chosen package manager

### DIFF
--- a/alchemy/bin/services/github-workflow.ts
+++ b/alchemy/bin/services/github-workflow.ts
@@ -1,8 +1,11 @@
+/** biome-ignore-all lint/suspicious/noTemplateCurlyInString: we are building a github template workflow */
 import { spinner } from "@clack/prompts";
-import * as fs from "fs-extra";
+import fs from "fs-extra";
 import path from "node:path";
+import YAML from "yaml";
 import { throwWithContext } from "../errors.ts";
 import type { ProjectContext } from "../types.ts";
+import { PackageManager } from "./package-manager.ts";
 
 export async function addGitHubWorkflowToAlchemy(
   context: ProjectContext,
@@ -16,120 +19,197 @@ export async function addGitHubWorkflowToAlchemy(
     const workflowDir = path.join(context.path, ".github", "workflows");
     await fs.ensureDir(workflowDir);
 
-    const prPreviewWorkflow = `name: Preview
+    const pmCommands =
+      PackageManager[context.packageManager] ?? PackageManager.bun;
+    const installCmd = pmCommands.install;
+    const runCmd = pmCommands.run;
 
-on:
-  pull_request:
-    types: [opened, reopened, synchronize, closed]
+    // Get the current Node.js major version
+    const nodeVersion = process.version.match(/^v(\d+)/)?.[1] || "22";
 
-# Ensure only one workflow runs at a time per PR
-concurrency:
-  group: "pr-preview-\${{ github.event.pull_request.number }}"
-  cancel-in-progress: false
+    const installRuntime =
+      context.packageManager === "bun"
+        ? {
+            name: "Setup Bun",
+            uses: "oven-sh/setup-bun@v1",
+            with: { "bun-version": "latest" },
+          }
+        : context.packageManager === "deno"
+          ? {
+              name: "Setup Deno",
+              uses: "denoland/setup-deno@v1",
+              with: { "deno-version": "v1.x" },
+            }
+          : {
+              name: "Setup Node.js",
+              uses: "actions/setup-node@v4",
+              with: {
+                "node-version": nodeVersion,
+                ...(context.packageManager === "pnpm" ||
+                context.packageManager === "yarn"
+                  ? { cache: context.packageManager }
+                  : {}),
+              },
+            };
 
-jobs:
-  deploy-preview:
-    if: \${{ github.event.action != 'closed' }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@v4
+    const installAdditionalPackageManager =
+      context.packageManager === "pnpm"
+        ? [
+            {
+              name: "Setup pnpm",
+              uses: "pnpm/action-setup@v3",
+              with: { version: "9" },
+            },
+          ]
+        : [];
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
-        with:
-          bun-version: latest
-
-      - name: Install dependencies
-        shell: bash
-        run: bun install
-
-      - name: Deploy Preview
-        run: bun run deploy --stage pr-\${{ github.event.pull_request.number }}
-        env:
-          GITHUB_SHA: \${{ github.event.pull_request.head.sha }}
-          GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
-          GITHUB_REPOSITORY_OWNER: \${{ github.repository_owner }}
-          GITHUB_REPOSITORY_NAME: \${{ github.event.repository.name }}
-          PULL_REQUEST: \${{ github.event.pull_request.number }}
-          CLOUDFLARE_API_TOKEN: \${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: \${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-
-  cleanup-preview:
-    if: \${{ github.event.action == 'closed' }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
-        with:
-          bun-version: latest
-
-      - name: Install dependencies
-        shell: bash
-        run: bun install
-
-      - name: Cleanup Preview
-        run: bun run destroy
-        env:
-          BRANCH_PREFIX: pr-\${{ github.event.pull_request.number }}
-          GITHUB_SHA: \${{ github.event.pull_request.head.sha }}
-          GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
-          GITHUB_REPOSITORY_OWNER: \${{ github.repository_owner }}
-          GITHUB_REPOSITORY_NAME: \${{ github.event.repository.name }}
-          PULL_REQUEST: \${{ github.event.pull_request.number }}
-          CLOUDFLARE_API_TOKEN: \${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: \${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-`;
-
-    const publishWorkflow = `name: Publish
-
-on:
-  push:
-    branches: [main]
-
-# Ensure only one workflow runs at a time
-concurrency:
-  group: "publish"
-  cancel-in-progress: false
-
-jobs:
-  publish:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
-        with:
-          bun-version: latest
-
-      - name: Install dependencies
-        shell: bash
-        run: bun install
-
-      - name: Deploy to Production
-        run: bun run deploy
-        env:
-          STAGE: prod
-          GITHUB_SHA: \${{ github.sha }}
-          CLOUDFLARE_API_TOKEN: \${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: \${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-`;
+    const installDependencies = {
+      name: "Install dependencies",
+      shell: "bash",
+      run: installCmd,
+    };
 
     await fs.writeFile(
       path.join(workflowDir, "pr-preview.yml"),
-      prPreviewWorkflow,
+      YAML.stringify({
+        name: "Preview",
+        on: {
+          pull_request: {
+            types: ["opened", "reopened", "synchronize", "closed"],
+          },
+        },
+        concurrency: {
+          group: "pr-preview-\${{ github.event.pull_request.number }}",
+          "cancel-in-progress": false,
+        },
+        jobs: {
+          "deploy-preview": {
+            if: "\${{ github.event.action != 'closed' }}",
+            "runs-on": "ubuntu-latest",
+            permissions: {
+              contents: "read",
+              "pull-requests": "write",
+            },
+            steps: [
+              { uses: "actions/checkout@v4" },
+              installRuntime,
+              ...installAdditionalPackageManager,
+              installDependencies,
+              {
+                name: "Deploy Preview",
+                run: `${runCmd} deploy --stage pr-\${{ github.event.pull_request.number }}`,
+                env: {
+                  GITHUB_SHA: "${{ github.event.pull_request.head.sha }}",
+                  GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}",
+                  GITHUB_REPOSITORY_OWNER: "${{ github.repository_owner }}",
+                  GITHUB_REPOSITORY_NAME: "${{ github.event.repository.name }}",
+                  PULL_REQUEST: "${{ github.event.pull_request.number }}",
+                  CLOUDFLARE_API_TOKEN: "${{ secrets.CLOUDFLARE_API_TOKEN }}",
+                  CLOUDFLARE_ACCOUNT_ID: "${{ secrets.CLOUDFLARE_ACCOUNT_ID }}",
+                },
+              },
+            ],
+          },
+          "cleanup-preview": {
+            if: "${{ github.event.action == 'closed' }}",
+            "runs-on": "ubuntu-latest",
+            permissions: {
+              contents: "read",
+              "pull-requests": "write",
+            },
+            steps: [
+              { uses: "actions/checkout@v4" },
+              installRuntime,
+              ...installAdditionalPackageManager,
+              installDependencies,
+              {
+                name: "Cleanup Preview",
+                run: `${runCmd} destroy`,
+                env: {
+                  BRANCH_PREFIX: "pr-${{ github.event.pull_request.number }}",
+                  GITHUB_SHA: "${{ github.event.pull_request.head.sha }}",
+                  GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}",
+                  GITHUB_REPOSITORY_OWNER: "${{ github.repository_owner }}",
+                  GITHUB_REPOSITORY_NAME: "${{ github.event.repository.name }}",
+                  PULL_REQUEST: "${{ github.event.pull_request.number }}",
+                  CLOUDFLARE_API_TOKEN: "${{ secrets.CLOUDFLARE_API_TOKEN }}",
+                  CLOUDFLARE_ACCOUNT_ID: "${{ secrets.CLOUDFLARE_ACCOUNT_ID }}",
+                },
+              },
+            ],
+          },
+        },
+      } as const),
     );
-    await fs.writeFile(path.join(workflowDir, "publish.yml"), publishWorkflow);
+    await fs.writeFile(
+      path.join(workflowDir, "publish.yml"),
+      YAML.stringify({
+        name: "Publish",
+        on: {
+          push: {
+            branches: ["main"],
+          },
+        },
+        concurrency: {
+          group: "publish",
+          "cancel-in-progress": false,
+        },
+        jobs: {
+          publish: {
+            "runs-on": "ubuntu-latest",
+            permissions: {
+              contents: "read",
+            },
+            steps: [
+              { uses: "actions/checkout@v4" },
+              context.packageManager === "bun"
+                ? {
+                    name: "Setup Bun",
+                    uses: "oven-sh/setup-bun@v1",
+                    with: { "bun-version": "latest" },
+                  }
+                : context.packageManager === "deno"
+                  ? {
+                      name: "Setup Deno",
+                      uses: "denoland/setup-deno@v1",
+                      with: { "deno-version": "v1.x" },
+                    }
+                  : {
+                      name: "Setup Node.js",
+                      uses: "actions/setup-node@v4",
+                      with: {
+                        "node-version": nodeVersion,
+                        ...(context.packageManager === "pnpm" ||
+                        context.packageManager === "yarn"
+                          ? { cache: context.packageManager }
+                          : {}),
+                      },
+                    },
+              ...(context.packageManager === "pnpm"
+                ? [
+                    {
+                      name: "Setup pnpm",
+                      uses: "pnpm/action-setup@v3",
+                      with: { version: "9" },
+                    },
+                  ]
+                : []),
+              { name: "Install dependencies", shell: "bash", run: installCmd },
+              {
+                name: "Deploy to Production",
+                run: `${runCmd} deploy`,
+                env: {
+                  STAGE: "prod",
+                  GITHUB_SHA: "${{ github.sha }}",
+                  CLOUDFLARE_API_TOKEN: "${{ secrets.CLOUDFLARE_API_TOKEN }}",
+                  CLOUDFLARE_ACCOUNT_ID: "${{ secrets.CLOUDFLARE_ACCOUNT_ID }}",
+                },
+              },
+            ],
+          },
+        },
+      } as const),
+    );
 
     let code = await fs.readFile(alchemyFilePath, "utf-8");
 


### PR DESCRIPTION
This changes our create template script to generate a github ci/cd workflow that installs the user's preferred package manager instead of assuming bun