### PR TITLE
fix(cloudflare): wasm bundling fails when imported from nested directory

### DIFF
--- a/alchemy/package.json
+++ b/alchemy/package.json
@@ -277,6 +277,7 @@
     "arktype": "^2.1.16",
     "astro": "^5.13.2",
     "braintrust": "^0.0.201",
+    "cojson-core-wasm": "^0.18.16",
     "cpx": "^1.5.0",
     "debug": "^4.4.1",
     "dofs": "^0.1.0",

--- a/alchemy/src/cloudflare/bundle/plugin-wasm.ts
+++ b/alchemy/src/cloudflare/bundle/plugin-wasm.ts
@@ -35,11 +35,11 @@ export function createWasmPlugin() {
         );
 
         // Copy to outdir so it's included in the upload
-        await fs.mkdir(outdir, { recursive: true });
-        await fs.copyFile(
-          path.join(args.resolveDir, name),
-          path.join(outdir, name),
-        );
+        const copyFrom = path.join(args.resolveDir, name);
+        const copyTo = path.join(outdir, name);
+        await fs.mkdir(path.dirname(copyTo), { recursive: true });
+        await fs.copyFile(copyFrom, copyTo);
+
         modules.set(args.path, {
           type: "wasm",
           path: name,

--- a/alchemy/test/cloudflare/bundle.test.ts
+++ b/alchemy/test/cloudflare/bundle.test.ts
@@ -173,4 +173,23 @@ describe("Bundle Worker Test", () => {
       await destroy(scope);
     }
   });
+
+  test("should bundle cojson-core-wasm/edge-lite", async (scope) => {
+    const workerName = `${BRANCH_PREFIX}-test-worker-cojson-wasm`;
+
+    try {
+      await Worker(workerName, {
+        name: workerName,
+        entrypoint: path.join(
+          import.meta.dirname,
+          "test-handlers/cojson-wasm.ts",
+        ),
+        compatibilityFlags: ["nodejs_compat"],
+        compatibilityDate: "2025-08-20",
+        adopt: true,
+      });
+    } finally {
+      await destroy(scope);
+    }
+  });
 });

--- a/alchemy/test/cloudflare/test-handlers/cojson-wasm.ts
+++ b/alchemy/test/cloudflare/test-handlers/cojson-wasm.ts
@@ -1,0 +1,8 @@
+import { initialize } from "cojson-core-wasm/edge-lite";
+
+export default {
+  async fetch() {
+    await initialize();
+    return new Response("Hello, world!");
+  },
+};

--- a/bun.lock
+++ b/bun.lock
@@ -85,6 +85,7 @@
         "arktype": "^2.1.16",
         "astro": "^5.13.2",
         "braintrust": "^0.0.201",
+        "cojson-core-wasm": "^0.18.16",
         "cpx": "^1.5.0",
         "debug": "^4.4.1",
         "dofs": "^0.1.0",
@@ -2700,6 +2701,8 @@
     "cluster-key-slot": ["cluster-key-slot@1.1.2", "", {}, "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA=="],
 
     "code-block-writer": ["code-block-writer@13.0.3", "", {}, "sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg=="],
+
+    "cojson-core-wasm": ["cojson-core-wasm@0.18.16", "", {}, "sha512-srcUXXKh06K5j5eBZaabsM2tP7tVjbzstqQmnwAQwybXM/PMarDw0LBF4xNo/zCtmoNpFnJlfUlyCPIVJ41tnw=="],
 
     "collapse-white-space": ["collapse-white-space@2.1.0", "", {}, "sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw=="],
 
@@ -5635,7 +5638,7 @@
 
     "alchemy/@types/bun": ["@types/bun@1.2.22", "", { "dependencies": { "bun-types": "1.2.22" } }, "sha512-5A/KrKos2ZcN0c6ljRSOa1fYIyCKhZfIVYeuyb4snnvomnpFqC0tTsEkdqNxbAgExV384OETQ//WAjl3XbYqQA=="],
 
-    "alchemy/@types/node": ["@types/node@24.5.1", "", { "dependencies": { "undici-types": "~7.12.0" } }, "sha512-/SQdmUP2xa+1rdx7VwB9yPq8PaKej8TD5cQ+XfKDPWWC+VDJU4rvVVagXqKUzhKjtFoNA8rXDJAkCxQPAe00+Q=="],
+    "alchemy/@types/node": ["@types/node@24.5.2", "", { "dependencies": { "undici-types": "~7.12.0" } }, "sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ=="],
 
     "alchemy/glob": ["glob@10.4.5", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg=="],
 


### PR DESCRIPTION
A user was unable to deploy a worker that imports from `cojson-core-wasm/edge-lite`. This was because the wasm file was located in a nested directory of the `cojson-core-wasm` package, so when we copy the WASM file into the bundle, we need to create the nested directory as part of the bundle output before attempting to copy the file.