### PR TITLE
Fix workspace root detection in nested monorepos

### DIFF
--- a/alchemy/bin/services/find-workspace-root.ts
+++ b/alchemy/bin/services/find-workspace-root.ts
@@ -1,48 +1,105 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 
-export async function findWorkspaceRoot(dir: string = process.cwd()) {
-  if ((await fs.stat(dir)).isDirectory()) {
-    if (await exists(dir, ".git")) {
-      // the root of the git repo is usually the workspace root and we should always stop here
-      return dir;
-    } else if ((await read(dir, "package.json"))?.workspaces) {
-      // package.json with workspaces (bun, npm, etc.)
-      return dir;
-    } else if (await anyExists(dir, ...rootFiles)) {
-      return dir;
-    }
-  }
-  return findWorkspaceRoot(path.resolve(dir, ".."));
-}
-
-const read = (...p: string[]): Promise<any> =>
-  fs
-    .readFile(path.join(...p), "utf8")
-    .then(JSON.parse)
-    .catch(() => undefined);
-
-const exists = (...p: string[]) =>
-  fs
-    .access(path.join(...p))
-    .then(() => true)
-    .catch(() => false);
-
-const anyExists = (base: string, ...files: string[]) =>
-  Promise.all(files.map((file) => exists(base, file))).then((results) =>
-    results.some(Boolean),
-  );
-
-const rootFiles = [
-  // pnpm
+// Clear separation of workspace marker types for better maintainability
+const WORKSPACE_CONFIGS = [
   "pnpm-workspace.yaml",
   "pnpm-workspace.yml",
-  // lerna
-  "lerna.json",
-  // nx
-  "nx.json",
-  // turbo
+  ".yarnrc.yml",
+  ".yarnrc", // Added support for Yarn Classic workspaces
+] as const;
+
+const TOOL_SPECIFIC_CONFIGS = [
   "turbo.json",
-  // rush
+  "nx.json",
+  "lerna.json",
   "rush.json",
-];
+] as const;
+
+export async function findWorkspaceRoot(
+  dir: string = process.cwd(),
+): Promise<string> {
+  let currentDir = path.resolve(dir);
+
+  // Track first tool-specific config found during traversal.
+  // We continue searching for authoritative markers (.git, workspace configs)
+  // but fall back to this if nothing better is found.
+  let toolConfigDir: string | null = null;
+
+  // Use filesystem root as natural boundary instead of arbitrary iteration limit
+  const fsRoot = path.parse(currentDir).root;
+
+  while (currentDir !== fsRoot) {
+    try {
+      const stat = await fs.stat(currentDir);
+      if (!stat.isDirectory()) {
+        currentDir = path.dirname(currentDir);
+        continue;
+      }
+
+      // 1. Check for .git directory (absolute boundary - always stops here)
+      if (await exists(currentDir, ".git")) {
+        return currentDir;
+      }
+
+      // 2. Check for package.json with workspaces field
+      const packageJson = await readJson(currentDir, "package.json");
+      if (packageJson?.workspaces) {
+        return currentDir;
+      }
+
+      // 3. Check for other workspace configuration files (batch for efficiency)
+      if (await anyExists(currentDir, ...WORKSPACE_CONFIGS)) {
+        return currentDir;
+      }
+
+      // 4. Remember first tool-specific config as fallback (but keep searching upward)
+      if (
+        !toolConfigDir &&
+        (await anyExists(currentDir, ...TOOL_SPECIFIC_CONFIGS))
+      ) {
+        toolConfigDir = currentDir;
+      }
+    } catch (error: any) {
+      // Only continue on expected filesystem errors (permission denied, not found)
+      // Throw unexpected errors for debugging
+      if (error?.code !== "EACCES" && error?.code !== "ENOENT") {
+        throw error;
+      }
+    }
+
+    currentDir = path.dirname(currentDir);
+  }
+
+  // Return in priority order: tool config if found, otherwise original directory
+  return toolConfigDir ?? dir;
+}
+
+// Helper to read and parse JSON files safely
+const readJson = async (...p: string[]): Promise<any> => {
+  try {
+    const content = await fs.readFile(path.join(...p), "utf8");
+    return JSON.parse(content);
+  } catch {
+    return undefined;
+  }
+};
+
+// Check if a file or directory exists
+const exists = async (...p: string[]): Promise<boolean> => {
+  try {
+    await fs.access(path.join(...p));
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+// Check if any of the provided files exist in the base directory
+const anyExists = async (
+  base: string,
+  ...files: readonly string[]
+): Promise<boolean> => {
+  const results = await Promise.all(files.map((file) => exists(base, file)));
+  return results.some(Boolean);
+};


### PR DESCRIPTION
## Summary

Fixes an issue with workspace root detection that causes apps to hang when using the new `--app` flag introduced in #953.

## Context

PR #953 added support for multi-app, interconnected monorepos with the `--app` flag. However, when apps have their own `turbo.json` files (common in Turborepo), the workspace root detection fails, causing module resolution to hang.

## The Problem

When using `--app frontend`, the `findWorkspaceRoot` function:
1. Starts searching from the app directory
2. Finds `turbo.json` in `apps/frontend/` 
3. **Incorrectly stops there** instead of continuing to the monorepo root
4. Passes wrong `--root-dir` to the alchemy process
5. Module imports like `import { backend } from "backend/alchemy"` fail to resolve
6. Process hangs indefinitely

This breaks the interconnected app pattern.

## The Solution

This PR fixes `findWorkspaceRoot` to properly handle nested monorepos by:
- Prioritizing authoritative markers (`.git`, `package.json` with workspaces)
- Treating tool configs (`turbo.json`, `nx.json`) as fallbacks only
- Continuing to search upward even after finding tool configs

## Reproduction

I've created a minimal reproduction with testing steps here: https://github.com/ghostwriternr/alchemy-root-detection-repro

## Impact

This fix enables the monorepo support to work with Turborepo projects where apps have their own `turbo.json` files extending the root config.

## AI usage
Claude Code was used to create this PR. Unfortunately don't have the prompts because I spun the conversation off from a session on my personal project, starting with debugging the issue.