### PR TITLE
chore: change name of posthog override

### DIFF
--- a/alchemy/src/util/telemetry/constants.ts
+++ b/alchemy/src/util/telemetry/constants.ts
@@ -7,7 +7,7 @@ export const TELEMETRY_DISABLED =
 
 // TODO(sam): replace with permanent URL
 export const POSTHOG_CLIENT_API_HOST =
-  process.env.POSTHOG_CLIENT_API_HOST ?? "https://ph.alchemy.run";
+  process.env.ALCHEMY_POSTHOG_CLIENT_API_HOST ?? "https://ph.alchemy.run";
 export const POSTHOG_PROJECT_ID =
-  process.env.POSTHOG_PROJECT_ID ??
+  process.env.ALCHEMY_POSTHOG_PROJECT_ID ??
   "phc_A51Mi7Q63TvnNrvRMgvBxE1il0DAL66rVg4LdWPRsfK";


### PR DESCRIPTION
`POSTHOG_PROJECT_ID` is a very broad env variable name and users might end up setting it in their own projects without intending to override the alchemy one.

The name change just make it harder to accidentally override the telemetry id that alchemy points to 