### PR TITLE
chore(web): remove close button from auth callback pages

### DIFF
--- a/alchemy-web/src/components/AuthLayout.astro
+++ b/alchemy-web/src/components/AuthLayout.astro
@@ -3,12 +3,12 @@ export interface Props {
   title: string;
   message: string;
   variant?: 'success' | 'error';
-  primaryAction: {
+  primaryAction?: {
     text: string;
     href?: string;
     onClick?: string;
   };
-  secondaryAction: {
+  secondaryAction?: {
     text: string;
     href?: string;
     onClick?: string;
@@ -41,16 +41,21 @@ const { title, message, variant = 'success', primaryAction, secondaryAction } = 
       <p class="message" set:html={message} />
       
       <div class="button-container">
-        {primaryAction.href ? (
-          <a href={primaryAction.href} class="primary-button">{primaryAction.text}</a>
-        ) : (
-          <button class="primary-button" onclick={primaryAction.onClick}>{primaryAction.text}</button>
+        {primaryAction && ( 
+          primaryAction.href ? (
+            <a href={primaryAction.href} class="primary-button">{primaryAction.text}</a>
+          ) : (
+            <button class="primary-button" onclick={primaryAction.onClick}>{primaryAction.text}</button>
+          )
         )}
-        
-        {secondaryAction.href ? (
-          <a href={secondaryAction.href} class="secondary-button">{secondaryAction.text}</a>
-        ) : (
-          <button class="secondary-button" onclick={secondaryAction.onClick}>{secondaryAction.text}</button>
+          
+
+        {secondaryAction && (
+            secondaryAction.href ? (
+            <a href={secondaryAction.href} class="secondary-button">{secondaryAction.text}</a>
+          ) : (
+            <button class="secondary-button" onclick={secondaryAction.onClick}>{secondaryAction.text}</button>
+          )
         )}
       </div>
     </div>

--- a/alchemy-web/src/pages/auth/error.astro
+++ b/alchemy-web/src/pages/auth/error.astro
@@ -10,8 +10,4 @@ import AuthLayout from '../../components/AuthLayout.astro';
     text: "Learn More",
     href: "/guides/cloudflare/"
   }}
-  secondaryAction={{
-    text: "Close",
-    onClick: "window.close()"
-  }}
 />

--- a/alchemy-web/src/pages/auth/success.astro
+++ b/alchemy-web/src/pages/auth/success.astro
@@ -6,10 +6,6 @@ import AuthLayout from '../../components/AuthLayout.astro';
   title="Authentication Complete"
   message="Your credentials have been automatically generated.<br>You can close this window and return to Alchemy."
   variant="success"
-  primaryAction={{
-    text: "Close",
-    onClick: "window.close()"
-  }}
   secondaryAction={{
     text: "Learn More",
     href: "/getting-started/"

--- a/alchemy-web/src/pages/cloudflare/auth/callback.astro
+++ b/alchemy-web/src/pages/cloudflare/auth/callback.astro
@@ -6,10 +6,6 @@ import AuthLayout from '../../../components/AuthLayout.astro';
   title="Authentication Complete"
   message="Your authentication was successful.<br>You can close this window and return to Alchemy."
   variant="success"
-  primaryAction={{
-    text: 'Close',
-    onClick: 'window.close()'
-  }}
   secondaryAction={{
     text: 'Learn More',
     href: '/getting-started/'

--- a/alchemy-web/src/pages/cloudflare/auth/logout.astro
+++ b/alchemy-web/src/pages/cloudflare/auth/logout.astro
@@ -6,10 +6,6 @@ import AuthLayout from '../../../components/AuthLayout.astro';
   title="Logged Out"
   message="You have been logged out successfully.<br>You may close this window or continue browsing."
   variant="success"
-  primaryAction={{
-    text: 'Close',
-    onClick: 'window.close()'
-  }}
   secondaryAction={{
     text: 'Home',
     href: '/'


### PR DESCRIPTION
The auth callback pages on our website have a "close" button that doesn't work. Been meaning to remove it for a while.