### PR TITLE
WIP: no public Symbols

### DIFF
--- a/alchemy/src/cloudflare/worker.ts
+++ b/alchemy/src/cloudflare/worker.ts
@@ -1,7 +1,7 @@
 import path from "pathe";
 import type { Context } from "../context.ts";
 import type { BundleProps } from "../esbuild/bundle.ts";
-import { Resource, ResourceKind } from "../resource.ts";
+import { type ExportedResource, Resource, ResourceKind } from "../resource.ts";
 import type { type } from "../type.ts";
 import { DeferredPromise } from "../util/deferred-promise.ts";
 import { logger } from "../util/logger.ts";
@@ -432,14 +432,21 @@ export type WorkerProps<
   RPC extends Rpc.WorkerEntrypointBranded = Rpc.WorkerEntrypointBranded,
 > = InlineWorkerProps<B, RPC> | EntrypointWorkerProps<B, RPC>;
 
-export function isWorker(resource: Resource): resource is Worker<any> {
+export function isWorker(resource: Resource): resource is WorkerResource<any> {
   return resource[ResourceKind] === "cloudflare::Worker";
 }
-
 /**
- * Output returned after Worker creation/update
+ * Output returned after Worker creation/update (Public API type without internal Symbols)
  */
 export type Worker<
+  B extends Bindings | undefined = Bindings | undefined,
+  RPC extends Rpc.WorkerEntrypointBranded = Rpc.WorkerEntrypointBranded,
+> = ExportedResource<WorkerResource<B, RPC>>;
+
+/**
+ * Resource (internal) returned after Worker creation/update
+ */
+type WorkerResource<
   B extends Bindings | undefined = Bindings | undefined,
   RPC extends Rpc.WorkerEntrypointBranded = Rpc.WorkerEntrypointBranded,
 > = Resource<"cloudflare::Worker"> &
@@ -735,7 +742,7 @@ const _Worker = Resource(
     alwaysUpdate: true,
   },
   async function <const B extends Bindings>(
-    this: Context<Worker<NoInfer<B>>>,
+    this: Context<WorkerResource<NoInfer<B>>>,
     id: string,
     props: WorkerProps<B>,
   ) {
@@ -920,7 +927,7 @@ const _Worker = Resource(
           hasRemote: this.output?.dev?.hasRemote ?? false,
         },
         Env: undefined!,
-      } as unknown as Worker<B>);
+      } as unknown as WorkerResource<B>);
     }
 
     if (this.phase === "create" || this.output.dev?.hasRemote === false) {
@@ -1074,7 +1081,7 @@ const _Worker = Resource(
       dev: {
         hasRemote: true,
       },
-    } as unknown as Worker<B>);
+    } as unknown as WorkerResource<B>);
   },
 );
 

--- a/alchemy/src/resource.ts
+++ b/alchemy/src/resource.ts
@@ -52,6 +52,13 @@ export function resolveDeletionHandler(typeName: string): Provider | undefined {
   return undefined;
 }
 
+// Used to remove all Symbol keys from a Resource so that Resources based on different
+// alchemy modules can play nicely together
+// Alternative approach would be to publish these symbols to a single alchemy module that never changes?
+type SymbolKeys<T> = Extract<keyof T, Symbol>;
+type WithoutResourceSymbols<T> = Omit<T, SymbolKeys<Resource>>;
+export type ExportedResource<T extends Resource> = WithoutResourceSymbols<T>;
+
 export type ResourceID = string;
 export const ResourceID = Symbol.for("alchemy::ResourceID");
 export type ResourceFQN = string;


### PR DESCRIPTION
Plan: Remove Symbols keys from public Alchemy Resources

So far:
- Cloudflare Workers ✅ 

Putting up a draft PR to show how I will do this, pls let me know if this seems OK

How does it work?

`ExportedResource<T extends Resource>` is a generic wrapper that strips the Resource Symbols

The `Worker` type is split into 2 types `Worker` (public type without Symbol Keys) and `WorkerResource` (internal type with Symbol keys).

WorkerResource is not exported from `worker.ts`

Possible Concerns:
- Not super robust enforcement that we don't leak types that need Symbol keys, particularly on arguments to other functions. If `WorkerResource` and other types like it can be kept internal (not exported) then this is fairly low risk

Alternatives considered:
- Declaring the alchemy Resource symbols in a separate only-one-version-will-ever-exist package
