### PR TITLE
fix(cli): support alchemy.run.mts

### DIFF
--- a/alchemy/bin/services/execute-alchemy.ts
+++ b/alchemy/bin/services/execute-alchemy.ts
@@ -136,7 +136,7 @@ export async function execAlchemy(
   const execArgsString = execArgs.join(" ");
   // Determine the command to run based on package manager and file extension
   let command: string;
-  const isTypeScript = main.endsWith(".ts") || main.endsWith(".mts");
+  const isTypeScript = main.endsWith("ts");
 
   switch (packageManager) {
     case "bun":


### PR DESCRIPTION
If you're running within a CJS project, you're likely to run into errors with Alchemy unless your `alchemy.run` file is treated as ESM by naming it `alchemy.run.mts` or `alchemy.run.mjs`. #924 tries to fix that with better CJS support, but here's a simpler CLI-level solution.