### PR TITLE
fix(core): pass dedent tests

### DIFF
--- a/alchemy/src/util/dedent.ts
+++ b/alchemy/src/util/dedent.ts
@@ -1,5 +1,3 @@
-import assert from "node:assert";
-
 /**
  * Tagged template literal for removing indentation from a block of text.
  *
@@ -10,34 +8,48 @@ export function dedent(strings: TemplateStringsArray, ...values: unknown[]) {
   const raw = String.raw({ raw: strings }, ...values);
   // Split the string by lines
   let lines = raw.split("\n");
-  assert(lines.length > 0);
 
-  // If the last line is just whitespace, remove it
-  if (lines[lines.length - 1].trim() === "") {
-    lines = lines.slice(0, lines.length - 1);
-  }
-
-  // Find the minimum-length indent, excluding the first line
-  let minIndent = "";
-  // (Could use `minIndent.length` for this, but then would need to start with
-  // infinitely long string)
-  let minIndentLength = Number.POSITIVE_INFINITY;
-  for (const line of lines.slice(1)) {
-    const indent = line.match(/^[ \t]*/)?.[0];
-    if (indent != null && indent.length < minIndentLength) {
-      minIndent = indent;
-      minIndentLength = indent.length;
-    }
-  }
-
-  // If the first line is just whitespace, remove it
-  if (lines.length > 0 && lines[0].trim() === "") {
+  // Remove leading blank lines
+  while (lines.length > 0 && lines[0].trim() === "") {
     lines = lines.slice(1);
   }
 
-  // Remove indent from all lines, and return them all joined together
-  lines = lines.map((line) =>
-    line.startsWith(minIndent) ? line.substring(minIndent.length) : line,
-  );
+  // Remove trailing blank lines
+  while (lines.length > 0 && lines[lines.length - 1].trim() === "") {
+    lines = lines.slice(0, lines.length - 1);
+  }
+
+  // If no content lines remain, return empty string
+  if (lines.length === 0) {
+    return "";
+  }
+
+  // Find the minimum-length indent from content lines (non-blank lines)
+  let minIndentLength = Number.POSITIVE_INFINITY;
+  for (const line of lines) {
+    if (line.trim() !== "") {
+      const indent = line.match(/^[ \t]*/)?.[0];
+      if (indent != null && indent.length < minIndentLength) {
+        minIndentLength = indent.length;
+      }
+    }
+  }
+
+  // If no indentation found, return lines as-is
+  if (minIndentLength === Number.POSITIVE_INFINITY) {
+    return lines.join("\n");
+  }
+
+  // Remove indent from all lines, preserving blank lines
+  lines = lines.map((line) => {
+    if (line.trim() === "") {
+      return line; // Preserve blank lines
+    }
+    return line.startsWith(" ".repeat(minIndentLength)) ||
+      line.startsWith("\t".repeat(minIndentLength))
+      ? line.substring(minIndentLength)
+      : line;
+  });
+
   return lines.join("\n");
 }


### PR DESCRIPTION
Noticed that our `dedent` tests weren't passing.

Before:

```
 ❯ alchemy/test/util/dedent.test.ts (8 tests | 3 failed) 8ms
   ✓ dedent > removes common indentation 5ms
   × dedent > removes leading and trailing blank lines 5ms
     → expected '\n      line1\n      line2\n' to be 'line1\nline2' // Object.is equality
   ✓ dedent > preserves extra indentation 5ms
   ✓ dedent > handles empty template 5ms
   ✓ dedent > handles single line 5ms
   ✓ dedent > interpolates values correctly 1ms
   × dedent > preserves blank lines in between 1ms
     → expected '      line1\n\n      line3' to be 'line1\n\nline3' // Object.is equality
   × dedent > returns empty for only whitespace lines 1ms
     → expected '\n   ' to be '' // Object.is equality
```

After:

```
 ✓ alchemy/test/util/dedent.test.ts (8 tests) 2ms
   ✓ dedent > removes common indentation 1ms
   ✓ dedent > removes leading and trailing blank lines 1ms
   ✓ dedent > preserves extra indentation 1ms
   ✓ dedent > handles empty template 1ms
   ✓ dedent > handles single line 1ms
   ✓ dedent > interpolates values correctly 0ms
   ✓ dedent > preserves blank lines in between 0ms
   ✓ dedent > returns empty for only whitespace lines 0ms
 ```