### PR TITLE
fix: preserve string literal types in bound.ts

### DIFF
--- a/alchemy/src/cloudflare/bound.ts
+++ b/alchemy/src/cloudflare/bound.ts
@@ -97,7 +97,7 @@ export type Bound<T extends Binding> = T extends _DurableObjectNamespace<
                                     : T extends _RateLimit
                                       ? RateLimit
                                       : T extends string
-                                        ? string
+                                        ? T
                                         : T extends BrowserRendering
                                           ? Fetcher
                                           : T extends _Ai<infer M>


### PR DESCRIPTION
Keep T when T extends string instead of losing resolution to generic string type.

Fixes ##1001

Generated with [Claude Code](https://claude.ai/code)