### PR TITLE
feat(cloudflare): flatten Website into Worker.assets

### DIFF
--- a/alchemy/src/cloudflare/vite/vite.ts
+++ b/alchemy/src/cloudflare/vite/vite.ts
@@ -1,6 +1,7 @@
 import { getPackageManagerRunner } from "../../util/detect-package-manager.ts";
 import type { Assets } from "../assets.ts";
 import type { Bindings } from "../bindings.ts";
+import { WebsitePlugin, type WebsitePluginProps } from "../website-plugin.ts";
 import { Website, type WebsiteProps } from "../website.ts";
 import type { Worker } from "../worker.ts";
 
@@ -11,11 +12,12 @@ export type Vite<B extends Bindings> = B extends { ASSETS: any }
   ? never
   : Worker<B & { ASSETS: Assets }>;
 
+const runner = await getPackageManagerRunner();
+
 export async function Vite<B extends Bindings>(
   id: string,
   props: ViteProps<B>,
 ): Promise<Vite<B>> {
-  const runner = await getPackageManagerRunner();
   return await Website(id, {
     ...props,
     spa: true,
@@ -30,5 +32,19 @@ export async function Vite<B extends Bindings>(
           },
     build: props.build ?? `${runner} vite build`,
     dev: props.dev ?? `${runner} vite dev`,
+  });
+}
+
+export type ViteAssetsProps = Partial<WebsitePluginProps>;
+export type ViteAssets = WebsitePlugin;
+
+export function ViteAssets(props: ViteAssetsProps = {}): WebsitePlugin {
+  return WebsitePlugin({
+    not_found_handling: "single-page-application",
+    build: props.build ?? `${runner} vite build`,
+    dev: props.dev ?? `${runner} vite dev`,
+    dist:
+      props.dist ??
+      ((props) => (props.entrypoint || props.script ? "dist/client" : "dist")),
   });
 }

--- a/alchemy/src/cloudflare/website-plugin.ts
+++ b/alchemy/src/cloudflare/website-plugin.ts
@@ -1,0 +1,300 @@
+import assert from "node:assert";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { Exec } from "../os/index.ts";
+import type { Scope } from "../scope.ts";
+import { isSecret } from "../secret.ts";
+import { dedent } from "../util/dedent.ts";
+import { Assets } from "./assets.ts";
+import type { Bindings } from "./bindings.ts";
+import { DEFAULT_COMPATIBILITY_DATE } from "./compatibility-date.gen.ts";
+import { unionCompatibilityFlags } from "./compatibility-presets.ts";
+import { writeMiniflareSymlink } from "./website.ts";
+import type { AssetsConfig, FinalWorkerProps, WorkerProps } from "./worker.ts";
+import { WranglerJson, type WranglerJsonSpec } from "./wrangler.json.ts";
+
+export interface WebsitePluginProps extends AssetsConfig {
+  /**
+   * Path to the main entrypoint script
+   */
+  main?: string;
+  /**
+   * The root directory of the project
+   * @default process.cwd()
+   */
+  cwd?: string;
+  /**
+   * Configuration for the build command
+   *
+   * If not provided, the build is assumed to have already happened.
+   */
+  build:
+    | string
+    | {
+        /**
+         * The command to run to build the site
+         */
+        command: string;
+        /**
+         * Additional environment variables to set when running the build command
+         */
+        env?: Record<string, string>;
+        /**
+         * Whether to memoize the command (only re-run if the command changes)
+         *
+         * When set to `true`, the command will only be re-executed if the command string changes.
+         *
+         * When set to an object with `patterns`, the command will be re-executed if either:
+         * 1. The command string changes, or
+         * 2. The contents of any files matching the glob patterns change
+         *
+         * ⚠️ **Important Note**: When using memoization with build commands, the build outputs
+         * will not be produced if the command is memoized. This is because the command is not
+         * actually executed when memoized. Consider disabling memoization in CI environments:
+         *
+         * @example
+         * // Disable memoization in CI to ensure build outputs are always produced
+         * await Website("my-website", {
+         *   command: "vite build",
+         *   memoize: process.env.CI ? false : {
+         *     patterns: ["./src/**"]
+         *   }
+         * });
+         *
+         * @default false
+         */
+        memoize?: boolean | { patterns: string[] };
+      };
+  /**
+   * Configuration for the dev command
+   */
+  dev?:
+    | string
+    | {
+        /**
+         * The command to run to start the dev server
+         */
+        command: string;
+        /**
+         * Additional environment variables to set when running the dev command
+         */
+        env?: Record<string, string>;
+      };
+  /**
+   * The directory containing static assets
+   */
+  dist: string | ((props: WorkerProps) => string);
+
+  /**
+   * Configuration for the wrangler.json file
+   */
+  wrangler?: {
+    /**
+     * Path to the wrangler.json file
+     *
+     * @default .alchemy/local/wrangler.jsonc
+     */
+    path?: string;
+    /**
+     * The main entry point for the worker
+     *
+     * @default worker.entrypoint
+     */
+    main?: string;
+    /**
+     * Hook to modify the wrangler.json object before it's written
+     *
+     * This function receives the generated wrangler.json spec and should return
+     * a modified version. It's applied as the final transformation before the
+     * file is written to disk.
+     *
+     * @param spec - The generated wrangler.json specification
+     * @returns The modified wrangler.json specification
+     */
+    transform?: (
+      spec: WranglerJsonSpec,
+    ) => WranglerJsonSpec | Promise<WranglerJsonSpec>;
+    /**
+     * Whether to include secrets in the wrangler.json file
+     *
+     * @default true if no path is specified, false otherwise
+     */
+    secrets?: boolean;
+  };
+}
+
+export function isWebsitePlugin(value: unknown): value is WebsitePlugin {
+  return typeof value === "object" && value !== null && "apply" in value;
+}
+
+export type WebsitePlugin = {
+  apply(
+    scope: Scope,
+    workerProps: WorkerProps<Bindings>,
+  ): Promise<FinalWorkerProps<Bindings>>;
+};
+
+export function WebsitePlugin<B extends Bindings>(
+  props: WebsitePluginProps,
+): WebsitePlugin {
+  return {
+    apply: async (
+      scope: Scope,
+      workerProps: WorkerProps<B>,
+    ): Promise<FinalWorkerProps<B>> => {
+      const build =
+        typeof props.build === "string"
+          ? { command: props.build }
+          : props.build;
+      const cwd = props.cwd ?? process.cwd();
+      const assets =
+        typeof props.dist === "string"
+          ? path.resolve(cwd, props.dist)
+          : props.dist(workerProps);
+      const local = path.resolve(cwd, ".alchemy", "local");
+      const entrypoint = path.resolve(
+        cwd,
+        workerProps.entrypoint ?? props.main ?? path.join(local, "worker.js"),
+      );
+      const wrangler = {
+        path: path.resolve(
+          cwd,
+          props.wrangler?.path ?? path.join(local, "wrangler.jsonc"),
+        ),
+        main: props.wrangler?.main
+          ? path.resolve(cwd, props.wrangler.main)
+          : entrypoint,
+      };
+
+      const secrets = props.wrangler?.secrets ?? !props.wrangler?.path;
+      const env = {
+        ...(process.env ?? {}),
+        ...(workerProps.env ?? {}),
+        ...Object.fromEntries(
+          Object.entries(workerProps.bindings ?? {}).flatMap(([key, value]) => {
+            if (typeof value === "string" || (isSecret(value) && secrets)) {
+              return [[key, value]];
+            }
+            return [];
+          }),
+        ),
+      };
+      const worker = {
+        ...workerProps,
+        noBundle: workerProps.noBundle ?? true,
+        cwd: path.relative(process.cwd(), cwd),
+        compatibilityFlags: unionCompatibilityFlags(
+          workerProps.compatibility,
+          workerProps.compatibilityFlags,
+        ),
+        compatibilityDate:
+          workerProps.compatibilityDate ?? DEFAULT_COMPATIBILITY_DATE,
+        assets: {
+          html_handling: props.html_handling ?? "auto-trailing-slash",
+          not_found_handling: props.not_found_handling ?? "none",
+          run_worker_first: props.run_worker_first ?? false,
+          _headers: props._headers,
+          _redirects: props._redirects,
+        },
+        entrypoint: path.relative(cwd, entrypoint),
+      } as FinalWorkerProps<B> & { name: string };
+
+      assert(
+        !workerProps.bindings?.ASSETS,
+        "ASSETS binding is reserved for internal use",
+      );
+      if (!workerProps.entrypoint) {
+        await fs.mkdir(path.dirname(entrypoint), { recursive: true });
+        const content =
+          workerProps.script ??
+          dedent`
+        export default {
+            async fetch(request, env) {
+                return new Response("Not Found", { status: 404 });
+            },
+        };`;
+        await fs.writeFile(entrypoint, content);
+      }
+
+      await writeMiniflareSymlink(cwd);
+
+      await WranglerJson("wrangler.jsonc", {
+        path: path.relative(cwd, wrangler.path),
+        worker,
+        assets: {
+          binding: "ASSETS",
+          directory: path.relative(cwd, assets),
+        },
+        main: path.relative(cwd, wrangler.main),
+        secrets,
+        transform: {
+          wrangler: props.wrangler?.transform,
+        },
+      });
+
+      if (build && !scope.local) {
+        await Exec("build", {
+          cwd: path.relative(process.cwd(), cwd),
+          command: build.command,
+          env: {
+            ...env,
+            ...(typeof build === "object" ? build.env : {}),
+            NODE_ENV: "production",
+          },
+          memoize: typeof build === "object" ? build.memoize : undefined,
+        });
+      }
+
+      let url: string | undefined;
+      if (props.dev && scope.local) {
+        url = await scope.spawn(worker.name, {
+          cmd: typeof props.dev === "string" ? props.dev : props.dev.command,
+          cwd: cwd,
+          extract: (line) => {
+            const URL_REGEX =
+              /http:\/\/(localhost|0\.0\.0\.0|127\.0\.0\.1|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}):\d+\/?/;
+            const match = line
+              .replace(/\x1B\[[0-9;]*[a-zA-Z]/g, "")
+              .match(URL_REGEX);
+            if (match) {
+              return match[0];
+            }
+          },
+          env: {
+            ...Object.fromEntries(
+              Object.entries(env ?? {}).flatMap(([key, value]) => {
+                if (isSecret(value)) {
+                  return [[key, value.unencrypted]];
+                }
+                if (typeof value === "string") {
+                  return [[key, value]];
+                }
+                return [];
+              }),
+            ),
+            ...(typeof props.dev === "object" ? props.dev.env : {}),
+            FORCE_COLOR: "1",
+            ...process.env,
+            // NOTE: we must set this to ensure the user does not accidentally set `NODE_ENV=production`
+            // which breaks `vite dev` (it won't, for example, re-write `process.env.TSS_APP_BASE` in the `.js` client side bundle)
+            NODE_ENV: "development",
+          },
+        });
+      }
+      return {
+        ...worker,
+        bindings: {
+          ...worker.bindings,
+          ...(!scope.local
+            ? {
+                ASSETS: await Assets("assets", {
+                  path: path.relative(process.cwd(), assets),
+                }),
+              }
+            : {}),
+        },
+        dev: url ? { url } : undefined,
+      } as FinalWorkerProps<B>;
+    },
+  };
+}

--- a/alchemy/src/cloudflare/website.ts
+++ b/alchemy/src/cloudflare/website.ts
@@ -12,7 +12,12 @@ import type { Bindings } from "./bindings.ts";
 import { DEFAULT_COMPATIBILITY_DATE } from "./compatibility-date.gen.ts";
 import { unionCompatibilityFlags } from "./compatibility-presets.ts";
 import { DEFAULT_PERSIST_PATH } from "./miniflare/paths.ts";
-import { type AssetsConfig, Worker, type WorkerProps } from "./worker.ts";
+import {
+  Worker,
+  type AssetsConfig,
+  type FinalWorkerProps,
+  type WorkerProps,
+} from "./worker.ts";
 import { WranglerJson, type WranglerJsonSpec } from "./wrangler.json.ts";
 
 export interface WebsiteProps<B extends Bindings>
@@ -253,7 +258,7 @@ export async function Website<B extends Bindings>(
       ...(typeof props.assets === "string" ? {} : props.assets),
     },
     entrypoint: path.relative(paths.cwd, paths.entrypoint),
-  } as WorkerProps<B> & { name: string };
+  } as FinalWorkerProps<B> & { name: string };
 
   return await alchemy.run(id, { parent: Scope.current }, async (scope) => {
     if (!workerProps.entrypoint) {
@@ -352,7 +357,7 @@ export async function Website<B extends Bindings>(
   });
 }
 
-async function writeMiniflareSymlink(cwd: string) {
+export async function writeMiniflareSymlink(cwd: string) {
   const target = path.resolve(DEFAULT_PERSIST_PATH);
   await fs.mkdir(target, { recursive: true });
 

--- a/alchemy/src/cloudflare/worker-assets.ts
+++ b/alchemy/src/cloudflare/worker-assets.ts
@@ -6,7 +6,7 @@ import { getContentType } from "../util/content-type.ts";
 import { CloudflareApiError } from "./api-error.ts";
 import type { CloudflareApi } from "./api.ts";
 import type { Assets } from "./assets.ts";
-import type { AssetsConfig, WorkerProps } from "./worker.ts";
+import type { AssetsConfig } from "./worker.ts";
 
 export interface AssetUploadResult {
   completionToken: string;
@@ -66,7 +66,7 @@ export async function uploadAssets(
   }: {
     workerName: string;
     assets: Assets;
-    assetConfig?: WorkerProps["assets"];
+    assetConfig?: AssetsConfig;
     namespace?: string;
   },
 ): Promise<AssetUploadResult> {

--- a/alchemy/src/cloudflare/worker-metadata.ts
+++ b/alchemy/src/cloudflare/worker-metadata.ts
@@ -207,7 +207,8 @@ export interface WorkerMetadata {
 
 export async function prepareWorkerMetadata(
   api: CloudflareApi,
-  props: Omit<WorkerProps, "entrypoint"> & {
+  props: Omit<WorkerProps, "entrypoint" | "assets"> & {
+    assets?: AssetsConfig;
     compatibilityDate: string;
     compatibilityFlags: string[];
     workerName: string;

--- a/alchemy/src/cloudflare/wrangler.json.ts
+++ b/alchemy/src/cloudflare/wrangler.json.ts
@@ -14,7 +14,7 @@ import type { DurableObjectNamespace } from "./durable-object-namespace.ts";
 import type { EventSource } from "./event-source.ts";
 import { isQueueEventSource } from "./event-source.ts";
 import { isQueue } from "./queue.ts";
-import type { Worker, WorkerProps } from "./worker.ts";
+import type { FinalWorkerProps, Worker } from "./worker.ts";
 
 type WranglerJsonRateLimit = Omit<WorkerBindingRateLimit, "type"> & {
   type: "rate_limit";
@@ -30,7 +30,7 @@ export interface WranglerJsonProps {
    */
   worker:
     | Worker
-    | (WorkerProps<any> & {
+    | (FinalWorkerProps<any> & {
         name: string;
       });
   /**

--- a/examples/cloudflare-vite/alchemy.run.ts
+++ b/examples/cloudflare-vite/alchemy.run.ts
@@ -1,7 +1,7 @@
 /// <reference types="node" />
 
 import alchemy from "alchemy";
-import { KVNamespace, Vite } from "alchemy/cloudflare";
+import { KVNamespace, ViteAssets, Worker } from "alchemy/cloudflare";
 
 const app = await alchemy("cloudflare-vite");
 
@@ -10,9 +10,9 @@ export const kv = await KVNamespace("kv", {
   adopt: true,
 });
 
-export const website = await Vite("website", {
-  entrypoint: "src/index.ts",
-  noBundle: false,
+export const website = await Worker("website", {
+  name: `${app.name}-${app.stage}-website`,
+  assets: ViteAssets(),
   adopt: true,
   bindings: {
     KV: kv,


### PR DESCRIPTION
```ts
export const website = await Worker("website", {
  name: `${app.name}-${app.stage}-website`,
  assets: ViteAssets(),
  adopt: true,
  bindings: {
    KV: kv,
    ALCHEMY_TEST_VALUE: alchemy.secret("Hello from Alchemy!"),
  },
});
```