### PR TITLE
fix(docker): enable buildkit

### DIFF
--- a/alchemy/src/docker/image.ts
+++ b/alchemy/src/docker/image.ts
@@ -135,16 +135,8 @@ export const Image = Resource(
     id: string,
     props: ImageProps,
   ): Promise<Image> {
-    // Create a temporary directory that will act as an isolated Docker config
-    // (credentials) directory. This prevents race-conditions when multiple
-    // concurrent tests perform `docker login` / `logout` by ensuring each
-    // Image operation has its own credential store.
-    const tempConfigDir = await fs.mkdtemp(
-      path.join(os.tmpdir(), "docker-config-"),
-    );
-
     // Initialize Docker API client with the isolated config directory
-    const api = new DockerApi({ configDir: tempConfigDir });
+    const api = new DockerApi();
 
     if (this.phase === "delete") {
       // No action needed for delete as Docker images aren't automatically removed
@@ -232,6 +224,15 @@ export const Image = Resource(
           : `${registryHost}/${imageRef}`;
 
         try {
+          // Create a temporary directory that will act as an isolated Docker config
+          // (credentials) directory. This prevents race-conditions when multiple
+          // concurrent tests perform `docker login` / `logout` by ensuring each
+          // Image operation has its own credential store.
+          const tempConfigDir = await fs.mkdtemp(
+            path.join(os.tmpdir(), "docker-config-"),
+          );
+          const api = new DockerApi({ configDir: tempConfigDir });
+
           // Authenticate to registry using the isolated config directory
           await api.login(registryHost, username, password.unencrypted);
 


### PR DESCRIPTION
Simple fix: run the build without the custom `configDir` so it uses buildkit, then only use the custom `configDir` for auth.

Tests for containers are passing... finally.