### PR TITLE
feat(cloudflare): update oauth client id and storage path

### DIFF
--- a/alchemy/bin/commands/login.ts
+++ b/alchemy/bin/commands/login.ts
@@ -1,9 +1,9 @@
 import { cancel, intro, log, outro } from "@clack/prompts";
 import pc from "picocolors";
 import { zod as z } from "trpc-cli";
-import { DEFAULT_SCOPES, wranglerLogin } from "../../src/cloudflare/oauth.ts";
+import { DEFAULT_SCOPES, cloudflareLogin } from "../../src/cloudflare/oauth.ts";
 import { throwWithContext } from "../errors.ts";
-import { loggedProcedure, ExitSignal } from "../trpc.ts";
+import { ExitSignal, loggedProcedure } from "../trpc.ts";
 
 export const login = loggedProcedure
   .meta({
@@ -40,7 +40,7 @@ export const login = loggedProcedure
         );
         return;
       }
-      const result = await wranglerLogin(scopes, (message) => {
+      const result = await cloudflareLogin(scopes, (message) => {
         log.step(message);
       });
 


### PR DESCRIPTION
- [x] Use our Cloudflare OAuth client ID
- [x] Store credentials in `${os.homedir()}/.alchemy`
- [x] Update login command and Cloudflare API to use updated implementation

Still testing to figure out the minimum required scopes. So far, it seems that even if we request all available scopes, we still can't create an R2 bucket. I'll keep going through and running tests to identify any other glaring regressions compared to the Wrangler-based implementation.