### PR TITLE
Add GITHUB_TOKEN to CI guide

### DIFF
--- a/alchemy-web/src/content/docs/guides/ci.mdx
+++ b/alchemy-web/src/content/docs/guides/ci.mdx
@@ -127,6 +127,7 @@ export function DeployWorkflow({ manager = "bun" }) {
               CLOUDFLARE_EMAIL: "${{ secrets.CLOUDFLARE_EMAIL }}",
               PULL_REQUEST: "${{ github.event.number }}",
               GITHUB_SHA: "${{ github.sha }}",
+              GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }},
             },
           },
         ],


### PR DESCRIPTION
The fix adds GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} to the deployment step. The GITHUB_TOKEN is automatically provided by GitHub Actions and has the necessary permissions.


Otherwise:

```
ERROR Scope failed api/pr-69/preview-comment
WARN Scope is in error, skipping finalize
ERROR Scope failed api/pr-69
node:internal/modules/run_main:123
    triggerUncaughtException(
    ^

Error: GitHub repository not found
```