### PR TITLE
fix(core): support importing find-process on plain node

### DIFF
--- a/alchemy/src/cloudflare/durable-object-namespace.ts
+++ b/alchemy/src/cloudflare/durable-object-namespace.ts
@@ -19,7 +19,6 @@ export type DurableObjectNamespace<T = any> = {
   environment?: string;
   sqlite?: boolean;
   namespaceId?: string;
-  // @ts-expect-error - phantom type
   __service__: T;
 };
 

--- a/alchemy/src/neon/project.ts
+++ b/alchemy/src/neon/project.ts
@@ -636,7 +636,6 @@ export const NeonProject = Resource(
         roles: response.roles,
         // @ts-expect-error
         databases: response.databases,
-        // @ts-expect-error
         branch: response.branch,
         // @ts-expect-error
         endpoints: response.endpoints,

--- a/alchemy/src/util/idempotent-spawn.ts
+++ b/alchemy/src/util/idempotent-spawn.ts
@@ -135,7 +135,6 @@ export async function idempotentSpawn({
       if (await isSameProcess?.(pid)) return pid;
       if (processName) {
         const findProcess = await import("find-process");
-        console.log(findProcess);
         const find =
           (findProcess as any).default?.default ??
           (findProcess as any).default ??

--- a/alchemy/src/util/idempotent-spawn.ts
+++ b/alchemy/src/util/idempotent-spawn.ts
@@ -135,10 +135,13 @@ export async function idempotentSpawn({
       if (await isSameProcess?.(pid)) return pid;
       if (processName) {
         const findProcess = await import("find-process");
+        console.log(findProcess);
         const find =
+          (findProcess as any).default?.default ??
           (findProcess as any).default ??
           (findProcess as any).find ??
           findProcess;
+        // const { default: { default: find } } = await import("find-process");
         const processes = await find("pid", pid);
         if (processes.length > 1) {
           console.warn(

--- a/alchemy/src/util/idempotent-spawn.ts
+++ b/alchemy/src/util/idempotent-spawn.ts
@@ -134,7 +134,11 @@ export async function idempotentSpawn({
       if (isPidAlive(pid)) return pid;
       if (await isSameProcess?.(pid)) return pid;
       if (processName) {
-        const { default: find } = await import("find-process");
+        const findProcess = await import("find-process");
+        const find =
+          (findProcess as any).default ??
+          (findProcess as any).find ??
+          findProcess;
         const processes = await find("pid", pid);
         if (processes.length > 1) {
           console.warn(

--- a/alchemy/src/util/idempotent-spawn.ts
+++ b/alchemy/src/util/idempotent-spawn.ts
@@ -134,13 +134,6 @@ export async function idempotentSpawn({
       if (isPidAlive(pid)) return pid;
       if (await isSameProcess?.(pid)) return pid;
       if (processName) {
-        const findProcess = await import("find-process");
-        const find =
-          (findProcess as any).default?.default ??
-          (findProcess as any).default ??
-          (findProcess as any).find ??
-          findProcess;
-        // const { default: { default: find } } = await import("find-process");
         const processes = await find("pid", pid);
         if (processes.length > 1) {
           console.warn(
@@ -323,7 +316,7 @@ export async function idempotentSpawn({
     // 2. Detect if it's still running.
     // The process appears to remain in the process table even after it's exited, so `isPidAlive` will return true.
     // However, if it's in the table, `find-process` will return it with a name of "<defunct>", so we can detect that instead.
-    const { default: find } = await import("find-process");
+    // const { default: find } = await import("find-process");
     const processes = await find("pid", pid);
     if (processes.some((p) => p.name !== "<defunct>")) {
       // 3. If it's still running, kill with SIGKILL
@@ -332,4 +325,15 @@ export async function idempotentSpawn({
       } catch {}
     }
   }
+}
+
+type Find = typeof import("find-process").default;
+async function find(...args: Parameters<Find>): ReturnType<Find> {
+  const findProcess = await import("find-process");
+  const find =
+    (findProcess as any).default?.default ??
+    (findProcess as any).default ??
+    (findProcess as any).find ??
+    findProcess;
+  return find(...args);
 }

--- a/alchemy/src/util/idempotent-spawn.ts
+++ b/alchemy/src/util/idempotent-spawn.ts
@@ -327,8 +327,19 @@ export async function idempotentSpawn({
   }
 }
 
-type Find = typeof import("find-process").default;
-async function find(...args: Parameters<Find>): ReturnType<Find> {
+/**
+ * The find-process package is a bit of a mess and has different behavior across runtimes (bun, tsx, node, etc.)
+ *
+ * This wrapper function defensively searches for the find function in the imported module.
+ *
+ * It confirmed to support:
+ * 1. node
+ * 2. bun
+ * 3. tsx
+ *
+ * TODO(sam): check deno?
+ */
+const find: typeof import("find-process").default = async (...args) => {
   const findProcess = await import("find-process");
   const find =
     (findProcess as any).default?.default ??
@@ -336,4 +347,4 @@ async function find(...args: Parameters<Find>): ReturnType<Find> {
     (findProcess as any).find ??
     findProcess;
   return find(...args);
-}
+};


### PR DESCRIPTION
There was a bug with how we imported find-process that did not work in plain `node`, this adds some defensive checks to support `node`, `bun` and `tsx`