### PR TITLE
fix(cloudflare): remove ai gateway binding type

### DIFF
--- a/alchemy-web/src/content/docs/providers/cloudflare/ai-gateway.md
+++ b/alchemy-web/src/content/docs/providers/cloudflare/ai-gateway.md
@@ -95,15 +95,19 @@ await Worker("chat-worker", {
 // src/worker.ts
 export default {
   async fetch(request, env) {
-    const { message } = await request.json();
+    const { prompt } = await request.json();
 
-    const response = await env.AI.run("@cf/meta/llama-3.1-8b-instruct", {
-      messages: [{ role: "user", content: message }],
-      gateway: {
-        id: env.GATEWAY_ID,
-        skipCache: true,
+    const response = await env.AI.run(
+      "@cf/meta/llama-3.1-8b-instruct-fast",
+      {
+        prompt,
       },
-    });
+      {
+        gateway: {
+          id: env.GATEWAY_ID,
+        },
+      },
+    );
 
     return Response.json({ response: response.response });
   },

--- a/alchemy-web/src/content/docs/providers/cloudflare/ai-gateway.md
+++ b/alchemy-web/src/content/docs/providers/cloudflare/ai-gateway.md
@@ -53,7 +53,7 @@ const loggingGateway = await AiGateway("logging-gateway", {
 Use the AI Gateway in a Cloudflare Worker:
 
 ```ts
-import { Worker, AiGateway } from "alchemy/cloudflare";
+import { Worker, Ai, AiGateway } from "alchemy/cloudflare";
 
 const gateway = await AiGateway("my-gateway", {
   name: "my-gateway",
@@ -63,7 +63,8 @@ await Worker("my-worker", {
   name: "my-worker",
   script: "console.log('Hello, world!')",
   bindings: {
-    AI: gateway,
+    AI: Ai(),
+    GATEWAY_ID: gateway.id,
   },
 });
 ```
@@ -73,7 +74,7 @@ await Worker("my-worker", {
 Here's a simple example showing how to use AI Gateway in a Cloudflare Worker:
 
 ```ts
-import { Worker, AiGateway } from "alchemy/cloudflare";
+import { Worker, Ai, AiGateway } from "alchemy/cloudflare";
 
 const aiGateway = await AiGateway("chat-gateway", {
   rateLimitingInterval: 60,
@@ -84,7 +85,8 @@ const aiGateway = await AiGateway("chat-gateway", {
 await Worker("chat-worker", {
   entrypoint: "./src/worker.ts",
   bindings: {
-    AI: aiGateway,
+    AI: Ai(),
+    GATEWAY_ID: aiGateway.id,
   },
 });
 ```
@@ -97,6 +99,10 @@ export default {
 
     const response = await env.AI.run("@cf/meta/llama-3.1-8b-instruct", {
       messages: [{ role: "user", content: message }],
+      gateway: {
+        id: env.GATEWAY_ID,
+        skipCache: true,
+      },
     });
 
     return Response.json({ response: response.response });

--- a/alchemy/src/cloudflare/bindings.ts
+++ b/alchemy/src/cloudflare/bindings.ts
@@ -4,7 +4,6 @@
  * https://developers.cloudflare.com/api/resources/workers/subresources/scripts/methods/update/
  */
 import type { Secret } from "../secret.ts";
-import type { AiGateway } from "./ai-gateway.ts";
 import type { Ai } from "./ai.ts";
 import type { AnalyticsEngineDataset } from "./analytics-engine.ts";
 import type { Assets } from "./assets.ts";
@@ -45,7 +44,6 @@ export declare namespace Bindings {
  */
 export type Binding =
   | Ai
-  | AiGateway
   | Assets
   | Container
   | CloudflareSecret

--- a/alchemy/src/cloudflare/bound.ts
+++ b/alchemy/src/cloudflare/bound.ts
@@ -1,6 +1,5 @@
 import type {
   Ai,
-  AiGateway,
   AnalyticsEngineDataset,
   D1Database,
   DispatchNamespace,
@@ -21,7 +20,6 @@ import type {
 } from "@cloudflare/workers-types";
 import type { Pipeline } from "cloudflare:pipelines";
 import type { Secret } from "../secret.ts";
-import type { AiGateway as _AiGateway } from "./ai-gateway.ts";
 import type { Ai as _Ai } from "./ai.ts";
 import type { AnalyticsEngineDataset as _AnalyticsEngineDataset } from "./analytics-engine.ts";
 import type { Assets } from "./assets.ts";
@@ -70,53 +68,51 @@ export type Bound<T extends Binding> = T extends _DurableObjectNamespace<
           ? Service
           : T extends _R2Bucket
             ? R2Bucket
-            : T extends _AiGateway
-              ? AiGateway
-              : T extends _Hyperdrive
-                ? Hyperdrive
-                : T extends Secret
-                  ? string
-                  : T extends CloudflareSecret
-                    ? SecretsStoreSecret
-                    : T extends SecretKey
-                      ? CryptoKey
-                      : T extends Assets
-                        ? Service
-                        : T extends _Workflow<infer P>
-                          ? Workflow<P>
-                          : T extends _D1Database
-                            ? D1Database
-                            : T extends DispatchNamespace
-                              ? DispatchNamespace
-                              : T extends _VectorizeIndex
-                                ? VectorizeIndex
-                                : T extends _Queue<infer Body>
-                                  ? Queue<Body>
-                                  : T extends _AnalyticsEngineDataset
-                                    ? AnalyticsEngineDataset
-                                    : T extends _Pipeline<infer R>
-                                      ? Pipeline<R>
-                                      : T extends _RateLimit
-                                        ? RateLimit
-                                        : T extends string
-                                          ? string
-                                          : T extends BrowserRendering
-                                            ? Fetcher
-                                            : T extends _Ai<infer M>
-                                              ? Ai<M>
-                                              : T extends _Images
-                                                ? ImagesBinding
-                                                : T extends _VersionMetadata
-                                                  ? WorkerVersionMetadata
-                                                  : T extends Self
-                                                    ? Service
-                                                    : T extends Json<infer T>
-                                                      ? T
-                                                      : T extends _Container<
-                                                            infer Obj
-                                                          >
-                                                        ? DurableObjectNamespace<
-                                                            Obj &
-                                                              Rpc.DurableObjectBranded
-                                                          >
-                                                        : Service;
+            : T extends _Hyperdrive
+              ? Hyperdrive
+              : T extends Secret
+                ? string
+                : T extends CloudflareSecret
+                  ? SecretsStoreSecret
+                  : T extends SecretKey
+                    ? CryptoKey
+                    : T extends Assets
+                      ? Service
+                      : T extends _Workflow<infer P>
+                        ? Workflow<P>
+                        : T extends _D1Database
+                          ? D1Database
+                          : T extends DispatchNamespace
+                            ? DispatchNamespace
+                            : T extends _VectorizeIndex
+                              ? VectorizeIndex
+                              : T extends _Queue<infer Body>
+                                ? Queue<Body>
+                                : T extends _AnalyticsEngineDataset
+                                  ? AnalyticsEngineDataset
+                                  : T extends _Pipeline<infer R>
+                                    ? Pipeline<R>
+                                    : T extends _RateLimit
+                                      ? RateLimit
+                                      : T extends string
+                                        ? string
+                                        : T extends BrowserRendering
+                                          ? Fetcher
+                                          : T extends _Ai<infer M>
+                                            ? Ai<M>
+                                            : T extends _Images
+                                              ? ImagesBinding
+                                              : T extends _VersionMetadata
+                                                ? WorkerVersionMetadata
+                                                : T extends Self
+                                                  ? Service
+                                                  : T extends Json<infer T>
+                                                    ? T
+                                                    : T extends _Container<
+                                                          infer Obj
+                                                        >
+                                                      ? DurableObjectNamespace<
+                                                          Obj &
+                                                            Rpc.DurableObjectBranded
+                                                        >
+                                                      : Service;

--- a/alchemy/src/cloudflare/miniflare/build-worker-options.ts
+++ b/alchemy/src/cloudflare/miniflare/build-worker-options.ts
@@ -29,7 +29,6 @@ export interface MiniflareWorkerInput {
 
 type RemoteOnlyBindingType =
   | "ai"
-  | "ai_gateway"
   | "browser"
   | "dispatch_namespace"
   | "mtls_certificate"
@@ -97,8 +96,13 @@ export const buildWorkerOptions = async (
       continue;
     }
     switch (binding.type) {
-      case "ai":
-      case "ai_gateway": {
+      case "ai": {
+        const existing = remoteBindings.find((b) => b.type === "ai");
+        if (existing) {
+          throw new Error(
+            `Workers cannot have multiple AI bindings. Binding "${key}" conflicts with "${existing.name}".`,
+          );
+        }
         remoteBindings.push({
           type: "ai",
           name: key,

--- a/alchemy/src/cloudflare/worker-metadata.ts
+++ b/alchemy/src/cloudflare/worker-metadata.ts
@@ -491,12 +491,6 @@ export async function prepareWorkerMetadata(
         name: bindingName,
         index_name: binding.name,
       });
-    } else if (binding.type === "ai_gateway") {
-      // AI Gateway binding - just needs the name property
-      meta.bindings.push({
-        type: "ai",
-        name: bindingName,
-      });
     } else if (binding.type === "hyperdrive") {
       // Hyperdrive binding
       meta.bindings.push({
@@ -510,6 +504,12 @@ export async function prepareWorkerMetadata(
         name: bindingName,
       });
     } else if (binding.type === "ai") {
+      const existing = meta.bindings.find((b) => b.type === "ai");
+      if (existing) {
+        throw new Error(
+          `Workers cannot have multiple AI bindings. Binding "${bindingName}" conflicts with "${existing.name}".`,
+        );
+      }
       meta.bindings.push({
         type: "ai",
         name: bindingName,


### PR DESCRIPTION
We had a hallucinated binding type for our `AiGateway` resource. This removes the mistaken type, updates the docs to explain how to use it correctly, and adds some checks to ensure you don't mistakenly try to add more than one AI binding (this seems to be unsupported).

Tested this manually but should I update `ai-gateway.test.ts` too?

Closes #962.