### PR TITLE
fix(d1): use stable dev.id for applyLocalD1Migrations databaseId in local dev

### DIFF
--- a/alchemy/src/cloudflare/d1-database.ts
+++ b/alchemy/src/cloudflare/d1-database.ts
@@ -273,7 +273,7 @@ const _D1Database = Resource(
     if (local) {
       if (props.migrationsFiles && props.migrationsFiles.length > 0) {
         await applyLocalD1Migrations({
-          databaseId: this.output?.id ?? id,
+          databaseId: dev.id,
           migrationsTable: props.migrationsTable ?? DEFAULT_MIGRATIONS_TABLE,
           migrations: props.migrationsFiles,
         });


### PR DESCRIPTION

### Summary
Fix local D1 migrations applying to a secondary empty SQLite DB instead of the DB the Worker actually uses.

Fixes sam-goodwin/alchemy#886.

### Root Cause
In local dev, subsequent runs passed databaseId: "" into applyLocalD1Migrations due to:
  databaseId: this.output?.id ?? id

After the first run, this.output?.id becomes an empty string (""), which is truthy in TS, so databaseId is always "".  
Miniflare then creates a fresh DB under .alchemy/miniflare/v3 and applies migrations there, while the Worker continues querying the original DB whose schema never updates.

### The Change
Use the stable dev-phase id instead:
  databaseId: dev.id

where:
  const dev = { id: this.output?.dev?.id ?? this.output?.id ?? id, ... }

This keeps the same identifier across phases so migrations always target the exact DB the Worker binds to.

### Results
- Migrations apply to the same SQLite file the Worker queries.
- No extra fresh DBs are created under .alchemy/miniflare/v3 on subsequent runs.
- Verified by:
  1. Creating 5 tables via migrations
  2. Dropping 4 tables in a new migration
  3. Observing d1_migrations and table list through a test endpoint: schema updates now reflect in the active DB.

### Notes
- No behavior change in non-dev modes.
- Minimal surface area: only swaps the databaseId source.
