### PR TITLE
fix(cloudflare): local workers fail to initialize concurrently

### DIFF
--- a/alchemy/src/cloudflare/worker.ts
+++ b/alchemy/src/cloudflare/worker.ts
@@ -34,6 +34,7 @@ import {
 } from "./durable-object-namespace.ts";
 import { type EventSource, isQueueEventSource } from "./event-source.ts";
 import { deleteMiniflareWorkerData } from "./miniflare/delete.ts";
+import { MiniflareController } from "./miniflare/miniflare-controller.ts";
 import {
   QueueConsumer,
   deleteQueueConsumer,
@@ -870,11 +871,7 @@ const _Worker = Resource(
       if (props.dev?.url) {
         url = props.dev.url;
       } else {
-        const { MiniflareController } = await import(
-          "./miniflare/miniflare-controller.js"
-        );
-        const controller = MiniflareController.singleton;
-        url = await controller.add({
+        url = await MiniflareController.singleton.add({
           api,
           id,
           name: options.name,
@@ -887,7 +884,7 @@ const _Worker = Resource(
           port: props.dev?.port,
           tunnel: props.dev?.tunnel ?? this.scope.tunnel,
         });
-        this.onCleanup(() => controller.dispose());
+        this.onCleanup(() => MiniflareController.singleton.dispose());
       }
       await provisionResources(
         {


### PR DESCRIPTION
## Changes

- [x] In the `Worker` resource, change the `MiniflareController` import from a dynamic import to a standard one.
- [x] In `createMiniflareWorkerProxy`, retry `server.listen()` on the next port if an `EADDRINUSE` error is encountered.
- [ ] Smoke tests are getting stuck... will verify no regressions before marking ready for review.

## Background

If you initialize multiple `Worker` resources concurrently in dev mode, this may create a race condition that prevents the dev server from starting. This seems to be because the `MiniflareController` is imported dynamically, which prevents the mutex from working as expected. In Node, this shows as an `EADDRINUSE` error; in Bun, it shows as something more cryptic:

```zsh
869 |       let url: string | undefined;
870 |       if (props.dev?.url) {
871 |         url = props.dev.url;
872 |       } else {
873 |         const { MiniflareController } = await import(
874 |           "./miniflare/miniflare-controller.js"
                ^
ReferenceError: Cannot access 'MiniflareController' before initialization.
      at /Users/johnroyal/Developer/Alchemy/alchemy/alchemy/src/cloudflare/worker.ts:874:11
      at processTicksAndRejections (native:7:39)

Bun v1.2.22 (macOS arm64)
```

This is exacerbated when the port is hard-coded, as there is no fallback mechanism for binding to the next available port.

### Reproduction

```ts title="alchemy.run.ts"
// bun run alchemy.run.ts --dev

import alchemy from "alchemy";
import { Worker } from "alchemy/cloudflare";

const app = await alchemy("concurrent-worker-test");

const workers = await Promise.all(
  Array.from({ length: 10 }).map((_, i) =>
    Worker(`worker-${i}`, {
      name: `worker-${i}`,
      script: `export default {
    async fetch(request, env, ctx) {
      return new Response("Hello world!");
    }
  }`,
    }),
  ),
);

console.log(workers.map((worker) => worker.url));

await app.finalize();

```