### PR TITLE
fix(cloudflare): skip path validation during astro output type check

### DIFF
--- a/alchemy/src/cloudflare/astro/astro.ts
+++ b/alchemy/src/cloudflare/astro/astro.ts
@@ -2,6 +2,7 @@ import { join, resolve } from "node:path";
 import { getPackageManagerRunner } from "../../util/detect-package-manager.ts";
 import type { Assets } from "../assets.ts";
 import type { Bindings } from "../bindings.ts";
+import { withSkipPathValidation } from "../miniflare/paths.ts";
 import { Website, type WebsiteProps } from "../website.ts";
 import type { Worker } from "../worker.ts";
 
@@ -92,7 +93,9 @@ async function resolveOutputType(cwd: string): Promise<"server" | "static"> {
   ];
   for (const candidate of candidates) {
     try {
-      const config = await import(join(cwd, candidate));
+      const config = await withSkipPathValidation(
+        () => import(join(cwd, candidate)),
+      );
       if (
         typeof config.default === "object" &&
         config.default &&

--- a/alchemy/src/cloudflare/miniflare/paths.ts
+++ b/alchemy/src/cloudflare/miniflare/paths.ts
@@ -1,4 +1,14 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import { existsSync, readlinkSync, statSync } from "node:fs";
+
+const dynamicImportContext = new AsyncLocalStorage<boolean>();
+
+/**
+ * Used to disable path validation during dynamic imports.
+ */
+export const withSkipPathValidation = <T>(callback: () => T) => {
+  return dynamicImportContext.run(true, callback);
+};
 
 export const DEFAULT_CONFIG_PATH = ".alchemy/local/wrangler.jsonc";
 export const DEFAULT_PERSIST_PATH = ".alchemy/miniflare/v3";
@@ -42,6 +52,9 @@ export const validatePersistPath = (
 const warned = new Set<string>();
 
 const warnOrThrow = (message: string, throws: boolean) => {
+  if (dynamicImportContext.getStore()) {
+    return;
+  }
   if (throws) {
     throw new Error(message);
   }


### PR DESCRIPTION
Closes #860.

Uses `AsyncLocalStorage` to detect when Miniflare path validation calls should not cause an error to be thrown.