### PR TITLE
feat(cli): susbtitute projectName construct stage-specific names

### DIFF
--- a/alchemy/bin/services/github-workflow.ts
+++ b/alchemy/bin/services/github-workflow.ts
@@ -221,6 +221,7 @@ export async function addGitHubWorkflowToAlchemy(
     );
 
     let code = await fs.readFile(alchemyFilePath, "utf-8");
+    code = code.replace("{projectName}", context.name);
 
     const alchemyImportRegex = /(import alchemy from "alchemy";)/;
     const alchemyImportMatch = code.match(alchemyImportRegex);
@@ -249,24 +250,6 @@ import { CloudflareStateStore } from "alchemy/state";`;
 });`,
       );
     }
-
-    const cloudflareResourceRegex =
-      /(await (?:Worker|TanStackStart|Nuxt|Astro|Website|SvelteKit|Redwood|ReactRouter|Vite)\([^,]+,\s*{[^}]*)(}\);)/g;
-    code = code.replace(
-      cloudflareResourceRegex,
-      (match, beforeClosing, closing) => {
-        if (beforeClosing.includes("version:")) {
-          return match;
-        }
-
-        const hasTrailingComma = beforeClosing.trim().endsWith(",");
-        const versionProp = hasTrailingComma
-          ? `  version: app.stage === "prod" ? undefined : app.stage,\n`
-          : `,\n  version: app.stage === "prod" ? undefined : app.stage,\n`;
-
-        return beforeClosing + versionProp + closing;
-      },
-    );
 
     const finalizeRegex = /(await app\.finalize\(\);)/;
     const finalizeMatch = code.match(finalizeRegex);

--- a/alchemy/templates/astro/alchemy.run.ts
+++ b/alchemy/templates/astro/alchemy.run.ts
@@ -3,9 +3,11 @@
 import alchemy from "alchemy";
 import { Astro } from "alchemy/cloudflare";
 
-const app = await alchemy("my-alchemy-app");
+const app = await alchemy("{projectName}");
 
-export const worker = await Astro("website");
+export const worker = await Astro("website", {
+  name: `${app.name}-${app.stage}-website`,
+});
 
 console.log({
   url: worker.url,

--- a/alchemy/templates/nuxt/alchemy.run.ts
+++ b/alchemy/templates/nuxt/alchemy.run.ts
@@ -3,9 +3,11 @@
 import alchemy from "alchemy";
 import { Nuxt } from "alchemy/cloudflare";
 
-const app = await alchemy("my-alchemy-app");
+const app = await alchemy("{projectName}");
 
-export const worker = await Nuxt("website");
+export const worker = await Nuxt("website", {
+  name: `${app.name}-${app.stage}-website`,
+});
 
 console.log({
   url: worker.url,

--- a/alchemy/templates/react-router/alchemy.run.ts
+++ b/alchemy/templates/react-router/alchemy.run.ts
@@ -3,9 +3,11 @@
 import alchemy from "alchemy";
 import { ReactRouter } from "alchemy/cloudflare";
 
-const app = await alchemy("my-alchemy-app");
+const app = await alchemy("{projectName}");
 
-export const worker = await ReactRouter("website");
+export const worker = await ReactRouter("website", {
+  name: `${app.name}-${app.stage}-website`,
+});
 
 console.log({
   url: worker.url,

--- a/alchemy/templates/rwsdk/alchemy.run.ts
+++ b/alchemy/templates/rwsdk/alchemy.run.ts
@@ -2,15 +2,15 @@
 import alchemy from "alchemy";
 import { D1Database, DurableObjectNamespace, Redwood } from "alchemy/cloudflare";
 
-const app = await alchemy("my-alchemy-app");
+const app = await alchemy("{projectName}");
     
 const database = await D1Database("database", {
-  name: "my-alchemy-app-db",
+  name: `${app.name}-${app.stage}-database`,
   migrationsDir: "migrations",
 });
 
 export const worker = await Redwood("website", {
-  name: "my-alchemy-app-website",
+  name: `${app.name}-${app.stage}-website`,
   bindings: {
     AUTH_SECRET_KEY: alchemy.secret(process.env.AUTH_SECRET_KEY),
     DB: database,

--- a/alchemy/templates/sveltekit/alchemy.run.ts
+++ b/alchemy/templates/sveltekit/alchemy.run.ts
@@ -3,9 +3,11 @@
 import alchemy from "alchemy";
 import { SvelteKit } from "alchemy/cloudflare";
 
-const app = await alchemy("my-alchemy-app");
+const app = await alchemy("{projectName}");
 
-export const worker = await SvelteKit("website");
+export const worker = await SvelteKit("website", {
+  name: `${app.name}-${app.stage}-website`,
+});
 
 console.log({
   url: worker.url,

--- a/alchemy/templates/tanstack-start/alchemy.run.ts
+++ b/alchemy/templates/tanstack-start/alchemy.run.ts
@@ -3,9 +3,11 @@
 import alchemy from "alchemy";
 import { TanStackStart } from "alchemy/cloudflare";
 
-const app = await alchemy("my-alchemy-app");
+const app = await alchemy("{projectName}");
 
-export const worker = await TanStackStart("website");
+export const worker = await TanStackStart("website", {
+  name: `${app.name}-${app.stage}-website`,
+});
 
 console.log({
   url: worker.url,

--- a/alchemy/templates/typescript/alchemy.run.ts
+++ b/alchemy/templates/typescript/alchemy.run.ts
@@ -3,10 +3,10 @@
 import alchemy from "alchemy";
 import { Worker } from "alchemy/cloudflare";
 
-const app = await alchemy("my-alchemy-app");
+const app = await alchemy("{projectName}");
 
 export const worker = await Worker("worker", {
-  name: "my-alchemy-app",
+  name: `${app.name}-${app.stage}-website`,
   entrypoint: "src/worker.ts",
 });
 

--- a/alchemy/templates/vite/alchemy.run.ts
+++ b/alchemy/templates/vite/alchemy.run.ts
@@ -3,9 +3,10 @@
 import alchemy from "alchemy";
 import { Vite } from "alchemy/cloudflare";
 
-const app = await alchemy("my-alchemy-app");
+const app = await alchemy("{projectName}");
 
 export const worker = await Vite("website", {
+  name: `${app.name}-${app.stage}-website`,
   entrypoint: "src/worker.ts",
 });
 


### PR DESCRIPTION
Updated all the templates to construct the name from the app name and stage

Example:
```ts
export const worker = await Astro("website", {
  name: `${app.name}-${app.stage}-website`,
});
```

Also removed the morph that would add `version: ` tag. Because DO migrations don't work in a preview worker, it's better to just deploy a whole separate worker.

A preview worker is only really helpful if you have a lot of static assets and want to avoid redundant uploads for each PR. But that should be done with knowledge of the drawbacks.