### PR TITLE
fix(cloudflare): enforce stateToken requirement in CloudflareStateSto…

### DIFF
--- a/alchemy/src/state/cloudflare-state-store.ts
+++ b/alchemy/src/state/cloudflare-state-store.ts
@@ -49,16 +49,11 @@ export class CloudflareStateStore extends StateStoreProxy {
     super(scope);
     if (!options.stateToken && !process.env.ALCHEMY_STATE_TOKEN) {
       throw new Error(
-        "Missing token for DOStateStore. Please set ALCHEMY_STATE_TOKEN in the environment or set the `stateToken` option in the DOStateStore constructor. See https://alchemy.run/guides/cloudflare-state-store/",
+        "Missing token for CloudflareStateStore. Please set ALCHEMY_STATE_TOKEN in the environment or set the `stateToken` option in the CloudflareStateStore constructor. See https://alchemy.run/guides/cloudflare-state-store/",
       );
     }
     const stateToken =
       options.stateToken ?? alchemy.secret(process.env.ALCHEMY_STATE_TOKEN);
-    if (!stateToken) {
-      throw new Error(
-        "Missing token for DOStateStore. Please set ALCHEMY_STATE_TOKEN in the environment or set the `stateToken` option in the DOStateStore constructor.",
-      );
-    }
     this.options = {
       ...options,
       stateToken: stateToken,

--- a/alchemy/src/state/cloudflare-state-store.ts
+++ b/alchemy/src/state/cloudflare-state-store.ts
@@ -47,6 +47,11 @@ export class CloudflareStateStore extends StateStoreProxy {
   options: CloudflareStateStoreOptions & { stateToken: Secret<string> };
   constructor(scope: Scope, options: CloudflareStateStoreOptions = {}) {
     super(scope);
+    if (!options.stateToken && !process.env.ALCHEMY_STATE_TOKEN) {
+      throw new Error(
+        "Missing token for DOStateStore. Please set ALCHEMY_STATE_TOKEN in the environment or set the `stateToken` option in the DOStateStore constructor. See https://alchemy.run/guides/cloudflare-state-store/",
+      );
+    }
     const stateToken =
       options.stateToken ?? alchemy.secret(process.env.ALCHEMY_STATE_TOKEN);
     if (!stateToken) {


### PR DESCRIPTION
This fixes #926 which is occurring on all template starters, or anything that requires this `ALCHEMY_STATE_TOKEN` env var but doesn't specify it in the instructions. This just makes it a bit clearer when the error occurs by throwing before it gets to the secrets error handler.