### PR TITLE
fix(cli): ignore turbo.json when finding workspace root

### DIFF
--- a/alchemy/bin/services/find-workspace-root.ts
+++ b/alchemy/bin/services/find-workspace-root.ts
@@ -42,7 +42,7 @@ const rootFiles = [
   // nx
   "nx.json",
   // turbo
-  "turbo.json",
+  // "turbo.json",
   // rush
   "rush.json",
 ];


### PR DESCRIPTION
See: https://github.com/sam-goodwin/alchemy/pull/961

`turbo.json` is not a good indicator of a monorepo root, so we should ignore it and rely on finding the workspaces config.