### PR TITLE
fix(cloudflare): allow React Router apps to be deployed in SPA mode

### DIFF
--- a/alchemy/src/cloudflare/react-router/react-router.ts
+++ b/alchemy/src/cloudflare/react-router/react-router.ts
@@ -1,4 +1,6 @@
+import path from "node:path";
 import { getPackageManagerRunner } from "../../util/detect-package-manager.ts";
+import { logger } from "../../util/logger.ts";
 import type { Assets } from "../assets.ts";
 import type { Bindings } from "../bindings.ts";
 import { Vite, type ViteProps } from "../vite/vite.ts";
@@ -21,6 +23,8 @@ export async function ReactRouter<B extends Bindings>(
   props: ReactRouterProps<B> = {},
 ): Promise<ReactRouter<B>> {
   const runner = await getPackageManagerRunner();
+  const cwd = path.resolve(props.cwd ?? process.cwd());
+  const ssr = await detectSSREnabled(cwd);
   return await Vite(id, {
     ...props,
     build:
@@ -29,13 +33,50 @@ export async function ReactRouter<B extends Bindings>(
     dev:
       props.dev ??
       `${runner} react-router typegen && ${runner} react-router dev`,
+    spa: !ssr,
     compatibility: "node",
-    entrypoint: props.entrypoint ?? "build/server/index.js",
+    entrypoint: props.entrypoint ?? (ssr ? "build/server/index.js" : undefined),
     noBundle: props.noBundle ?? true,
     assets: props.assets ?? "build/client",
     wrangler: {
-      main: props.wrangler?.main ?? props.main ?? "workers/app.ts",
+      main:
+        props.wrangler?.main ??
+        props.main ??
+        (ssr ? "workers/app.ts" : undefined),
       transform: props.wrangler?.transform,
     },
   });
+}
+
+/**
+ * Detect if SSR is enabled by checking for an `ssr` property in `react-router.config.ts`.
+ * If no config is found or if there is no `ssr` property, default to true in line with React Router's default behavior.
+ * @see https://reactrouter.com/api/framework-conventions/react-router.config.ts
+ */
+async function detectSSREnabled(cwd: string): Promise<boolean> {
+  const candidates = [
+    "react-router.config.mjs",
+    "react-router.config.js",
+    "react-router.config.ts",
+    "react-router.config.mts",
+  ];
+  try {
+    const config = await Promise.any(
+      candidates.map((candidate) => import(path.join(cwd, candidate))),
+    );
+    if (
+      typeof config.default === "object" &&
+      config.default &&
+      "ssr" in config.default &&
+      typeof config.default.ssr === "boolean"
+    ) {
+      return config.default.ssr;
+    }
+    return true;
+  } catch {
+    logger.warn(
+      "[ReactRouter] No react-router.config.{ts,js,mts,mjs} found, assuming SSR is enabled",
+    );
+    return true;
+  }
 }

--- a/alchemy/src/cloudflare/react-router/react-router.ts
+++ b/alchemy/src/cloudflare/react-router/react-router.ts
@@ -55,10 +55,10 @@ export async function ReactRouter<B extends Bindings>(
  */
 async function detectSSREnabled(cwd: string): Promise<boolean> {
   const candidates = [
-    "react-router.config.mjs",
-    "react-router.config.js",
     "react-router.config.ts",
     "react-router.config.mts",
+    "react-router.config.mjs",
+    "react-router.config.js",
   ];
   try {
     const config = await Promise.any(

--- a/alchemy/src/cloudflare/vite/vite.ts
+++ b/alchemy/src/cloudflare/vite/vite.ts
@@ -4,8 +4,7 @@ import type { Bindings } from "../bindings.ts";
 import { Website, type WebsiteProps } from "../website.ts";
 import type { Worker } from "../worker.ts";
 
-export interface ViteProps<B extends Bindings>
-  extends Omit<WebsiteProps<B>, "spa"> {}
+export interface ViteProps<B extends Bindings> extends WebsiteProps<B> {}
 
 export type Vite<B extends Bindings> = B extends { ASSETS: any }
   ? never
@@ -17,8 +16,8 @@ export async function Vite<B extends Bindings>(
 ): Promise<Vite<B>> {
   const runner = await getPackageManagerRunner();
   return await Website(id, {
-    ...props,
     spa: true,
+    ...props,
     assets:
       typeof props.assets === "string"
         ? { directory: props.assets }


### PR DESCRIPTION
React Router doesn't currently work in SPA mode because the `ReactRouter` resource always expects a server entrypoint. To fix this:

- [x] Read `react-router.config.ts` to detect `ssr: false` (React Router v7 defaults to `ssr: true` unless the file is present and `ssr` is set to `false`; see [React Router docs](https://reactrouter.com/api/framework-conventions/react-router.config.ts))
- [x] If SSR is disabled, enable SPA mode in the Vite resource and avoid autofilling `worker.entrypoint` or `wrangler.main`