### PR TITLE
chore: add robots.txt to docs

### DIFF
--- a/alchemy-web/public/robots.txt
+++ b/alchemy-web/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://alchemy.run/sitemap-index.xml


### PR DESCRIPTION
Our website doesn't have a robots.txt, which may prevent LLMs from reading our docs.