### PR TITLE
feat: remove Resource symbols and this(..) syntax

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -353,15 +353,14 @@ export const {{ResourceName}} = Resource(
         const data = await response.json();
         const resource = data.result || data;
 
-        // Return the resource using this() to construct output
-        return this({
+        return {
           id: resource.id,
           name: resource.name,
           description: resource.description,
           createdAt: resource.created_at || Date.now(),
           // Include all other required properties from the interface
           ...props // Include any additional properties from props
-        });
+        };
       } catch (error) {
         console.error("Error creating/updating resource:", error);
         throw error;
@@ -386,11 +385,11 @@ export const {{ResourceName}} = Resource(
 
    - Use `this.phase` to check the current operation phase ("create", "update", or "delete")
    - For deletion, return `this.destroy()`
-   - For creation/update, return `this({...})` with the resource properties
+   - For creation/update, return `{...}` with the resource properties
 
 4. **Output Construction**:
 
-   - Use `this({...})` to construct the resource output
+   - Use `{...}` to construct the resource output
    - Include all required properties from the interface
    - Spread the props object to include any additional properties
 
@@ -651,7 +650,7 @@ Alchemy resources follow an async/await pattern with a pseudo-class implementati
    - Access context through `this: Context<T>`
    - Use `this.phase` for operation type ("create", "update", "delete")
    - Use `this.output` for current resource state
-   - Use `this({...})` to construct resource output
+   - Use `{...}` to construct resource output
    - Use `this.destroy()` for deletion
 
 4. **Phase Handling**:
@@ -662,10 +661,10 @@ Alchemy resources follow an async/await pattern with a pseudo-class implementati
      return this.destroy();
    } else if (this.phase === "update") {
      // Handle update
-     return this({ ...updatedProps });
+     return { ...updatedProps };
    } else {
      // Handle create
-     return this({ ...newProps });
+     return { ...newProps };
    }
    ```
 
@@ -673,12 +672,12 @@ Alchemy resources follow an async/await pattern with a pseudo-class implementati
 
    ```typescript
    // Construct resource output
-   return this({
+   return {
      id: resourceId,
      ...props,
      // Add computed properties
      createdAt: Date.now(),
-   });
+   };
    ```
 
 6. **Error Handling**:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,11 +161,11 @@ export const {Resource} = Resource(
       }
       
       const data = await response.json();
-      return this({
+      return {
         id: data.id,
         ...props,
         // other computed properties
-      });
+      };
     }
   }
 );
@@ -176,7 +176,7 @@ export const {Resource} = Resource(
 - **Validate immutable properties** during updates
 - **Use `this.phase`** to determine operation type ("create", "update", "delete")
 - **Return `this.destroy()`** for deletion
-- **Return `this({...})`** for creation/update with all required properties
+- **Return `{...}`** for creation/update with all required properties
 - **Check response status directly** instead of relying on exceptions
 - **Handle 404s gracefully** during deletion
 

--- a/alchemy-web/src/content/docs/blog/2025-07-01-how-alchemy-is-different.md
+++ b/alchemy-web/src/content/docs/blog/2025-07-01-how-alchemy-is-different.md
@@ -170,10 +170,10 @@ export const Database = Resource(
       return this.destroy();
     } else if (this.phase === "update") {
       // Update logic
-      return this({ id: "db-123", ...props });
+      return { id: "db-123", ...props };
     } else {
       // Create logic
-      return this({ id: "db-123", ...props });
+      return { id: "db-123", ...props };
     }
   }
 );

--- a/alchemy-web/src/content/docs/concepts/resource.mdx
+++ b/alchemy-web/src/content/docs/concepts/resource.mdx
@@ -42,7 +42,7 @@ export interface DatabaseProps {
 Each Resource has an interface for its "output attributes":
 
 ```typescript
-export interface Database extends Resource<"neon::Database">, DatabaseProps {
+export interface Database extends DatabaseProps {
   id: string;
   createdAt: number;
   // Additional properties...
@@ -92,11 +92,11 @@ export const Database = Resource(
     } else if (this.phase === "update") {
       // Update resource logic
       // ...
-      return this({/* updated resource */});
+      return {/* updated resource */};
     } else {
       // Create resource logic
       // ...
-      return this({/* new resource */});
+      return {/* new resource */};
     }
   }
 );
@@ -149,37 +149,21 @@ if (this.phase === "delete") {
 } else if (this.phase === "update") {
   // Update resource logic
   // ...
-  return this({/* updated properties */});
+  return {/* updated properties */};
 } else {
   // Create resource logic
   // ...
-  return this({/* initial properties */});
+  return {/* initial properties */};
 }
 ```
 
 ## Create
 
-To construct the resource (including your properites and Alchemy's intrinsic properties), call `this(props)` with your output properties:
+To construct the resource (including your properites and Alchemy's intrinsic properties), return `props` with your output properties:
 
 ```ts
-return this({/* updated properties */});
+return {/* updated properties */};
 ```
-
-What's going on here? `this` is a function? Huh?
-
-Alchemy resources are implemented with pure functions, but are designed to emulate classes (except with an async constructor that implements a CRUD lifecycle handler).
-
-`this` is analagous to `super` in a standard class:
-```ts
-return super({/* updated properties */});
-```
-
-:::tip
-If this syntax freaks you out too much, it is also aliased as `this.create`:
-```ts
-return this.create({/* updated properties */});
-```
-:::
 
 ## Destroy
 
@@ -308,10 +292,10 @@ if (this.phase === "update") {
   }
 }
 
-return this({
+return {
   ...props,
   name,
-});
+};
 ```
 ::: 
 

--- a/alchemy-web/src/content/docs/concepts/scope.md
+++ b/alchemy-web/src/content/docs/concepts/scope.md
@@ -71,11 +71,11 @@ export const WebApp = Resource(
     const database = await Database("db", {});
     const apiGateway = await ApiGateway("api", {});
     
-    return this({
+    return {
       id,
       url: apiGateway.url,
       dbConnectionString: database.connectionString
-    });
+    };
   }
 );
 

--- a/alchemy-web/src/content/docs/what-is-alchemy.md
+++ b/alchemy-web/src/content/docs/what-is-alchemy.md
@@ -277,10 +277,10 @@ export const MyResource = Resource(
       return this.destroy();
     } else if (this.phase === "update") {
       // Update logic
-      return this({ ...props, id: this.output.id });
+      return { ...props, id: this.output.id };
     } else {
       // Create logic
-      return this({ ...props, id: "new-id" });
+      return { ...props, id: "new-id" };
     }
   }
 );

--- a/alchemy/src/aws/bucket.ts
+++ b/alchemy/src/aws/bucket.ts
@@ -26,7 +26,7 @@ export interface BucketProps {
 /**
  * Output returned after S3 bucket creation/update
  */
-export interface Bucket extends Resource<"s3::Bucket">, BucketProps {
+export interface Bucket extends BucketProps {
   /**
    * The ARN (Amazon Resource Name) of the bucket
    * Format: arn:aws:s3:::bucket-name
@@ -244,7 +244,7 @@ export const Bucket = Resource(
       }
     }
 
-    return this({
+    return {
       bucketName: bucketName,
       arn: `arn:aws:s3:::${bucketName}`,
       bucketDomainName: `${bucketName}.s3.amazonaws.com`,
@@ -254,7 +254,7 @@ export const Bucket = Resource(
       versioningEnabled: versioningResponse.Status === "Enabled",
       acl: aclResponse.Grants?.[0]?.Permission?.toLowerCase(),
       ...(tags && { tags }),
-    });
+    };
   },
 );
 

--- a/alchemy/src/aws/control/resource.ts
+++ b/alchemy/src/aws/control/resource.ts
@@ -1,5 +1,4 @@
 import jsonpatch from "fast-json-patch";
-const compare = jsonpatch.compare;
 import type { Context } from "../../context.ts";
 import {
   registerDynamicResource,
@@ -15,6 +14,7 @@ import {
   UpdateFailedError,
 } from "./error.ts";
 import readOnlyPropertiesMap from "./properties.ts";
+const compare = jsonpatch.compare;
 
 /**
  * Properties for creating or updating a Cloud Control resource
@@ -60,9 +60,7 @@ export interface CloudControlResourceProps {
 /**
  * Output returned after Cloud Control resource creation/update
  */
-export interface CloudControlResource
-  extends Resource<"aws::CloudControlResource">,
-    CloudControlResourceProps {
+export interface CloudControlResource extends CloudControlResourceProps {
   /**
    * The identifier of the resource
    */
@@ -337,12 +335,12 @@ async function CloudControlLifecycle(
     );
   }
 
-  return this({
+  return {
     ...props,
     id: response.Identifier!,
     createdAt: Date.now(),
     ...(await client.getResource(props.typeName, response.Identifier!)),
-  });
+  };
 }
 
 async function updateResourceWithPatch(

--- a/alchemy/src/aws/ec2/internet-gateway-attachment.ts
+++ b/alchemy/src/aws/ec2/internet-gateway-attachment.ts
@@ -38,8 +38,7 @@ export interface InternetGatewayAttachmentProps extends AwsClientProps {
  * Output returned after Internet Gateway Attachment creation/update
  */
 export interface InternetGatewayAttachment
-  extends Resource<"aws::InternetGatewayAttachment">,
-    InternetGatewayAttachmentProps {
+  extends InternetGatewayAttachmentProps {
   /**
    * The ID of the Internet Gateway
    */
@@ -277,12 +276,12 @@ export const InternetGatewayAttachment = Resource(
       const attachment = igw?.Attachments?.find((att) => att.VpcId === vpcId);
 
       if (attachment) {
-        return this({
+        return {
           internetGatewayId,
           vpcId,
           state: "attached",
           ...props,
-        });
+        };
       }
     }
 
@@ -353,12 +352,12 @@ export const InternetGatewayAttachment = Resource(
       "to be attached",
     );
 
-    return this({
+    return {
       internetGatewayId,
       vpcId,
       state: "attached",
       ...props,
-    });
+    };
   },
 );
 

--- a/alchemy/src/aws/ec2/internet-gateway.ts
+++ b/alchemy/src/aws/ec2/internet-gateway.ts
@@ -31,9 +31,7 @@ export interface InternetGatewayProps extends AwsClientProps {
 /**
  * Output returned after Internet Gateway creation/update
  */
-export interface InternetGateway
-  extends Resource<"aws::InternetGateway">,
-    InternetGatewayProps {
+export interface InternetGateway extends InternetGatewayProps {
   /**
    * The ID of the Internet Gateway
    */
@@ -358,7 +356,7 @@ export const InternetGateway = Resource(
       );
     }
 
-    return this({
+    return {
       internetGatewayId: internetGateway.InternetGatewayId!,
       state: "available",
       attachments: internetGateway.Attachments?.map((att) => ({
@@ -367,7 +365,7 @@ export const InternetGateway = Resource(
       })),
       ownerId: internetGateway.OwnerId,
       ...props,
-    });
+    };
   },
 );
 

--- a/alchemy/src/aws/ec2/nat-gateway.ts
+++ b/alchemy/src/aws/ec2/nat-gateway.ts
@@ -48,9 +48,7 @@ export interface NatGatewayProps extends AwsClientProps {
 /**
  * Output returned after NAT Gateway creation/update
  */
-export interface NatGateway
-  extends Resource<"aws::NatGateway">,
-    NatGatewayProps {
+export interface NatGateway extends NatGatewayProps {
   /**
    * The ID of the NAT Gateway
    */
@@ -423,7 +421,7 @@ export const NatGateway = Resource(
       );
     }
 
-    const result = this({
+    const result = {
       natGatewayId: natGateway.NatGatewayId!,
       subnetId: natGateway.SubnetId!,
       vpcId: natGateway.VpcId!,
@@ -434,7 +432,7 @@ export const NatGateway = Resource(
       createdElasticIp,
       ...props,
       subnet: subnetId,
-    });
+    };
     return result;
   },
 );

--- a/alchemy/src/aws/ec2/route-table-association.ts
+++ b/alchemy/src/aws/ec2/route-table-association.ts
@@ -44,9 +44,7 @@ export interface RouteTableAssociationProps {
 /**
  * Output returned after Route Table Association creation/update
  */
-export interface RouteTableAssociation
-  extends Resource<"aws::RouteTableAssociation">,
-    RouteTableAssociationProps {
+export interface RouteTableAssociation extends RouteTableAssociationProps {
   /**
    * The ID of the route table association
    */
@@ -418,7 +416,7 @@ export const RouteTableAssociation = Resource(
       }
     }
 
-    return this({
+    return {
       associationId,
       routeTableId,
       subnetId,
@@ -429,7 +427,7 @@ export const RouteTableAssociation = Resource(
       routeTable: routeTableId,
       subnet: subnetId,
       gateway: gatewayId,
-    });
+    };
   },
 );
 

--- a/alchemy/src/aws/ec2/route-table.ts
+++ b/alchemy/src/aws/ec2/route-table.ts
@@ -37,9 +37,7 @@ export interface RouteTableProps extends AwsClientProps {
 /**
  * Output returned after Route Table creation/update
  */
-export interface RouteTable
-  extends Resource<"aws::RouteTable">,
-    RouteTableProps {
+export interface RouteTable extends RouteTableProps {
   /**
    * The ID of the route table
    */
@@ -272,12 +270,12 @@ export const RouteTable = Resource(
       logger.log(`  ✅ Route Table ${routeTable.RouteTableId} created`);
     }
 
-    return this({
+    return {
       routeTableId: routeTable.RouteTableId!,
       vpcId: routeTable.VpcId!,
       ...props,
       vpc: vpcId,
-    });
+    };
   },
 );
 

--- a/alchemy/src/aws/ec2/route.ts
+++ b/alchemy/src/aws/ec2/route.ts
@@ -52,7 +52,7 @@ export interface RouteProps extends AwsClientProps {
 /**
  * Output returned after Route creation/update
  */
-export interface Route extends Resource<"aws::Route">, RouteProps {
+export interface Route extends RouteProps {
   /**
    * The ID of the route table
    */
@@ -333,7 +333,7 @@ export const Route = Resource(
       throw new Error("Failed to find created route");
     }
 
-    return this({
+    return {
       routeTableId,
       state: route.State as "active" | "blackhole",
       origin: route.Origin as
@@ -342,7 +342,7 @@ export const Route = Resource(
         | "EnableVgwRoutePropagation",
       ...props,
       routeTable: routeTableId,
-    });
+    };
   },
 );
 

--- a/alchemy/src/aws/ec2/security-group-rule.ts
+++ b/alchemy/src/aws/ec2/security-group-rule.ts
@@ -56,9 +56,7 @@ export interface SecurityGroupRuleProps {
 /**
  * Output returned after Security Group Rule creation/update
  */
-export interface SecurityGroupRule
-  extends Resource<"aws::SecurityGroupRule">,
-    SecurityGroupRuleProps {
+export interface SecurityGroupRule extends SecurityGroupRuleProps {
   /**
    * A unique identifier for the rule resource.
    */
@@ -156,10 +154,10 @@ export const SecurityGroupRule = Resource(
       authorizeParams,
     );
 
-    return this({
+    return {
       ruleId,
       ...props,
-    });
+    };
   },
 );
 

--- a/alchemy/src/aws/ec2/security-group.ts
+++ b/alchemy/src/aws/ec2/security-group.ts
@@ -56,9 +56,7 @@ export interface SecurityGroupProps extends AwsClientProps {
 /**
  * Output returned after Security Group creation/update
  */
-export interface SecurityGroup
-  extends Resource<"aws::SecurityGroup">,
-    SecurityGroupProps {
+export interface SecurityGroup extends SecurityGroupProps {
   /**
    * The ID of the security group.
    */
@@ -322,14 +320,14 @@ export const SecurityGroup = Resource(
       securityGroup = sgResponse.SecurityGroups[0];
     }
 
-    return this({
+    return {
       groupId: securityGroup.GroupId,
       groupName,
       vpcId: securityGroup.VpcId,
       ownerId: securityGroup.OwnerId,
       ...props,
       vpc: vpcId,
-    });
+    };
   },
 );
 

--- a/alchemy/src/aws/ec2/subnet.ts
+++ b/alchemy/src/aws/ec2/subnet.ts
@@ -54,7 +54,7 @@ export interface SubnetProps extends AwsClientProps {
 /**
  * Output returned after Subnet creation/update
  */
-export interface Subnet extends Resource<"aws::Subnet">, SubnetProps {
+export interface Subnet extends SubnetProps {
   /**
    * The ID of the subnet
    */
@@ -407,7 +407,7 @@ export const Subnet = Resource(
       await waitForSubnetAvailable(client, subnet.SubnetId, timeoutConfig);
     }
 
-    return this({
+    return {
       subnetId: subnet.SubnetId,
       vpcId: subnet.VpcId,
       state: subnet.State as "pending" | "available",
@@ -415,7 +415,7 @@ export const Subnet = Resource(
       defaultForAz: subnet.DefaultForAz,
       ...props,
       vpc: vpcId,
-    });
+    };
   },
 );
 

--- a/alchemy/src/aws/ec2/vpc.ts
+++ b/alchemy/src/aws/ec2/vpc.ts
@@ -80,7 +80,7 @@ export interface VpcProps extends AwsClientProps {
 /**
  * Output returned after VPC creation/update
  */
-export interface Vpc extends Resource<"aws::Vpc">, VpcProps {
+export interface Vpc extends VpcProps {
   /**
    * The ID of the VPC
    */
@@ -388,13 +388,13 @@ export const Vpc = Resource(
       }
     }
 
-    return this({
+    return {
       vpcId: vpc.VpcId!,
       state: vpc.State as "pending" | "available",
       isDefault: vpc.IsDefault || false,
       dhcpOptionsId: vpc.DhcpOptionsId!,
       ...props,
-    });
+    };
   },
 );
 

--- a/alchemy/src/aws/function.ts
+++ b/alchemy/src/aws/function.ts
@@ -136,7 +136,7 @@ export interface FunctionProps {
 /**
  * Output returned after Lambda function creation/update
  */
-export interface Function extends Resource<"lambda::Function">, FunctionProps {
+export interface Function extends FunctionProps {
   /**
    * ARN of the Lambda function
    */
@@ -745,7 +745,7 @@ export const Function = Resource(
       }
     }
 
-    return this({
+    return {
       ...props,
       arn: config.FunctionArn!,
       functionName,
@@ -769,7 +769,7 @@ export const Function = Resource(
       signingProfileVersionArn: config.SigningProfileVersionArn,
       signingJobArn: config.SigningJobArn,
       functionUrl: functionUrl,
-    });
+    };
   },
 );
 

--- a/alchemy/src/aws/oidc/oidc-provider.ts
+++ b/alchemy/src/aws/oidc/oidc-provider.ts
@@ -71,9 +71,7 @@ export interface OIDCProviderProps {
 /**
  * Output returned after OIDC provider configuration
  */
-export interface OIDCProvider
-  extends Resource<"aws::OIDCProvider">,
-    OIDCProviderProps {
+export interface OIDCProvider extends OIDCProviderProps {
   /**
    * The ARN of the OIDC provider
    * Format: arn:aws:iam::account-id:oidc-provider/token.actions.githubusercontent.com
@@ -280,11 +278,11 @@ export const OIDCProvider = Resource(
         }),
       );
 
-      return this({
+      return {
         ...props,
         providerArn,
         createdAt: Date.now(),
-      });
+      };
     } catch (error) {
       logger.error("Error configuring OIDC provider:", error);
       throw error;

--- a/alchemy/src/aws/policy-attachment.ts
+++ b/alchemy/src/aws/policy-attachment.ts
@@ -22,9 +22,7 @@ export interface PolicyAttachmentProps {
 /**
  * Output returned after policy attachment creation/update
  */
-export interface PolicyAttachment
-  extends Resource<"iam::PolicyAttachment">,
-    PolicyAttachmentProps {}
+export interface PolicyAttachment extends PolicyAttachmentProps {}
 
 /**
  * AWS IAM Policy Attachment Resource
@@ -97,6 +95,6 @@ export const PolicyAttachment = Resource(
       ),
     );
 
-    return this(props);
+    return props;
   },
 );

--- a/alchemy/src/aws/policy.ts
+++ b/alchemy/src/aws/policy.ts
@@ -108,7 +108,7 @@ export interface PolicyProps {
 /**
  * Output returned after IAM policy creation/update
  */
-export interface Policy extends Resource<"iam::Policy">, PolicyProps {
+export interface Policy extends PolicyProps {
   /**
    * ARN of the policy
    */
@@ -364,7 +364,7 @@ export const Policy = Resource(
         ),
       );
 
-      return this({
+      return {
         ...props,
         arn: policy.Policy!.Arn!,
         policyName,
@@ -373,7 +373,7 @@ export const Policy = Resource(
         createDate: policy.Policy!.CreateDate!,
         updateDate: policy.Policy!.UpdateDate!,
         isAttachable: policy.Policy!.IsAttachable!,
-      });
+      };
     } catch (error: any) {
       if (error.name === "NoSuchEntity") {
         // Create new policy
@@ -394,7 +394,7 @@ export const Policy = Resource(
           ),
         );
 
-        return this({
+        return {
           ...props,
           arn: newPolicy.Policy!.Arn!,
           policyName,
@@ -403,7 +403,7 @@ export const Policy = Resource(
           createDate: newPolicy.Policy!.CreateDate!,
           updateDate: newPolicy.Policy!.UpdateDate!,
           isAttachable: newPolicy.Policy!.IsAttachable!,
-        });
+        };
       }
       throw error;
     }

--- a/alchemy/src/aws/queue.ts
+++ b/alchemy/src/aws/queue.ts
@@ -79,7 +79,7 @@ export interface QueueProps {
 /**
  * Output returned after SQS queue creation/update
  */
-export interface Queue extends Resource<"sqs::Queue">, QueueProps {
+export interface Queue extends QueueProps {
   /**
    * ARN of the queue
    */
@@ -283,12 +283,12 @@ export const Queue = Resource(
         ),
       );
 
-      return this({
+      return {
         ...props,
         arn: attributesResponse.Attributes!.QueueArn!,
         queueName,
         url: createResponse.QueueUrl!,
-      });
+      };
     } catch (error: any) {
       if (isQueueDeletedRecently(error)) {
         logger.log(
@@ -324,12 +324,12 @@ export const Queue = Resource(
               ),
             );
 
-            return this({
+            return {
               ...props,
               arn: attributesResponse.Attributes!.QueueArn!,
               queueName,
               url: createResponse.QueueUrl!,
-            });
+            };
           } catch (retryError: any) {
             if (
               !isQueueDeletedRecently(retryError) ||

--- a/alchemy/src/aws/role.ts
+++ b/alchemy/src/aws/role.ts
@@ -67,7 +67,7 @@ export interface RoleProps {
 /**
  * Output returned after IAM role creation/update
  */
-export interface Role extends Resource<"iam::Role">, RoleProps {
+export interface Role extends RoleProps {
   /**
    * ARN of the role
    */
@@ -535,13 +535,13 @@ export const Role = Resource(
       throw new Error(`Failed to create or update role ${props.roleName}`);
     }
 
-    return this({
+    return {
       ...props,
       arn: role.Role.Arn!,
       uniqueId: role.Role.RoleId!,
       roleId: role.Role.RoleId!,
       roleName,
       createDate: role.Role.CreateDate!,
-    });
+    };
   },
 );

--- a/alchemy/src/aws/ses.ts
+++ b/alchemy/src/aws/ses.ts
@@ -74,7 +74,7 @@ export interface SESProps {
 /**
  * Output returned after SES resource creation/update
  */
-export interface SES extends Resource<"aws::SES">, SESProps {
+export interface SES extends SESProps {
   /**
    * ARN of the configuration set if created
    * Format: arn:aws:ses:region:account-id:configuration-set/name
@@ -404,12 +404,12 @@ export const SES = Resource(
     }
 
     // Return the resource output
-    return this({
+    return {
       ...props,
       configurationSetArn,
       emailIdentityArn,
       emailIdentityVerificationStatus,
       dkimVerificationStatus,
-    });
+    };
   },
 );

--- a/alchemy/src/aws/ssm-parameter.ts
+++ b/alchemy/src/aws/ssm-parameter.ts
@@ -89,7 +89,7 @@ export type SSMParameterProps =
 /**
  * Output returned after SSM Parameter creation/update
  */
-export type SSMParameter = Resource<"ssm::Parameter"> & {
+export type SSMParameter = {
   /**
    * ARN of the parameter
    */
@@ -316,7 +316,7 @@ export const SSMParameter = Resource(
         );
       }
 
-      return this({
+      return {
         ...props,
         arn: parameter.Parameter.ARN!,
         version: parameter.Parameter.Version!,
@@ -324,7 +324,7 @@ export const SSMParameter = Resource(
         name: parameter.Parameter.Name ?? parameterName,
         value: props.value,
         type: (parameter.Parameter.Type as any) ?? parameterType,
-      } as SSMParameter);
+      } as SSMParameter;
     } catch (error: any) {
       logger.error(
         `Error creating/updating parameter ${parameterName}:`,

--- a/alchemy/src/aws/table.ts
+++ b/alchemy/src/aws/table.ts
@@ -77,7 +77,7 @@ export interface TableProps {
 /**
  * Output returned after DynamoDB table creation/update
  */
-export interface Table extends Resource<"dynamo::Table">, TableProps {
+export interface Table extends TableProps {
   /**
    * ARN of the table
    * Format: arn:aws:dynamodb:region:account-id:table/table-name
@@ -323,12 +323,12 @@ export const Table = Resource(
       );
     }
 
-    return this({
+    return {
       ...props,
       arn: tableDescription!.TableArn!,
       tableName,
       streamArn: tableDescription!.LatestStreamArn,
       tableId: tableDescription!.TableId!,
-    });
+    };
   },
 );

--- a/alchemy/src/cloudflare/account-api-token.ts
+++ b/alchemy/src/cloudflare/account-api-token.ts
@@ -140,8 +140,7 @@ interface CloudflareApiToken {
 /**
  * Output returned after Account API Token creation/update
  */
-export interface AccountApiToken
-  extends Resource<"cloudflare::AccountApiToken"> {
+export interface AccountApiToken {
   /**
    * The ID of the token
    *
@@ -385,7 +384,7 @@ export const AccountApiToken = Resource(
     }
 
     // Transform API response to our format
-    return this({
+    return {
       id: tokenData.id,
       name: tokenData.name,
       status: tokenData.status,
@@ -406,6 +405,6 @@ export const AccountApiToken = Resource(
       value: tokenValue,
       accessKeyId: alchemy.secret(tokenData.id),
       secretAccessKey: alchemy.secret(sha256(tokenValue.unencrypted)),
-    });
+    };
   },
 );

--- a/alchemy/src/cloudflare/ai-gateway.ts
+++ b/alchemy/src/cloudflare/ai-gateway.ts
@@ -92,9 +92,7 @@ export interface AiGatewayProps extends CloudflareApiOptions {
  * Output returned after Cloudflare AI Gateway creation/update.
  * IMPORTANT: The interface name MUST match the exported resource name.
  */
-export interface AiGateway
-  extends Resource<"cloudflare::AiGateway">,
-    AiGatewayProps {
+export interface AiGateway extends AiGatewayProps {
   /**
    * The ID (name) of the gateway.
    */
@@ -248,7 +246,7 @@ export const AiGateway = Resource(
     }
 
     // Construct the output object from API response and merged props
-    return this({
+    return {
       ...mergedProps, // Start with the input props (including defaults)
       id: apiResource.id,
       gatewayName,
@@ -270,7 +268,7 @@ export const AiGateway = Resource(
       logpush: apiResource.logpush,
       logpushPublicKey: apiResource.logpush_public_key,
       type: "ai_gateway",
-    });
+    };
   },
 );
 

--- a/alchemy/src/cloudflare/api-gateway-operation.ts
+++ b/alchemy/src/cloudflare/api-gateway-operation.ts
@@ -56,8 +56,7 @@ export interface APIGatewayOperationProps extends CloudflareApiOptions {
 /**
  * API Operation output
  */
-export interface APIGatewayOperation
-  extends Resource<"cloudflare::APIGatewayOperation"> {
+export interface APIGatewayOperation {
   /**
    * Zone ID
    */
@@ -202,7 +201,7 @@ export const APIGatewayOperation = Resource(
       }
     }
 
-    return this({
+    return {
       zoneId,
       zoneName,
       operationId,
@@ -210,7 +209,7 @@ export const APIGatewayOperation = Resource(
       host: props.host,
       method: props.method.toUpperCase(),
       action: props.mitigation ?? null,
-    });
+    };
   },
 );
 

--- a/alchemy/src/cloudflare/api-schema.ts
+++ b/alchemy/src/cloudflare/api-schema.ts
@@ -48,33 +48,32 @@ export interface APISchemaProps<S extends OpenAPIV3.Document>
 /**
  * APISchema resource attributes.
  */
-export type APISchema<S extends OpenAPIV3.Document = OpenAPIV3.Document> =
-  Resource<"cloudflare::APISchema"> & {
-    /**
-     * Schema ID
-     */
-    id: string;
+export type APISchema<S extends OpenAPIV3.Document = OpenAPIV3.Document> = {
+  /**
+   * Schema ID
+   */
+  id: string;
 
-    /**
-     * Name for the schema
-     */
-    name: string;
+  /**
+   * Name for the schema
+   */
+  name: string;
 
-    /**
-     * The API Schema
-     */
-    schema: S;
+  /**
+   * The API Schema
+   */
+  schema: S;
 
-    /**
-     * Source of the schema
-     */
-    source: string;
+  /**
+   * Source of the schema
+   */
+  source: string;
 
-    /**
-     * Whether validation is enabled
-     */
-    enabled: boolean;
-  };
+  /**
+   * Whether validation is enabled
+   */
+  enabled: boolean;
+};
 
 /**
  * Cloudflare API Gateway Schema manages OpenAPI v3 schemas for API validation.
@@ -191,13 +190,13 @@ export const APISchema = Resource("cloudflare::APISchema", async function <
     });
   }
 
-  return this({
+  return {
     id: schemaDetails.id,
     name: schemaDetails.name,
     schema: parsedSchema as any,
     source: schemaDetails.source,
     enabled: schemaDetails.validationEnabled,
-  });
+  };
 });
 
 // API helper functions

--- a/alchemy/src/cloudflare/api-shield.ts
+++ b/alchemy/src/cloudflare/api-shield.ts
@@ -163,8 +163,7 @@ export interface ValidationSettings {
 /**
  * Schema Validation output
  */
-export interface APIShield<S extends OpenAPIV3.Document = OpenAPIV3.Document>
-  extends Resource<"cloudflare::APIShield"> {
+export interface APIShield<S extends OpenAPIV3.Document = OpenAPIV3.Document> {
   /**
    * Name of the API Shield.
    */
@@ -440,7 +439,7 @@ const _APIShield = Resource(
       email: props.email,
     });
 
-    return this({
+    return {
       zoneId,
       schema,
       name: schemaName,
@@ -475,7 +474,7 @@ const _APIShield = Resource(
           );
         }),
       ),
-    });
+    };
   },
 );
 

--- a/alchemy/src/cloudflare/bucket.ts
+++ b/alchemy/src/cloudflare/bucket.ts
@@ -296,52 +296,51 @@ export type R2Bucket = _R2Bucket & {
 /**
  * Output returned after R2 Bucket creation/update
  */
-type _R2Bucket = Resource<"cloudflare::R2Bucket"> &
-  Omit<BucketProps, "delete" | "dev"> & {
+type _R2Bucket = Omit<BucketProps, "delete" | "dev"> & {
+  /**
+   * Resource type identifier
+   */
+  type: "r2_bucket";
+
+  /**
+   * The name of the bucket
+   */
+  name: string;
+
+  /**
+   * Location of the bucket
+   */
+  location: string;
+
+  /**
+   * Time at which the bucket was created
+   */
+  creationDate: Date;
+
+  /**
+   * The `r2.dev` subdomain for the bucket, if `allowPublicAccess` is true
+   */
+  domain: string | undefined;
+
+  /**
+   * Development mode properties
+   * @internal
+   */
+  dev: {
     /**
-     * Resource type identifier
+     * The ID of the bucket in development mode
      */
-    type: "r2_bucket";
+    id: string;
 
     /**
-     * The name of the bucket
+     * Whether the bucket is running remotely
      */
-    name: string;
-
-    /**
-     * Location of the bucket
-     */
-    location: string;
-
-    /**
-     * Time at which the bucket was created
-     */
-    creationDate: Date;
-
-    /**
-     * The `r2.dev` subdomain for the bucket, if `allowPublicAccess` is true
-     */
-    domain: string | undefined;
-
-    /**
-     * Development mode properties
-     * @internal
-     */
-    dev: {
-      /**
-       * The ID of the bucket in development mode
-       */
-      id: string;
-
-      /**
-       * Whether the bucket is running remotely
-       */
-      remote: boolean;
-    };
+    remote: boolean;
   };
+};
 
-export function isBucket(resource: Resource): resource is R2Bucket {
-  return resource[ResourceKind] === "cloudflare::R2Bucket";
+export function isBucket(resource: any): resource is R2Bucket {
+  return resource?.[ResourceKind] === "cloudflare::R2Bucket";
 }
 
 /**
@@ -496,7 +495,7 @@ const _R2Bucket = Resource(
     const adopt = props.adopt ?? this.scope.adopt;
 
     if (this.scope.local && !props.dev?.remote) {
-      return this({
+      return {
         name: this.output?.name ?? "",
         location: this.output?.location ?? "",
         creationDate: this.output?.creationDate ?? new Date(),
@@ -507,7 +506,7 @@ const _R2Bucket = Resource(
         accountId: this.output?.accountId ?? "",
         cors: props.cors,
         dev,
-      });
+      };
     }
 
     const api = await createCloudflareApi(props);
@@ -553,7 +552,7 @@ const _R2Bucket = Resource(
       if (props.lock?.length) {
         await putBucketLockRules(api, bucketName, props);
       }
-      return this({
+      return {
         name: bucketName,
         location: bucket.location,
         creationDate: new Date(bucket.creation_date),
@@ -566,7 +565,7 @@ const _R2Bucket = Resource(
         lock: props.lock,
         cors: props.cors,
         dev,
-      });
+      };
     } else {
       if (bucketName !== this.output.name) {
         throw new Error(
@@ -593,7 +592,7 @@ const _R2Bucket = Resource(
       if (!isDeepStrictEqual(this.output.lock ?? [], props.lock ?? [])) {
         await putBucketLockRules(api, bucketName, props);
       }
-      return this({
+      return {
         ...this.output,
         allowPublicAccess,
         dev,
@@ -601,7 +600,7 @@ const _R2Bucket = Resource(
         lifecycle: props.lifecycle,
         lock: props.lock,
         domain,
-      });
+      };
     }
   },
 );

--- a/alchemy/src/cloudflare/certificate-pack.ts
+++ b/alchemy/src/cloudflare/certificate-pack.ts
@@ -127,8 +127,7 @@ export interface CertificatePackProps extends CloudflareApiOptions {
 /**
  * Output returned after Certificate Pack creation/update
  */
-export interface CertificatePack
-  extends Resource<"cloudflare::CertificatePack"> {
+export interface CertificatePack {
   /**
    * The unique ID of the certificate pack
    */
@@ -356,7 +355,7 @@ export const CertificatePack = Resource(
         `Adopting existing certificate pack ${existingPack.id} instead of creating a new one`,
       );
 
-      return this({
+      return {
         id: existingPack.id,
         certificateAuthority: existingPack.certificate_authority,
         cloudflareBranding: props.cloudflareBranding ?? false,
@@ -367,7 +366,7 @@ export const CertificatePack = Resource(
         validityDays: existingPack.validity_days,
         zoneId,
         zoneName: zoneName,
-      });
+      };
     }
 
     logger.log(
@@ -416,7 +415,7 @@ export const CertificatePack = Resource(
       `Certificate pack created with ID ${createdPack.id}. Status: ${createdPack.status}. Note: Certificate provisioning can take up to 10 minutes.`,
     );
 
-    return this({
+    return {
       id: createdPack.id,
       certificateAuthority: createdPack.certificate_authority,
       cloudflareBranding: props.cloudflareBranding ?? false,
@@ -427,7 +426,7 @@ export const CertificatePack = Resource(
       validityDays: createdPack.validity_days,
       zoneId,
       zoneName: zoneName,
-    });
+    };
   },
 );
 

--- a/alchemy/src/cloudflare/container.ts
+++ b/alchemy/src/cloudflare/container.ts
@@ -410,8 +410,7 @@ export type SchedulingPolicy =
  * This resource manages the lifecycle of containerized applications running on
  * Cloudflare's global network with automatic scaling and scheduling.
  */
-export interface ContainerApplication
-  extends Resource<"cloudflare::ContainerApplication"> {
+export interface ContainerApplication {
   /** Unique identifier for the container application */
   id: string;
 
@@ -514,10 +513,10 @@ export const ContainerApplication = Resource(
     const applicationName = props.name ?? this.scope.createPhysicalName(id);
 
     if (this.scope.local && props.dev) {
-      return this({
+      return {
         id: this.output?.id ?? "",
         name: applicationName,
-      });
+      };
     }
 
     const adopt = props.adopt ?? this.scope.adopt;
@@ -565,10 +564,10 @@ export const ContainerApplication = Resource(
         step_percentage: props.rollout?.stepPercentage ?? 25,
         target_configuration: configuration,
       });
-      return this({
+      return {
         id: application.id,
         name: application.name,
-      });
+      };
     } else {
       let application: ContainerApplicationData;
 
@@ -643,10 +642,10 @@ export const ContainerApplication = Resource(
         }
       }
 
-      return this({
+      return {
         id: application.id,
         name: application.name,
-      });
+      };
     }
   },
 );

--- a/alchemy/src/cloudflare/custom-domain.ts
+++ b/alchemy/src/cloudflare/custom-domain.ts
@@ -69,9 +69,7 @@ interface CloudflareDomain {
 /**
  * Output returned after CustomDomain creation/update
  */
-export interface CustomDomain
-  extends Resource<"cloudflare::CustomDomain">,
-    CustomDomainProps {
+export interface CustomDomain extends CustomDomainProps {
   /**
    * The unique identifier for the Cloudflare domain binding.
    */
@@ -125,14 +123,14 @@ export const CustomDomain = Resource(
   ): Promise<CustomDomain> {
     if (this.scope.local && props.dev) {
       const now = Date.now();
-      return this({
+      return {
         ...props,
         id: this.output?.id ?? "noop-domain",
         zoneId: props.zoneId ?? "noop-zone",
         environment: props.environment ?? "production",
         createdAt: this.output?.createdAt ?? now,
         updatedAt: now,
-      });
+      };
     }
 
     // Create Cloudflare API client with automatic account discovery

--- a/alchemy/src/cloudflare/d1-database.ts
+++ b/alchemy/src/cloudflare/d1-database.ts
@@ -117,48 +117,47 @@ export interface D1DatabaseProps extends CloudflareApiOptions {
   };
 }
 
-export function isD1Database(resource: Resource): resource is D1Database {
-  return resource[ResourceKind] === "cloudflare::D1Database";
+export function isD1Database(resource: any): resource is D1Database {
+  return resource?.[ResourceKind] === "cloudflare::D1Database";
 }
 
 /**
  * Output returned after D1 Database creation/update
  */
-export type D1Database = Resource<"cloudflare::D1Database"> &
-  Pick<
-    D1DatabaseProps,
-    | "migrationsDir"
-    | "migrationsTable"
-    | "primaryLocationHint"
-    | "readReplication"
-  > & {
-    type: "d1";
+export type D1Database = Pick<
+  D1DatabaseProps,
+  | "migrationsDir"
+  | "migrationsTable"
+  | "primaryLocationHint"
+  | "readReplication"
+> & {
+  type: "d1";
+  /**
+   * The unique ID of the database (UUID)
+   */
+  id: string;
+
+  /**
+   * The name of the database
+   */
+  name: string;
+
+  /**
+   * Development mode properties
+   * @internal
+   */
+  dev: {
     /**
-     * The unique ID of the database (UUID)
+     * The ID of the database in development mode
      */
     id: string;
 
     /**
-     * The name of the database
+     * Whether the database is running remotely
      */
-    name: string;
-
-    /**
-     * Development mode properties
-     * @internal
-     */
-    dev: {
-      /**
-       * The ID of the database in development mode
-       */
-      id: string;
-
-      /**
-       * Whether the database is running remotely
-       */
-      remote: boolean;
-    };
+    remote: boolean;
   };
+};
 
 /**
  * Creates and manages Cloudflare D1 Databases.
@@ -286,7 +285,7 @@ const _D1Database = Resource(
           rootDir: this.scope.rootDir,
         });
       }
-      return this({
+      return {
         type: "d1",
         id: this.output?.id ?? "",
         name: databaseName,
@@ -295,7 +294,7 @@ const _D1Database = Resource(
         migrationsDir: props.migrationsDir,
         migrationsTable: props.migrationsTable ?? DEFAULT_MIGRATIONS_TABLE,
         dev,
-      });
+      };
     }
 
     const api = await createCloudflareApi(props);
@@ -414,7 +413,7 @@ const _D1Database = Resource(
       // TODO(sam): why would this ever happen?
       throw new Error("Database ID not found");
     }
-    return this({
+    return {
       type: "d1",
       id: dbData.result.uuid!,
       name: databaseName,
@@ -423,7 +422,7 @@ const _D1Database = Resource(
       dev,
       migrationsDir: props.migrationsDir,
       migrationsTable: props.migrationsTable ?? DEFAULT_MIGRATIONS_TABLE,
-    });
+    };
   },
 );
 

--- a/alchemy/src/cloudflare/dispatch-namespace.ts
+++ b/alchemy/src/cloudflare/dispatch-namespace.ts
@@ -37,17 +37,16 @@ export interface DispatchNamespaceProps extends CloudflareApiOptions {
 }
 
 export function isDispatchNamespace(
-  resource: Resource,
+  resource: any,
 ): resource is DispatchNamespace {
-  return resource[ResourceKind] === "cloudflare::DispatchNamespace";
+  return resource?.[ResourceKind] === "cloudflare::DispatchNamespace";
 }
 
 /**
  * Output returned after Dispatch Namespace creation/update
  */
 export interface DispatchNamespace
-  extends Resource<"cloudflare::DispatchNamespace">,
-    Omit<DispatchNamespaceProps, "delete"> {
+  extends Omit<DispatchNamespaceProps, "delete"> {
   type: "dispatch_namespace";
   /**
    * The name of the namespace
@@ -182,14 +181,14 @@ export const DispatchNamespace = Resource(
       throw new Error(`Failed to get namespace information for '${namespace}'`);
     }
 
-    return this({
+    return {
       type: "dispatch_namespace",
       namespace,
       namespaceName: namespaceInfo.namespaceName,
       namespaceId: namespaceInfo.namespaceId,
       createdAt: createdAt,
       modifiedAt: Date.now(),
-    });
+    };
   },
 );
 

--- a/alchemy/src/cloudflare/dns-records.ts
+++ b/alchemy/src/cloudflare/dns-records.ts
@@ -68,7 +68,7 @@ export interface DnsRecordsProps extends CloudflareApiOptions {
 /**
  * Output returned after DNS records creation/update
  */
-export interface DnsRecords extends Resource<"cloudflare::DnsRecords"> {
+export interface DnsRecords {
   /**
    * Zone ID where records are created
    */
@@ -219,10 +219,10 @@ export const DnsRecords = Resource(
         }),
       );
 
-      return this({
+      return {
         zoneId,
         records: updatedRecords,
-      });
+      };
     }
 
     // Create new records
@@ -270,10 +270,10 @@ export const DnsRecords = Resource(
       }),
     );
 
-    return this({
+    return {
       zoneId,
       records: createdRecords,
-    });
+    };
   },
 );
 

--- a/alchemy/src/cloudflare/email-address.ts
+++ b/alchemy/src/cloudflare/email-address.ts
@@ -36,7 +36,7 @@ export interface EmailAddressProps extends CloudflareApiOptions {
 /**
  * A destination email address for Cloudflare email routing
  */
-export interface EmailAddress extends Resource<"cloudflare::EmailAddress"> {
+export interface EmailAddress {
   /**
    * The email address
    */
@@ -145,13 +145,13 @@ export const EmailAddress = Resource(
           const result =
             (await getResponse.json()) as CloudflareResponse<CloudflareEmailAddress>;
 
-          return this({
+          return {
             email: result.result.email,
             verified: result.result.verified,
             created: result.result.created,
             modified: result.result.modified,
             tag: result.result.tag,
-          });
+          };
         }
       }
     }
@@ -166,13 +166,13 @@ export const EmailAddress = Resource(
       const result =
         (await getResponse.json()) as CloudflareResponse<CloudflareEmailAddress>;
 
-      return this({
+      return {
         email: result.result.email,
         verified: result.result.verified,
         created: result.result.created,
         modified: result.result.modified,
         tag: result.result.tag,
-      });
+      };
     }
 
     // Create new email address
@@ -192,12 +192,12 @@ export const EmailAddress = Resource(
     const result =
       (await createResponse.json()) as CloudflareResponse<CloudflareEmailAddress>;
 
-    return this({
+    return {
       email: result.result.email,
       verified: result.result.verified,
       created: result.result.created,
       modified: result.result.modified,
       tag: result.result.tag,
-    });
+    };
   },
 );

--- a/alchemy/src/cloudflare/email-catch-all.ts
+++ b/alchemy/src/cloudflare/email-catch-all.ts
@@ -1,8 +1,8 @@
 import type { Context } from "../context.ts";
 import { Resource } from "../resource.ts";
 import { type CloudflareApiOptions, createCloudflareApi } from "./api.ts";
-import type { CloudflareResponse } from "./response.ts";
 import type { EmailAction, EmailMatcher } from "./email-rule.ts";
+import type { CloudflareResponse } from "./response.ts";
 import type { Zone } from "./zone.ts";
 
 /**
@@ -54,7 +54,7 @@ export interface EmailCatchAllProps extends CloudflareApiOptions {
 /**
  * A catch-all email routing rule for a Cloudflare zone
  */
-export interface EmailCatchAll extends Resource<"cloudflare::EmailCatchAll"> {
+export interface EmailCatchAll {
   /**
    * Zone ID where the catch-all rule is configured
    */
@@ -203,14 +203,14 @@ export const EmailCatchAll = Resource(
       const result =
         (await response.json()) as CloudflareResponse<CloudflareEmailCatchAll>;
 
-      return this({
+      return {
         zoneId,
         enabled: result.result.enabled,
         name: result.result.name,
         matchers: result.result.matchers,
         actions: result.result.actions,
         tag: result.result.tag,
-      });
+      };
     }
 
     // Create or update catch-all rule
@@ -236,13 +236,13 @@ export const EmailCatchAll = Resource(
     const result =
       (await response.json()) as CloudflareResponse<CloudflareEmailCatchAll>;
 
-    return this({
+    return {
       zoneId,
       enabled: result.result.enabled,
       name: result.result.name,
       matchers: result.result.matchers,
       actions: result.result.actions,
       tag: result.result.tag,
-    });
+    };
   },
 );

--- a/alchemy/src/cloudflare/email-routing.ts
+++ b/alchemy/src/cloudflare/email-routing.ts
@@ -43,7 +43,7 @@ export interface EmailRoutingProps extends CloudflareApiOptions {
 /**
  * Email routing configuration for a Cloudflare zone
  */
-export interface EmailRouting extends Resource<"cloudflare::EmailRouting"> {
+export interface EmailRouting {
   /**
    * Zone ID where email routing is configured
    */
@@ -173,14 +173,14 @@ export const EmailRouting = Resource(
       const result =
         (await getResponse.json()) as CloudflareResponse<CloudflareEmailRouting>;
 
-      return this({
+      return {
         zoneId,
         enabled: result.result.enabled,
         name: result.result.name,
         created: result.result.created,
         modified: result.result.modified,
         tag: result.result.tag,
-      });
+      };
     }
 
     // Create/Enable email routing
@@ -218,13 +218,13 @@ export const EmailRouting = Resource(
     const result =
       (await getResponse.json()) as CloudflareResponse<CloudflareEmailRouting>;
 
-    return this({
+    return {
       zoneId,
       enabled: result.result.enabled,
       name: result.result.name,
       created: result.result.created,
       modified: result.result.modified,
       tag: result.result.tag,
-    });
+    };
   },
 );

--- a/alchemy/src/cloudflare/email-rule.ts
+++ b/alchemy/src/cloudflare/email-rule.ts
@@ -104,7 +104,7 @@ export interface EmailRuleProps extends CloudflareApiOptions {
 /**
  * An email routing rule for a Cloudflare zone
  */
-export interface EmailRule extends Resource<"cloudflare::EmailRule"> {
+export interface EmailRule {
   /**
    * Zone ID where the rule is created
    */
@@ -274,7 +274,7 @@ export const EmailRule = Resource(
         const result =
           (await response.json()) as CloudflareResponse<CloudflareEmailRule>;
 
-        return this({
+        return {
           zoneId,
           ruleId: result.result.id,
           name: result.result.name,
@@ -283,7 +283,7 @@ export const EmailRule = Resource(
           matchers: result.result.matchers,
           actions: result.result.actions,
           tag: result.result.tag,
-        });
+        };
       }
     }
 
@@ -308,7 +308,7 @@ export const EmailRule = Resource(
     const result =
       (await createResponse.json()) as CloudflareResponse<CloudflareEmailRule>;
 
-    return this({
+    return {
       zoneId,
       ruleId: result.result.id,
       name: result.result.name,
@@ -317,6 +317,6 @@ export const EmailRule = Resource(
       matchers: result.result.matchers,
       actions: result.result.actions,
       tag: result.result.tag,
-    });
+    };
   },
 );

--- a/alchemy/src/cloudflare/hyperdrive.ts
+++ b/alchemy/src/cloudflare/hyperdrive.ts
@@ -190,45 +190,44 @@ export interface HyperdriveProps extends CloudflareApiOptions {
  * Output returned after Cloudflare Hyperdrive creation/update.
  * IMPORTANT: The interface name MUST match the exported resource name.
  */
-export type Hyperdrive = Resource<"cloudflare::Hyperdrive"> &
-  Omit<HyperdriveProps, "origin" | "dev"> & {
-    /**
-     * The ID of the resource
-     */
-    id: string;
+export type Hyperdrive = Omit<HyperdriveProps, "origin" | "dev"> & {
+  /**
+   * The ID of the resource
+   */
+  id: string;
 
-    /**
-     * Name of the Hyperdrive configuration
-     */
-    name: string;
+  /**
+   * Name of the Hyperdrive configuration
+   */
+  name: string;
 
-    /**
-     * The Cloudflare-generated UUID of the hyperdrive
-     */
-    hyperdriveId: string;
+  /**
+   * The Cloudflare-generated UUID of the hyperdrive
+   */
+  hyperdriveId: string;
 
-    /**
-     * Database connection origin configuration
-     */
-    origin: HyperdrivePublicOrigin | HyperdriveOriginWithAccess;
+  /**
+   * Database connection origin configuration
+   */
+  origin: HyperdrivePublicOrigin | HyperdriveOriginWithAccess;
 
+  /**
+   * Local development configuration
+   * @internal
+   */
+  dev: {
     /**
-     * Local development configuration
-     * @internal
+     * The connection string to use for local development
      */
-    dev: {
-      /**
-       * The connection string to use for local development
-       */
-      origin: Secret;
-    };
-
-    /**
-     * Resource type identifier for binding.
-     * @internal
-     */
-    type: "hyperdrive";
+    origin: Secret;
   };
+
+  /**
+   * Resource type identifier for binding.
+   * @internal
+   */
+  type: "hyperdrive";
+};
 
 /**
  * Represents a Cloudflare Hyperdrive configuration.
@@ -356,7 +355,7 @@ const _Hyperdrive = Resource(
       props.name ?? this.output?.name ?? this.scope.createPhysicalName(id);
 
     if (this.scope.local) {
-      return this({
+      return {
         id,
         hyperdriveId: hyperdriveId || "",
         name,
@@ -365,7 +364,7 @@ const _Hyperdrive = Resource(
         mtls: props.mtls,
         dev: props.dev,
         type: "hyperdrive",
-      });
+      };
     }
     const api = await createCloudflareApi(props);
 
@@ -445,7 +444,7 @@ const _Hyperdrive = Resource(
     }
 
     // Construct the output object from API response and props
-    return this({
+    return {
       id,
       hyperdriveId: result.id, // Store the Cloudflare-assigned UUID
       name: result.name,
@@ -454,7 +453,7 @@ const _Hyperdrive = Resource(
       mtls: result.mtls,
       dev: props.dev,
       type: "hyperdrive",
-    });
+    };
   },
 );
 

--- a/alchemy/src/cloudflare/kv-namespace.ts
+++ b/alchemy/src/cloudflare/kv-namespace.ts
@@ -95,47 +95,46 @@ export interface KVPair {
   metadata?: any;
 }
 
-export function isKVNamespace(resource: Resource): resource is KVNamespace {
-  return resource[ResourceKind] === "cloudflare::KVNamespace";
+export function isKVNamespace(resource: any): resource is KVNamespace {
+  return resource?.[ResourceKind] === "cloudflare::KVNamespace";
 }
 
 /**
  * Output returned after KV Namespace creation/update
  */
-export type KVNamespace = Resource<"cloudflare::KVNamespace"> &
-  Omit<KVNamespaceProps, "delete" | "dev"> & {
-    type: "kv_namespace";
+export type KVNamespace = Omit<KVNamespaceProps, "delete" | "dev"> & {
+  type: "kv_namespace";
+  /**
+   * The ID of the namespace
+   */
+  namespaceId: string;
+
+  /**
+   * Time at which the namespace was created
+   */
+  createdAt: number;
+
+  /**
+   * Time at which the namespace was last modified
+   */
+  modifiedAt: number;
+
+  /**
+   * Development mode properties
+   * @internal
+   */
+  dev: {
     /**
-     * The ID of the namespace
+     * The ID of the KV namespace in development mode
      */
-    namespaceId: string;
+    id: string;
 
     /**
-     * Time at which the namespace was created
+     * Whether the KV namespace is running remotely
      */
-    createdAt: number;
-
-    /**
-     * Time at which the namespace was last modified
-     */
-    modifiedAt: number;
-
-    /**
-     * Development mode properties
-     * @internal
-     */
-    dev: {
-      /**
-       * The ID of the KV namespace in development mode
-       */
-      id: string;
-
-      /**
-       * Whether the KV namespace is running remotely
-       */
-      remote: boolean;
-    };
+    remote: boolean;
   };
+};
 
 /**
  * A Cloudflare KV Namespace is a key-value store that can be used to store data for your application.
@@ -221,7 +220,7 @@ const _KVNamespace = Resource(
     };
 
     if (local) {
-      return this({
+      return {
         type: "kv_namespace",
         namespaceId: this.output?.namespaceId ?? "",
         title,
@@ -229,7 +228,7 @@ const _KVNamespace = Resource(
         dev,
         createdAt: this.output?.createdAt ?? Date.now(),
         modifiedAt: Date.now(),
-      });
+      };
     }
 
     const api = await createCloudflareApi(props);
@@ -260,7 +259,7 @@ const _KVNamespace = Resource(
 
     await insertKVRecords(api, result.namespaceId, props);
 
-    return this({
+    return {
       type: "kv_namespace",
       namespaceId: result.namespaceId,
       title,
@@ -268,7 +267,7 @@ const _KVNamespace = Resource(
       dev,
       createdAt: result.createdAt,
       modifiedAt: Date.now(),
-    });
+    };
   },
 );
 

--- a/alchemy/src/cloudflare/permission-groups.ts
+++ b/alchemy/src/cloudflare/permission-groups.ts
@@ -45,7 +45,7 @@ export type R2PermissionGroups =
  *
  * @see https://developers.cloudflare.com/r2/api/tokens/#permissions
  */
-export type PermissionGroups = Resource<"cloudflare::PermissionGroups"> & {
+export type PermissionGroups = {
   /**
    * Admin Read & Write - Allows create, list, delete buckets and edit bucket configurations
    * plus list, write, and read object access
@@ -140,10 +140,8 @@ export const PermissionGroups = Resource(
       );
     }
 
-    return this(
-      Object.fromEntries(
-        data.result.map((group) => [group.name, group]),
-      ) as PermissionGroups,
-    );
+    return Object.fromEntries(
+      data.result.map((group) => [group.name, group]),
+    ) as PermissionGroups;
   },
 );

--- a/alchemy/src/cloudflare/pipeline.ts
+++ b/alchemy/src/cloudflare/pipeline.ts
@@ -229,41 +229,40 @@ export interface PipelineRecord {
   [key: string]: any;
 }
 
-export function isPipeline(resource: Resource): resource is Pipeline {
-  return resource[ResourceKind] === "cloudflare::Pipeline";
+export function isPipeline(resource: any): resource is Pipeline {
+  return resource?.[ResourceKind] === "cloudflare::Pipeline";
 }
 
 /**
  * Output returned after Pipeline creation/update
  */
 export type Pipeline<_T extends PipelineRecord = PipelineRecord> =
-  Resource<"cloudflare::Pipeline"> &
-    PipelineProps & {
-      /**
-       * Type identifier for the Pipeline resource
-       */
-      type: "pipeline";
+  PipelineProps & {
+    /**
+     * Type identifier for the Pipeline resource
+     */
+    type: "pipeline";
 
-      /**
-       * The unique ID of the pipeline
-       */
-      id: string;
+    /**
+     * The unique ID of the pipeline
+     */
+    id: string;
 
-      /**
-       * The name of the pipeline
-       */
-      name: string;
+    /**
+     * The name of the pipeline
+     */
+    name: string;
 
-      /**
-       * HTTP endpoint URL for the pipeline
-       */
-      endpoint: string;
+    /**
+     * HTTP endpoint URL for the pipeline
+     */
+    endpoint: string;
 
-      /**
-       * Version of the pipeline
-       */
-      version: number;
-    };
+    /**
+     * Version of the pipeline
+     */
+    version: number;
+  };
 
 /**
  * Creates and manages Cloudflare Pipelines.
@@ -341,7 +340,7 @@ export const Pipeline = Resource("cloudflare::Pipeline", async function <
     props.name ?? this.output?.name ?? this.scope.createPhysicalName(id);
 
   if (this.scope.local && !props.dev?.remote) {
-    return this({
+    return {
       type: "pipeline",
       id: this.output?.id ?? "",
       name: this.output?.name ?? pipelineName,
@@ -351,7 +350,7 @@ export const Pipeline = Resource("cloudflare::Pipeline", async function <
       destination: props.destination,
       compression: props.compression,
       accountId: this.output?.accountId ?? "",
-    });
+    };
   }
 
   if (this.phase === "update" && this.output?.name !== pipelineName) {
@@ -418,7 +417,7 @@ export const Pipeline = Resource("cloudflare::Pipeline", async function <
     }
   }
 
-  return this({
+  return {
     type: "pipeline",
     id: pipelineData.result.id,
     name: pipelineName,
@@ -433,7 +432,7 @@ export const Pipeline = Resource("cloudflare::Pipeline", async function <
     destination: props.destination, // Use the input destination, not the API response
     compression: props.compression,
     accountId: api.accountId,
-  });
+  };
 });
 
 interface CloudflarePipelineResponse {

--- a/alchemy/src/cloudflare/queue-consumer.ts
+++ b/alchemy/src/cloudflare/queue-consumer.ts
@@ -96,9 +96,7 @@ export interface QueueConsumerProps extends CloudflareApiOptions {
 /**
  * Output returned after Queue Consumer creation/update
  */
-export interface QueueConsumer
-  extends Resource<"cloudflare::QueueConsumer">,
-    QueueConsumerProps {
+export interface QueueConsumer extends QueueConsumerProps {
   /**
    * Unique ID for the consumer
    */
@@ -162,7 +160,7 @@ export const QueueConsumer = Resource(
       typeof props.queue === "string" ? props.queue : props.queue.id;
 
     if (this.scope.local && props.dev) {
-      return this({
+      return {
         id: this.output?.id ?? "",
         queueId,
         queue: props.queue,
@@ -170,7 +168,7 @@ export const QueueConsumer = Resource(
         scriptName: props.scriptName,
         settings: props.settings,
         accountId: this.output?.accountId ?? "",
-      });
+      };
     }
 
     const api = await createCloudflareApi(props);
@@ -231,7 +229,7 @@ export const QueueConsumer = Resource(
       );
     }
 
-    return this({
+    return {
       id: consumerData.result.consumer_id,
       queueId,
       queue: props.queue,
@@ -249,7 +247,7 @@ export const QueueConsumer = Resource(
         : undefined,
       createdOn: consumerData.result.created_on,
       accountId: api.accountId,
-    });
+    };
   },
 );
 

--- a/alchemy/src/cloudflare/queue.ts
+++ b/alchemy/src/cloudflare/queue.ts
@@ -100,56 +100,55 @@ export function isQueue(eventSource: any): eventSource is Queue {
 /**
  * Output returned after Cloudflare Queue creation/update
  */
-export type Queue<Body = unknown> = Resource<"cloudflare::Queue"> &
-  Omit<QueueProps, "dev"> & {
-    /**
-     * Type identifier for Cloudflare Queue
-     */
-    type: "queue";
+export type Queue<Body = unknown> = Omit<QueueProps, "dev"> & {
+  /**
+   * Type identifier for Cloudflare Queue
+   */
+  type: "queue";
 
+  /**
+   * The unique ID of the queue
+   */
+  id: string;
+
+  /**
+   * The name of the queue
+   */
+  name: string;
+
+  /**
+   * Time when the queue was created
+   */
+  createdOn: string;
+
+  /**
+   * Modified timestamp
+   */
+  modifiedOn: string;
+
+  /**
+   * Phantom property to allow type inference
+   */
+  Body: Body;
+
+  Batch: MessageBatch<Body>;
+
+  /**
+   * Development mode properties
+   * @internal
+   */
+  dev: {
     /**
-     * The unique ID of the queue
+     * The ID of the queue in development mode
      */
     id: string;
 
     /**
-     * The name of the queue
+     * Whether the queue is running remotely
      */
-    name: string;
-
-    /**
-     * Time when the queue was created
-     */
-    createdOn: string;
-
-    /**
-     * Modified timestamp
-     */
-    modifiedOn: string;
-
-    /**
-     * Phantom property to allow type inference
-     */
-    Body: Body;
-
-    Batch: MessageBatch<Body>;
-
-    /**
-     * Development mode properties
-     * @internal
-     */
-    dev: {
-      /**
-       * The ID of the queue in development mode
-       */
-      id: string;
-
-      /**
-       * Whether the queue is running remotely
-       */
-      remote: boolean;
-    };
+    remote: boolean;
   };
+};
 
 /**
  * Creates and manages Cloudflare Queues.
@@ -256,7 +255,7 @@ const _Queue = Resource("cloudflare::Queue", async function <
     remote: props.dev?.remote ?? false,
   };
   if (this.scope.local && !props.dev?.remote) {
-    return this({
+    return {
       type: "queue",
       id: this.output?.id ?? "",
       name: queueName,
@@ -265,7 +264,7 @@ const _Queue = Resource("cloudflare::Queue", async function <
       modifiedOn: this.output?.modifiedOn ?? new Date().toISOString(),
       Body: undefined as T,
       Batch: undefined! as MessageBatch<T>,
-    });
+    };
   }
 
   const api = await createCloudflareApi(props);
@@ -320,7 +319,7 @@ const _Queue = Resource("cloudflare::Queue", async function <
     }
   }
 
-  return this({
+  return {
     type: "queue",
     id: queueData.result.queue_id || "",
     name: queueName,
@@ -340,7 +339,7 @@ const _Queue = Resource("cloudflare::Queue", async function <
     // phantom properties
     Body: undefined as T,
     Batch: undefined! as MessageBatch<T>,
-  });
+  };
 });
 
 interface CloudflareQueueResponse {

--- a/alchemy/src/cloudflare/redirect-rule.ts
+++ b/alchemy/src/cloudflare/redirect-rule.ts
@@ -94,7 +94,7 @@ interface CloudflareRule {
 /**
  * Output returned after RedirectRule creation/update
  */
-export interface RedirectRule extends Resource<"cloudflare::RedirectRule"> {
+export interface RedirectRule {
   /**
    * The ID of the redirect rule
    */
@@ -263,7 +263,7 @@ export const RedirectRule = Resource(
         },
       );
 
-      return this({
+      return {
         ruleId: updatedRule.id,
         rulesetId: this.output.rulesetId,
         zoneId,
@@ -274,7 +274,7 @@ export const RedirectRule = Resource(
         preserveQueryString,
         enabled: updatedRule.enabled ?? true,
         lastUpdated: updatedRule.last_updated,
-      });
+      };
     }
 
     // Get or create the redirect ruleset for this zone
@@ -288,7 +288,7 @@ export const RedirectRule = Resource(
       preserveQueryString,
     });
 
-    return this({
+    return {
       ruleId: createdRule.id,
       rulesetId,
       zoneId,
@@ -299,7 +299,7 @@ export const RedirectRule = Resource(
       preserveQueryString,
       enabled: createdRule.enabled ?? true,
       lastUpdated: createdRule.last_updated,
-    });
+    };
   },
 );
 

--- a/alchemy/src/cloudflare/route.ts
+++ b/alchemy/src/cloudflare/route.ts
@@ -62,7 +62,7 @@ export interface RouteProps extends CloudflareApiOptions {
 /**
  * Output returned after Route creation/update
  */
-export interface Route extends Resource<"cloudflare::Route">, RouteProps {
+export interface Route extends RouteProps {
   /**
    * The unique ID of the route
    */
@@ -166,12 +166,12 @@ export const Route = Resource(
         zoneId = this.output?.zoneId ?? "noop-zone";
       }
 
-      return this({
+      return {
         id: this.output?.id ?? "noop-route",
         pattern: props.pattern,
         script: scriptName,
         zoneId: zoneId,
-      });
+      };
     }
 
     // Get or infer zone ID (only needed for create/update phases)
@@ -247,12 +247,12 @@ export const Route = Resource(
     }
 
     // Return the route resource
-    return this({
+    return {
       id: routeData.result.id,
       pattern: routeData.result.pattern,
       script: routeData.result.script,
       zoneId,
-    });
+    };
   },
 );
 

--- a/alchemy/src/cloudflare/ruleset.ts
+++ b/alchemy/src/cloudflare/ruleset.ts
@@ -46,8 +46,7 @@ export interface RulesetProps<Phase extends RulePhase>
 /**
  * Output returned after Ruleset creation/update
  */
-export interface Ruleset<Phase extends RulePhase>
-  extends Resource<"cloudflare::Ruleset"> {
+export interface Ruleset<Phase extends RulePhase> {
   /**
    * The ID of the ruleset
    */
@@ -185,7 +184,7 @@ export const Ruleset = Resource("cloudflare::Ruleset", async function <
   });
 
   // Transform response back to our format
-  return this({
+  return {
     id: result.id,
     zoneId,
     phase: props.phase,
@@ -194,7 +193,7 @@ export const Ruleset = Resource("cloudflare::Ruleset", async function <
     rules: (result.rules as Array<Rule> | undefined) ?? [],
     lastUpdated: result.last_updated,
     version: result.version,
-  });
+  };
 });
 
 interface CloudflareApiRuleset {

--- a/alchemy/src/cloudflare/secret.ts
+++ b/alchemy/src/cloudflare/secret.ts
@@ -51,42 +51,41 @@ export interface SecretProps extends CloudflareApiOptions {
   delete?: boolean;
 }
 
-export function isSecret(resource: Resource): resource is Secret {
-  return resource[ResourceKind] === "cloudflare::Secret";
+export function isSecret(resource: any): resource is Secret {
+  return resource?.[ResourceKind] === "cloudflare::Secret";
 }
 
-export type Secret = Resource<"cloudflare::Secret"> &
-  Omit<SecretProps, "delete" | "value"> & {
-    /**
-     * The binding type for Cloudflare Workers
-     */
-    type: "secrets_store_secret";
+export type Secret = Omit<SecretProps, "delete" | "value"> & {
+  /**
+   * The binding type for Cloudflare Workers
+   */
+  type: "secrets_store_secret";
 
-    /**
-     * The name of the secret
-     */
-    name: string;
+  /**
+   * The name of the secret
+   */
+  name: string;
 
-    /**
-     * The unique identifier of the secrets store this secret belongs to
-     */
-    storeId: string;
+  /**
+   * The unique identifier of the secrets store this secret belongs to
+   */
+  storeId: string;
 
-    /**
-     * The secret value (as an alchemy Secret instance)
-     */
-    value: AlchemySecret;
+  /**
+   * The secret value (as an alchemy Secret instance)
+   */
+  value: AlchemySecret;
 
-    /**
-     * Timestamp when the secret was created
-     */
-    createdAt: number;
+  /**
+   * Timestamp when the secret was created
+   */
+  createdAt: number;
 
-    /**
-     * Timestamp when the secret was last modified
-     */
-    modifiedAt: number;
-  };
+  /**
+   * Timestamp when the secret was last modified
+   */
+  modifiedAt: number;
+};
 
 /**
  * A Cloudflare Secret represents an individual secret stored in a Secrets Store.
@@ -197,7 +196,7 @@ const _Secret = Resource(
     // Insert or update the secret
     await insertSecret(api, storeId, secretName, props.value);
 
-    return this({
+    return {
       type: "secrets_store_secret",
       name: secretName,
       storeId,
@@ -205,7 +204,7 @@ const _Secret = Resource(
       value: props.value,
       createdAt,
       modifiedAt: Date.now(),
-    });
+    };
   },
 );
 

--- a/alchemy/src/cloudflare/secrets-store.ts
+++ b/alchemy/src/cloudflare/secrets-store.ts
@@ -54,16 +54,13 @@ export interface SecretsStoreProps<
   delete?: boolean;
 }
 
-export function isSecretsStore(
-  resource: Resource,
-): resource is SecretsStore<any> {
-  return resource[ResourceKind] === "cloudflare::SecretsStore";
+export function isSecretsStore(resource: any): resource is SecretsStore<any> {
+  return resource?.[ResourceKind] === "cloudflare::SecretsStore";
 }
 
 export interface SecretsStore<
   S extends Record<string, Secret> | undefined = undefined,
-> extends Resource<"cloudflare::SecretsStore">,
-    Omit<SecretsStoreProps<S>, "delete"> {
+> extends Omit<SecretsStoreProps<S>, "delete"> {
   /**
    * The unique identifier of the secrets store
    */
@@ -240,13 +237,13 @@ const _SecretsStore = Resource("cloudflare::SecretsStore", async function <
     await insertSecrets(api, storeId, props);
   }
 
-  return this({
+  return {
     id: storeId,
     name: name,
     secrets: props.secrets as S,
     createdAt: createdAt,
     modifiedAt: Date.now(),
-  });
+  };
 });
 
 export async function createSecretsStore<

--- a/alchemy/src/cloudflare/tunnel.ts
+++ b/alchemy/src/cloudflare/tunnel.ts
@@ -264,16 +264,14 @@ export interface OriginRequestConfig {
   tcpKeepAliveInterval?: number;
 }
 
-export function isTunnel(resource: Resource): resource is Tunnel {
-  return resource[ResourceKind] === "cloudflare::Tunnel";
+export function isTunnel(resource: any): resource is Tunnel {
+  return resource?.[ResourceKind] === "cloudflare::Tunnel";
 }
 
 /**
  * Output returned after Tunnel creation/update
  */
-export interface Tunnel
-  extends Resource<"cloudflare::Tunnel">,
-    Omit<TunnelProps, "delete" | "tunnelSecret"> {
+export interface Tunnel extends Omit<TunnelProps, "delete" | "tunnelSecret"> {
   /**
    * The name of the tunnel
    */
@@ -667,7 +665,7 @@ export const Tunnel = Resource(
     }
 
     // Transform API response to our interface
-    return this({
+    return {
       tunnelId: tunnelData.id,
       accountTag: tunnelData.account_tag,
       name: tunnelData.name,
@@ -697,7 +695,7 @@ export const Tunnel = Resource(
       originRequest: props.originRequest,
       configSrc: props.configSrc,
       dnsRecords: Object.keys(dnsRecords).length > 0 ? dnsRecords : undefined,
-    });
+    };
   },
 );
 

--- a/alchemy/src/cloudflare/vectorize-index.ts
+++ b/alchemy/src/cloudflare/vectorize-index.ts
@@ -51,18 +51,14 @@ export interface VectorizeIndexProps extends CloudflareApiOptions {
   adopt?: boolean;
 }
 
-export function isVectorizeIndex(
-  resource: Resource,
-): resource is VectorizeIndex {
-  return resource[ResourceKind] === "cloudflare::VectorizeIndex";
+export function isVectorizeIndex(resource: any): resource is VectorizeIndex {
+  return resource?.[ResourceKind] === "cloudflare::VectorizeIndex";
 }
 
 /**
  * Output returned after Vectorize Index creation/update
  */
-export interface VectorizeIndex
-  extends Resource<"cloudflare::VectorizeIndex">,
-    VectorizeIndexProps {
+export interface VectorizeIndex extends VectorizeIndexProps {
   type: "vectorize";
 
   /**
@@ -176,10 +172,10 @@ export const VectorizeIndex = Resource(
             `Attempted to update Vectorize index ${indexName} but only the delete property can be changed.`,
           );
         }
-        return this({
+        return {
           ...this.output,
           delete: props.delete,
-        });
+        };
       }
 
       // Check if this is a no-op update
@@ -194,7 +190,7 @@ export const VectorizeIndex = Resource(
             `Attempted to update Vectorize index ${indexName} but it was a no-op.`,
           );
         }
-        return this(this.output);
+        return this.output;
       }
 
       // Update operation is not supported by Vectorize API
@@ -204,7 +200,7 @@ export const VectorizeIndex = Resource(
       );
     }
 
-    return this({
+    return {
       type: "vectorize",
       id: indexName,
       name: indexName,
@@ -218,7 +214,7 @@ export const VectorizeIndex = Resource(
       createdAt: indexData.result.created_on
         ? new Date(indexData.result.created_on).getTime()
         : undefined,
-    });
+    };
   },
 );
 

--- a/alchemy/src/cloudflare/vectorize-metadata-index.ts
+++ b/alchemy/src/cloudflare/vectorize-metadata-index.ts
@@ -30,17 +30,15 @@ export interface VectorizeMetadataIndexProps extends CloudflareApiOptions {
 }
 
 export function isVectorizeMetadataIndex(
-  resource: Resource,
+  resource: any,
 ): resource is VectorizeMetadataIndex {
-  return resource[ResourceKind] === "cloudflare::VectorizeMetadataIndex";
+  return resource?.[ResourceKind] === "cloudflare::VectorizeMetadataIndex";
 }
 
 /**
  * Output returned after Vectorize Metadata Index creation/deletion
  */
-export interface VectorizeMetadataIndex
-  extends Resource<"cloudflare::VectorizeMetadataIndex">,
-    VectorizeMetadataIndexProps {
+export interface VectorizeMetadataIndex extends VectorizeMetadataIndexProps {
   /**
    * ID of this metadata index (derived from propertyName)
    */
@@ -126,7 +124,7 @@ export const VectorizeMetadataIndex = Resource(
             `Attempted to update Vectorize metadata index ${this.props.propertyName} but it was a no-op.`,
           );
         }
-        return this(this.output);
+        return this.output;
       }
       // Update operation is not supported
       throw new Error(
@@ -136,14 +134,14 @@ export const VectorizeMetadataIndex = Resource(
     }
     const indexData = await createMetadataIndex(api, indexName, props);
 
-    return this({
+    return {
       id: propertyName, // Use propertyName as ID
       index: props.index,
       propertyName: props.propertyName,
       indexType: props.indexType,
       accountId: api.accountId,
       mutationId: indexData.result.mutationId,
-    });
+    };
   },
 );
 

--- a/alchemy/src/cloudflare/worker-stub.ts
+++ b/alchemy/src/cloudflare/worker-stub.ts
@@ -43,7 +43,7 @@ export interface WorkerStubProps<
  */
 export interface WorkerStub<
   RPC extends Rpc.WorkerEntrypointBranded = Rpc.WorkerEntrypointBranded,
-> extends Resource<"cloudflare::WorkerStub"> {
+> {
   type: "service";
   /**
    * The name of the worker
@@ -64,8 +64,8 @@ export interface WorkerStub<
   __rpc__?: RPC;
 }
 
-export function isWorkerStub(resource: Resource): resource is WorkerStub {
-  return resource[ResourceKind] === "cloudflare::WorkerStub";
+export function isWorkerStub(resource: any): resource is WorkerStub {
+  return resource?.[ResourceKind] === "cloudflare::WorkerStub";
 }
 
 /**
@@ -120,12 +120,12 @@ export const WorkerStub = Resource("cloudflare::WorkerStub", async function <
       : undefined;
 
   // Return the worker stub info
-  return this({
+  return {
     type: "service",
     __rpc__: props.rpc as unknown as RPC,
     ...props,
     url: subdomain?.url,
-  }) as WorkerStub<RPC>;
+  } as WorkerStub<RPC>;
 });
 
 async function exists(

--- a/alchemy/src/cloudflare/worker-subdomain.ts
+++ b/alchemy/src/cloudflare/worker-subdomain.ts
@@ -37,8 +37,7 @@ interface WorkerSubdomainProps extends CloudflareApiOptions {
   dev?: boolean;
 }
 
-export interface WorkerSubdomain
-  extends Resource<"cloudflare::WorkerSubdomain"> {
+export interface WorkerSubdomain {
   /**
    * The `workers.dev` URL for the worker or preview version.
    */
@@ -49,13 +48,13 @@ export const WorkerSubdomain = Resource(
   "cloudflare::WorkerSubdomain",
   async function (
     this: Context<WorkerSubdomain>,
-    id: string,
+    _id: string,
     props: WorkerSubdomainProps,
   ) {
     if (this.scope.local && props.dev) {
-      return this({
+      return {
         url: this.output?.url ?? "https://unavailable.alchemy.run",
-      });
+      };
     }
 
     const api = await createCloudflareApi(props);
@@ -74,9 +73,9 @@ export const WorkerSubdomain = Resource(
     } else {
       url = `https://${props.scriptName}.${base}`;
     }
-    return this(id, {
+    return {
       url,
-    });
+    };
   },
 );
 

--- a/alchemy/src/cloudflare/worker.ts
+++ b/alchemy/src/cloudflare/worker.ts
@@ -432,8 +432,8 @@ export type WorkerProps<
   RPC extends Rpc.WorkerEntrypointBranded = Rpc.WorkerEntrypointBranded,
 > = InlineWorkerProps<B, RPC> | EntrypointWorkerProps<B, RPC>;
 
-export function isWorker(resource: Resource): resource is Worker<any> {
-  return resource[ResourceKind] === "cloudflare::Worker";
+export function isWorker(resource: any): resource is Worker<any> {
+  return resource?.[ResourceKind] === "cloudflare::Worker";
 }
 
 /**
@@ -442,109 +442,108 @@ export function isWorker(resource: Resource): resource is Worker<any> {
 export type Worker<
   B extends Bindings | undefined = Bindings | undefined,
   RPC extends Rpc.WorkerEntrypointBranded = Rpc.WorkerEntrypointBranded,
-> = Resource<"cloudflare::Worker"> &
-  Omit<WorkerProps<B>, "url" | "script" | "routes" | "domains"> & {
-    /** @internal phantom property */
-    __rpc__?: RPC;
+> = Omit<WorkerProps<B>, "url" | "script" | "routes" | "domains"> & {
+  /** @internal phantom property */
+  __rpc__?: RPC;
 
-    type: "service";
+  type: "service";
 
-    /**
-     * The ID of the worker
-     */
-    id: string;
+  /**
+   * The ID of the worker
+   */
+  id: string;
 
-    /**
-     * The name of the worker
-     */
-    name: string;
+  /**
+   * The name of the worker
+   */
+  name: string;
 
-    /**
-     * The root directory of the project
-     * @default process.cwd()
-     */
-    cwd: string;
+  /**
+   * The root directory of the project
+   * @default process.cwd()
+   */
+  cwd: string;
 
-    /**
-     * Time at which the worker was created
-     */
-    createdAt: number;
+  /**
+   * Time at which the worker was created
+   */
+  createdAt: number;
 
-    /**
-     * Time at which the worker was last updated
-     */
-    updatedAt: number;
+  /**
+   * Time at which the worker was last updated
+   */
+  updatedAt: number;
 
-    /**
-     * The worker's URL if enabled
-     * Format: {name}.{subdomain}.workers.dev
-     *
-     * @default true
-     */
-    url?: string;
+  /**
+   * The worker's URL if enabled
+   * Format: {name}.{subdomain}.workers.dev
+   *
+   * @default true
+   */
+  url?: string;
 
-    /**
-     * The bindings that were created
-     */
-    bindings: B;
+  /**
+   * The bindings that were created
+   */
+  bindings: B;
 
-    /**
-     * Configuration for static assets
-     */
-    assets?: AssetsConfig;
+  /**
+   * Configuration for static assets
+   */
+  assets?: AssetsConfig;
 
-    /**
-     * The routes that were created for this worker
-     */
-    routes?: Route[];
+  /**
+   * The routes that were created for this worker
+   */
+  routes?: Route[];
 
-    /**
-     * The custom domains that were created for this worker
-     */
-    domains?: CustomDomain[];
+  /**
+   * The custom domains that were created for this worker
+   */
+  domains?: CustomDomain[];
 
-    // phantom property (for typeof myWorker.Env)
-    Env: B extends Bindings
-      ? {
-          [bindingName in keyof B]: Bound<B[bindingName]>;
-        }
-      : undefined;
+  // phantom property (for typeof myWorker.Env)
+  Env: B extends Bindings
+    ? {
+        [bindingName in keyof B]: Bound<B[bindingName]>;
+      }
+    : undefined;
 
-    /**
-     * The compatibility date for the worker
-     */
-    compatibilityDate: string;
+  /**
+   * The compatibility date for the worker
+   */
+  compatibilityDate: string;
 
-    /**
-     * The compatibility flags for the worker
-     */
-    compatibilityFlags: string[];
+  /**
+   * The compatibility flags for the worker
+   */
+  compatibilityFlags: string[];
 
-    /**
-     * The dispatch namespace this worker is deployed to
-     */
-    namespace?: string | DispatchNamespace;
+  /**
+   * The dispatch namespace this worker is deployed to
+   */
+  namespace?: string | DispatchNamespace;
 
-    /**
-     * Version label for this worker deployment
-     */
-    version?: string;
+  /**
+   * Version label for this worker deployment
+   */
+  version?: string;
 
-    /**
-     * Smart placement configuration for the worker
-     */
-    placement?: {
-      mode: "smart";
-    };
-
-    /**
-     * Whether the worker has a remote deployment
-     * @internal
-     */
-    dev?: {
-      hasRemote: boolean;
-    };
+  /**
+   * Smart placement configuration for the worker
+   */
+  placement?: {
+    mode: "smart";
   };
+
+  /**
+   * Whether the worker has a remote deployment
+   * @internal
+   */
+  dev?: {
+    hasRemote: boolean;
+  };
+};
 
 /**
  * A Cloudflare Worker is a serverless function that can be deployed to the Cloudflare network.
@@ -901,7 +900,7 @@ const _Worker = Resource(
           containers: options.containers,
         },
       );
-      return this({
+      return {
         ...props,
         type: "service",
         id,
@@ -920,7 +919,7 @@ const _Worker = Resource(
           hasRemote: this.output?.dev?.hasRemote ?? false,
         },
         Env: undefined!,
-      } as unknown as Worker<B>);
+      } as unknown as Worker<B>;
     }
 
     if (this.phase === "create" || this.output.dev?.hasRemote === false) {
@@ -1045,7 +1044,7 @@ const _Worker = Resource(
     );
 
     const now = new Date();
-    return this({
+    return {
       ...props,
       type: "service",
       id,
@@ -1074,7 +1073,7 @@ const _Worker = Resource(
       dev: {
         hasRemote: true,
       },
-    } as unknown as Worker<B>);
+    } as unknown as Worker<B>;
   },
 );
 

--- a/alchemy/src/cloudflare/zone.ts
+++ b/alchemy/src/cloudflare/zone.ts
@@ -263,7 +263,7 @@ export interface ZoneData {
 /**
  * Output returned after Zone creation/update
  */
-export interface Zone extends Resource<"cloudflare::Zone">, ZoneData {}
+export interface Zone extends ZoneData {}
 
 /**
  * A Cloudflare Zone represents a domain and its configuration settings on Cloudflare.
@@ -425,7 +425,7 @@ export const Zone = Resource(
       this.props?.botManagement,
     );
 
-    return this({
+    return {
       id: zoneData.id,
       name: zoneData.name,
       type: zoneData.type,
@@ -440,7 +440,7 @@ export const Zone = Resource(
         ? new Date(zoneData.activated_on).getTime()
         : null,
       settings: await getZoneSettings(api, zoneData.id),
-    });
+    };
   },
 );
 

--- a/alchemy/src/context.ts
+++ b/alchemy/src/context.ts
@@ -6,24 +6,26 @@ import {
   ResourceScope,
   ResourceSeq,
   type Resource,
+  type ResourceAttributes,
   type ResourceProps,
 } from "./resource.ts";
 import type { Scope } from "./scope.ts";
 import type { State } from "./state.ts";
 
 export type Context<
-  Out extends Resource,
+  Out extends ResourceAttributes,
   Props extends ResourceProps = ResourceProps,
 > = CreateContext<Out> | UpdateContext<Out, Props> | DeleteContext<Out, Props>;
 
-export interface CreateContext<Out extends Resource> extends BaseContext<Out> {
+export interface CreateContext<Out extends ResourceAttributes>
+  extends BaseContext<Out> {
   phase: "create";
   output?: undefined;
   props?: undefined;
 }
 
 export interface UpdateContext<
-  Out extends Resource,
+  Out extends ResourceAttributes,
   Props extends ResourceProps = ResourceProps,
 > extends BaseContext<Out> {
   phase: "update";
@@ -32,7 +34,7 @@ export interface UpdateContext<
 }
 
 export interface DeleteContext<
-  Out extends Resource,
+  Out extends ResourceAttributes,
   Props extends ResourceProps = ResourceProps,
 > extends BaseContext<Out> {
   phase: "delete";
@@ -40,7 +42,7 @@ export interface DeleteContext<
   props: Props;
 }
 
-export interface BaseContext<Out extends Resource> {
+export interface BaseContext<Out extends ResourceAttributes> {
   quiet: boolean;
   stage: string;
   id: ResourceID;
@@ -94,7 +96,7 @@ export interface BaseContext<Out extends Resource> {
 export function context<
   Kind extends string,
   Props extends ResourceProps | undefined,
-  Out extends Resource,
+  Out extends ResourceAttributes,
 >({
   scope,
   phase,
@@ -114,7 +116,7 @@ export function context<
   fqn: ResourceFQN;
   seq: number;
   props: Props;
-  state: State<Kind, Props, Out>;
+  state: State<Kind, Props, Out & Resource>;
   replace: (force?: boolean) => never;
   isReplacement?: boolean;
 }): Context<Out> {

--- a/alchemy/src/destroy.ts
+++ b/alchemy/src/destroy.ts
@@ -50,10 +50,10 @@ function isScopeArgs(a: any): a is [scope: Scope, options?: DestroyOptions] {
 /**
  * Prune all resources from an Output and "down", i.e. that branches from it.
  */
-export async function destroy<Type extends string>(
+export async function destroy(
   ...args:
     | [scope: Scope, options?: DestroyOptions]
-    | [resource: Resource<Type> | undefined | null, options?: DestroyOptions]
+    | [resource: any | undefined | null, options?: DestroyOptions]
 ): Promise<void> {
   if (isScopeArgs(args)) {
     const [scope] = args;

--- a/alchemy/src/dns/import-dns.ts
+++ b/alchemy/src/dns/import-dns.ts
@@ -62,9 +62,7 @@ export interface ImportDnsRecordsProps {
 /**
  * Output returned after DNS records import
  */
-export interface ImportDnsRecords
-  extends Resource<"dns::ImportDnsRecords">,
-    ImportDnsRecordsProps {
+export interface ImportDnsRecords extends ImportDnsRecordsProps {
   /**
    * The DNS records as a flat array, directly compatible with DnsRecords function
    */
@@ -204,11 +202,11 @@ export const ImportDnsRecords = Resource(
     }
 
     // Return the resource with fetched records as a flat array
-    return this({
+    return {
       domain: props.domain,
       recordTypes: [...recordTypes],
       records: allRecords,
       importedAt: Date.now(),
-    });
+    };
   },
 );

--- a/alchemy/src/docker/container.ts
+++ b/alchemy/src/docker/container.ts
@@ -120,9 +120,7 @@ export interface ContainerProps {
 /**
  * Docker Container resource
  */
-export interface Container
-  extends Resource<"docker::Container">,
-    ContainerProps {
+export interface Container extends ContainerProps {
   /**
    * Container ID
    */
@@ -266,14 +264,13 @@ export const Container = Resource(
         containerState = "running";
       }
 
-      // Return the resource using this() to construct output
-      return this({
+      return {
         ...props,
         id: containerId,
         name: containerName,
         state: containerState,
         createdAt: Date.now(),
-      });
+      };
     }
   },
 );

--- a/alchemy/src/docker/image.ts
+++ b/alchemy/src/docker/image.ts
@@ -84,7 +84,7 @@ export interface ImageProps {
 /**
  * Docker Image resource
  */
-export interface Image extends Resource<"docker::Image">, ImageProps {
+export interface Image extends ImageProps {
   /**
    * Image name
    */
@@ -266,15 +266,14 @@ export const Image = Resource(
         }
       }
 
-      // Return the resource using this() to construct output
-      return this({
+      return {
         ...props,
         name,
         imageRef: finalImageRef,
         imageId,
         repoDigest,
         builtAt: Date.now(),
-      });
+      };
     }
   },
 );

--- a/alchemy/src/docker/network.ts
+++ b/alchemy/src/docker/network.ts
@@ -34,7 +34,7 @@ export interface NetworkProps {
 /**
  * Docker Network resource
  */
-export interface Network extends Resource<"docker::Network">, NetworkProps {
+export interface Network extends NetworkProps {
   /**
    * Network ID
    */
@@ -104,13 +104,12 @@ export const Network = Resource(
       props.driver = props.driver || "bridge";
       const networkId = await api.createNetwork(networkName, props.driver);
 
-      // Return the resource using this() to construct output
-      return this({
+      return {
         ...props,
         id: networkId,
         name: networkName,
         createdAt: Date.now(),
-      });
+      };
     }
   },
 );

--- a/alchemy/src/docker/remote-image.ts
+++ b/alchemy/src/docker/remote-image.ts
@@ -25,9 +25,7 @@ export interface RemoteImageProps {
 /**
  * Docker Remote Image resource
  */
-export interface RemoteImage
-  extends Resource<"docker::RemoteImage">,
-    RemoteImageProps {
+export interface RemoteImage extends RemoteImageProps {
   /**
    * Full image reference (name:tag)
    */
@@ -72,12 +70,11 @@ export const RemoteImage = Resource(
       // Pull image
       await api.pullImage(imageRef);
 
-      // Return the resource using this() to construct output
-      return this({
+      return {
         ...props,
         imageRef,
         createdAt: Date.now(),
-      });
+      };
     }
   },
 );

--- a/alchemy/src/docker/volume.ts
+++ b/alchemy/src/docker/volume.ts
@@ -48,7 +48,7 @@ export interface VolumeProps {
 /**
  * Docker Volume resource
  */
-export interface Volume extends Resource<"docker::Volume">, VolumeProps {
+export interface Volume extends VolumeProps {
   /**
    * Volume ID (same as name for Docker volumes)
    */
@@ -150,8 +150,7 @@ export const Volume = Resource(
       const volumeInfos = await api.inspectVolume(volumeId);
       const mountpoint = volumeInfos[0].Mountpoint;
 
-      // Return the resource using this() to construct output
-      return this({
+      return {
         ...props,
         id: volumeId,
         name: volumeName,
@@ -159,7 +158,7 @@ export const Volume = Resource(
         createdAt: Date.now(),
         labels: Array.isArray(props.labels) ? props.labels : undefined,
         driverOpts: props.driverOpts,
-      });
+      };
     }
   },
 );

--- a/alchemy/src/esbuild/bundle.ts
+++ b/alchemy/src/esbuild/bundle.ts
@@ -74,8 +74,7 @@ export interface BundleProps extends Partial<esbuild.BuildOptions> {
  * Output returned after bundle creation/update
  */
 export interface Bundle<P extends BundleProps = BundleProps>
-  extends Resource<"esbuild::Bundle">,
-    BundleProps {
+  extends BundleProps {
   /**
    * Path to the bundled file
    * Absolute or relative path to the generated bundle
@@ -161,21 +160,24 @@ export const Bundle = Resource(
     if (outputFile === undefined && bundlePath === undefined) {
       throw new Error("Failed to create bundle");
     }
+    type Path = Props extends { outdir: string } | { outfile: string }
+      ? string
+      : undefined;
     if (outputFile) {
-      return this({
+      return {
         ...props,
-        path: bundlePath,
+        path: bundlePath as Path,
         hash: outputFile.hash,
         content: outputFile.text,
-      });
+      };
     }
     const content = await fs.readFile(bundlePath!, "utf-8");
-    return this({
+    return {
       ...props,
-      path: bundlePath,
+      path: bundlePath as Path,
       hash: crypto.createHash("sha256").update(content).digest("hex"),
       content,
-    });
+    };
   },
 );
 

--- a/alchemy/src/fs/copy-file.ts
+++ b/alchemy/src/fs/copy-file.ts
@@ -28,7 +28,7 @@ export interface CopyFileProps {
 /**
  * Output returned after CopyFile creation/update
  */
-export interface CopyFile extends Resource<"fs::CopyFile">, CopyFileProps {
+export interface CopyFile extends CopyFileProps {
   /**
    * Time at which the object was created
    */
@@ -100,13 +100,13 @@ export const CopyFile = Resource(
         await fs.promises.copyFile(src, dest);
       }
 
-      return this({
+      return {
         src,
         dest,
         overwrite,
         copied: true,
         createdAt: Date.now(),
-      });
+      };
     } catch (error) {
       logger.error("Error copying file:", error);
       throw error;

--- a/alchemy/src/fs/file.ts
+++ b/alchemy/src/fs/file.ts
@@ -111,7 +111,7 @@ alchemy.folder = async (dir: string, props?: { recursive?: boolean }) => {
 /**
  * Base file resource type
  */
-export interface File extends Resource<"fs::File"> {
+export interface File {
   /**
    * Path to the file
    */
@@ -193,9 +193,9 @@ export const File = Resource(
 
     await fs.promises.writeFile(filePath, props.content);
 
-    return this({
+    return {
       path: filePath,
       content: props.content,
-    });
+    };
   },
 );

--- a/alchemy/src/fs/folder.ts
+++ b/alchemy/src/fs/folder.ts
@@ -30,7 +30,7 @@ export interface FolderProps {
 /**
  * Base folder resource type
  */
-export interface Folder extends Resource<"fs::Folder"> {
+export interface Folder {
   path: string;
 }
 
@@ -76,8 +76,8 @@ export const Folder = Resource(
     await ignore("EEXIST", async () =>
       fs.promises.mkdir(dirPath, { recursive: props?.recursive ?? true }),
     );
-    return this({
+    return {
       path: dirPath,
-    });
+    };
   },
 );

--- a/alchemy/src/github/comment.ts
+++ b/alchemy/src/github/comment.ts
@@ -47,9 +47,7 @@ export interface GitHubCommentProps {
 /**
  * Output returned after Comment creation/update
  */
-export interface GitHubComment
-  extends Resource<"github::Comment">,
-    Omit<GitHubCommentProps, "token"> {
+export interface GitHubComment extends Omit<GitHubCommentProps, "token"> {
   /**
    * The ID of the resource
    */
@@ -222,7 +220,7 @@ export const GitHubComment = Resource(
             body: props.body,
           });
 
-        return this({
+        return {
           id: `${props.owner}/${props.repository}/issues/${props.issueNumber}/comments/${updatedComment.id}`,
           commentId: updatedComment.id,
           owner: props.owner,
@@ -232,7 +230,7 @@ export const GitHubComment = Resource(
           allowDelete: props.allowDelete,
           htmlUrl: updatedComment.html_url,
           updatedAt: updatedComment.updated_at,
-        });
+        };
       } else {
         // Create new comment
         const { data: newComment } = await octokit.rest.issues.createComment({
@@ -242,7 +240,7 @@ export const GitHubComment = Resource(
           body: props.body,
         });
 
-        return this({
+        return {
           id: `${props.owner}/${props.repository}/issues/${props.issueNumber}/comments/${newComment.id}`,
           commentId: newComment.id,
           owner: props.owner,
@@ -252,7 +250,7 @@ export const GitHubComment = Resource(
           allowDelete: props.allowDelete,
           htmlUrl: newComment.html_url,
           updatedAt: newComment.updated_at,
-        });
+        };
       }
     } catch (error: any) {
       if (error.status === 403) {

--- a/alchemy/src/github/repository-environment.ts
+++ b/alchemy/src/github/repository-environment.ts
@@ -98,9 +98,7 @@ export interface RepositoryEnvironmentProps {
 /**
  * Output returned after Repository Environment creation/update
  */
-export interface RepositoryEnvironment
-  extends Resource<"github::RepositoryEnvironment">,
-    RepositoryEnvironmentProps {
+export interface RepositoryEnvironment extends RepositoryEnvironmentProps {
   /**
    * The ID of the resource
    */
@@ -442,7 +440,7 @@ export const RepositoryEnvironment = Resource(
       });
 
       // Return environment details
-      return this({
+      return {
         id: `${props.owner}/${props.repository}/${environmentName}`,
         environmentId: environmentId || env.id,
         owner: props.owner,
@@ -456,7 +454,7 @@ export const RepositoryEnvironment = Resource(
         branchPatterns: props.branchPatterns,
         token: props.token,
         updatedAt: new Date().toISOString(),
-      });
+      };
     } catch (error: any) {
       if (
         error.status === 403 &&

--- a/alchemy/src/github/repository-webhook.ts
+++ b/alchemy/src/github/repository-webhook.ts
@@ -63,9 +63,7 @@ export interface RepositoryWebhookProps {
 /**
  * Output returned after Repository Webhook creation/update
  */
-export interface RepositoryWebhook
-  extends Resource<"github::RepositoryWebhook">,
-    RepositoryWebhookProps {
+export interface RepositoryWebhook extends RepositoryWebhookProps {
   /**
    * The ID of the resource
    */
@@ -227,7 +225,7 @@ export const RepositoryWebhook = Resource(
       }
 
       // Return webhook details
-      return this({
+      return {
         id: `${props.owner}/${props.repository}/webhook/${webhookId}`,
         webhookId,
         owner: props.owner,
@@ -243,7 +241,7 @@ export const RepositoryWebhook = Resource(
         updatedAt: webhookData.updated_at,
         pingUrl: webhookData.ping_url,
         testUrl: webhookData.test_url,
-      });
+      };
     } catch (error: any) {
       if (
         error.status === 403 &&

--- a/alchemy/src/github/secret.ts
+++ b/alchemy/src/github/secret.ts
@@ -46,9 +46,7 @@ export interface GitHubSecretProps {
 /**
  * Output returned after Secret creation/update
  */
-export interface GitHubSecretOutput
-  extends Resource<"github::Secret">,
-    Omit<GitHubSecretProps, "value"> {
+export interface GitHubSecretOutput extends Omit<GitHubSecretProps, "value"> {
   /**
    * The ID of the resource
    */
@@ -280,7 +278,7 @@ export const GitHubSecret = Resource(
       }
       idParts.push(props.name);
 
-      return this({
+      return {
         id: idParts.join("/"),
         owner: props.owner,
         repository: props.repository,
@@ -288,7 +286,7 @@ export const GitHubSecret = Resource(
         environment: props.environment,
         token: props.token,
         updatedAt: new Date().toISOString(),
-      });
+      };
     } catch (error: any) {
       if (
         error.status === 403 &&

--- a/alchemy/src/neon/project.ts
+++ b/alchemy/src/neon/project.ts
@@ -435,8 +435,7 @@ interface NeonApiResponse {
  * IMPORTANT: The interface name MUST match the exported resource name
  */
 export interface NeonProject
-  extends Resource<"neon::Project">,
-    Omit<NeonProjectProps, "apiKey" | "existing_project_id"> {
+  extends Omit<NeonProjectProps, "apiKey" | "existing_project_id"> {
   /**
    * The ID of the project
    */
@@ -617,7 +616,7 @@ export const NeonProject = Resource(
         response = await getProject(api, response.project.id, response);
       }
 
-      return this({
+      return {
         id: response.project.id,
         name: response.project.name,
         region_id: response.project.region_id as NeonRegion,
@@ -639,7 +638,7 @@ export const NeonProject = Resource(
         branch: response.branch,
         // @ts-expect-error
         endpoints: response.endpoints,
-      });
+      };
     } catch (error) {
       logger.error(`Error ${this.phase} Neon project '${id}':`, error);
       throw error;

--- a/alchemy/src/os/exec.ts
+++ b/alchemy/src/os/exec.ts
@@ -60,7 +60,7 @@ export interface ExecProps {
 /**
  * Output returned after command execution
  */
-export interface Exec extends Resource<"os::Exec">, ExecProps {
+export interface Exec extends ExecProps {
   /**
    * Unique identifier for this execution
    */
@@ -268,7 +268,7 @@ export const Exec = Resource(
     }
 
     // Return the execution result
-    return this({
+    return {
       id,
       command: props.command,
       cwd: props.cwd,
@@ -281,7 +281,7 @@ export const Exec = Resource(
       executedAt: Date.now(),
       completed: true,
       hash,
-    });
+    };
   },
 );
 

--- a/alchemy/src/planetscale/branch.ts
+++ b/alchemy/src/planetscale/branch.ts
@@ -81,7 +81,7 @@ export interface BranchProps extends PlanetScaleProps {
 /**
  * Represents a PlanetScale Branch
  */
-export interface Branch extends Resource<"planetscale::Branch">, BranchProps {
+export interface Branch extends BranchProps {
   /**
    * The name of the branch
    */
@@ -286,14 +286,14 @@ export const Branch = Resource(
         );
       }
 
-      return this({
+      return {
         ...props,
         name: branchName,
         parentBranch: currentParentBranch,
         createdAt: data.created_at,
         updatedAt: data.updated_at,
         htmlUrl: data.html_url,
-      });
+      };
     }
     let clusterSize: string | undefined;
     const parent = await waitForBranchReady(
@@ -359,13 +359,13 @@ export const Branch = Resource(
       );
     }
 
-    return this({
+    return {
       ...props,
       name: branchName,
       parentBranch: data.parent_branch,
       createdAt: data.created_at,
       updatedAt: data.updated_at,
       htmlUrl: data.html_url,
-    });
+    };
   },
 );

--- a/alchemy/src/planetscale/database.ts
+++ b/alchemy/src/planetscale/database.ts
@@ -117,48 +117,47 @@ export type DatabaseProps = BaseDatabaseProps &
 /**
  * Represents a PlanetScale Database
  */
-export type Database = Resource<"planetscale::Database"> &
-  DatabaseProps & {
-    /**
-     * The unique identifier of the database
-     */
-    id: string;
+export type Database = DatabaseProps & {
+  /**
+   * The unique identifier of the database
+   */
+  id: string;
 
-    /**
-     * The name of the database
-     */
-    name: string;
+  /**
+   * The name of the database
+   */
+  name: string;
 
-    /**
-     * The current state of the database
-     */
-    state: string;
+  /**
+   * The current state of the database
+   */
+  state: string;
 
-    /**
-     * The default branch name
-     */
-    defaultBranch: string;
+  /**
+   * The default branch name
+   */
+  defaultBranch: string;
 
-    /**
-     * The plan type
-     */
-    plan: string;
+  /**
+   * The plan type
+   */
+  plan: string;
 
-    /**
-     * Time at which the database was created
-     */
-    createdAt: string;
+  /**
+   * Time at which the database was created
+   */
+  createdAt: string;
 
-    /**
-     * Time at which the database was last updated
-     */
-    updatedAt: string;
+  /**
+   * Time at which the database was last updated
+   */
+  updatedAt: string;
 
-    /**
-     * HTML URL to access the database
-     */
-    htmlUrl: string;
-  };
+  /**
+   * HTML URL to access the database
+   */
+  htmlUrl: string;
+};
 
 /**
  * Create, manage and delete PlanetScale databases
@@ -311,7 +310,7 @@ export const Database = Resource(
         clusterSize,
       );
 
-      return this({
+      return {
         ...props,
         id: updateResponse.id,
         name: databaseName,
@@ -321,7 +320,7 @@ export const Database = Resource(
         createdAt: updateResponse.created_at,
         updatedAt: updateResponse.updated_at,
         htmlUrl: updateResponse.html_url,
-      });
+      };
     }
 
     if (getResponse.data) {
@@ -406,7 +405,7 @@ export const Database = Resource(
           },
         });
 
-        return this({
+        return {
           ...props,
           id: data.id,
           name: databaseName,
@@ -416,11 +415,11 @@ export const Database = Resource(
           createdAt: updatedData.created_at,
           updatedAt: updatedData.updated_at,
           htmlUrl: updatedData.html_url,
-        });
+        };
       }
     }
 
-    return this({
+    return {
       ...props,
       id: data.id,
       name: databaseName,
@@ -430,6 +429,6 @@ export const Database = Resource(
       createdAt: data.created_at,
       updatedAt: data.updated_at,
       htmlUrl: data.html_url,
-    });
+    };
   },
 );

--- a/alchemy/src/planetscale/password.ts
+++ b/alchemy/src/planetscale/password.ts
@@ -62,9 +62,7 @@ export interface PasswordProps extends PlanetScaleProps {
 /**
  * Represents a PlanetScale Branch
  */
-export interface Password
-  extends Resource<"planetscale::Password">,
-    PasswordProps {
+export interface Password extends PasswordProps {
   /**
    * The unique identifier for the password
    */
@@ -327,11 +325,11 @@ export const Password = Resource(
         },
       });
 
-      return this({
+      return {
         ...this.output,
         ...props,
         name,
-      });
+      };
     }
 
     const data = await api.organizations.databases.branches.passwords.post({
@@ -349,7 +347,7 @@ export const Password = Resource(
       },
     });
 
-    return this({
+    return {
       id: data.id,
       expiresAt: data.expires_at,
       host: data.access_host_url,
@@ -358,7 +356,7 @@ export const Password = Resource(
       nameSlug,
       ...props,
       name: `${props.name}-${nameSlug}`,
-    });
+    };
   },
 );
 

--- a/alchemy/src/planetscale/role.ts
+++ b/alchemy/src/planetscale/role.ts
@@ -63,9 +63,7 @@ export type InheritedRole =
   | "pg_write_all_data"
   | (string & {});
 
-export interface Role
-  extends Resource<"planetscale::Role">,
-    Omit<RoleProps, "inheritedRoles"> {
+export interface Role extends Omit<RoleProps, "inheritedRoles"> {
   /**
    * The unique identifier for the role
    */
@@ -250,7 +248,7 @@ export const Role = Resource(
             inherited_roles: inheritedRoles,
           } as CreateRoleData["body"],
         });
-        return this({
+        return {
           ...props,
           id: role.id,
           name: role.name,
@@ -266,7 +264,7 @@ export const Role = Resource(
           connectionUrlPooled: alchemy.secret(
             `postgresql://${role.username}:${role.password}@${role.access_host_url}:6432/${role.database_name}?sslmode=verify-full`,
           ),
-        });
+        };
       }
       case "update": {
         // According to the types, the only property that can be updated is the name.

--- a/alchemy/src/random/random-string.ts
+++ b/alchemy/src/random/random-string.ts
@@ -27,7 +27,7 @@ export interface RandomStringProps {
 /**
  * A cryptographically secure random string resource
  */
-export interface RandomString extends Resource<"random::String"> {
+export interface RandomString {
   /**
    * The generated random string value, stored as a secret
    */
@@ -110,10 +110,10 @@ export const RandomString = Resource(
       // this is an update (input props changed)
       // but the length and encoding did not change
       // so, we can just return the existing output (no-op)
-      return this(this.output);
+      return this.output;
     }
     const crypto = await import("node:crypto");
-    return this({
+    return {
       length,
       encoding,
       value: alchemy.secret(
@@ -121,6 +121,6 @@ export const RandomString = Resource(
           .randomBytes(props.length ?? 32)
           .toString(props.encoding ?? "hex"),
       ),
-    });
+    };
   },
 );

--- a/alchemy/src/resource.ts
+++ b/alchemy/src/resource.ts
@@ -79,6 +79,10 @@ export type ResourceProps = {
   [key: string]: any;
 };
 
+export type ResourceAttributes = {
+  [key: string]: any;
+};
+
 export type Provider<
   Type extends string = string,
   F extends ResourceLifecycleHandler = ResourceLifecycleHandler,
@@ -116,7 +120,7 @@ type ResourceLifecycleHandler = (
   this: Context<any, any>,
   id: string,
   props: any,
-) => Promise<Resource<string>>;
+) => Promise<ResourceAttributes>;
 
 // see: https://x.com/samgoodwin89/status/1904640134097887653
 type Handler<F extends (...args: any[]) => any> =
@@ -157,7 +161,7 @@ export function Resource<
   const provider = (async (
     resourceID: string,
     props: ResourceProps,
-  ): Promise<Resource<string>> => {
+  ): Promise<ResourceAttributes> => {
     const scope = _Scope.current;
 
     if (resourceID.includes(":")) {

--- a/alchemy/src/sentry/client-key.ts
+++ b/alchemy/src/sentry/client-key.ts
@@ -62,9 +62,7 @@ export interface ClientKeyProps {
 /**
  * Output returned after ClientKey creation/update
  */
-export interface ClientKey
-  extends Resource<"sentry::ClientKey">,
-    ClientKeyProps {
+export interface ClientKey extends ClientKeyProps {
   /**
    * The ID of the key
    */
@@ -295,7 +293,7 @@ export const ClientKey = Resource(
           ClientKey,
           keyof ClientKeyProps
         >;
-        return this({
+        return {
           ...props,
           id: data.id,
           name: clientKeyName,
@@ -309,7 +307,7 @@ export const ClientKey = Resource(
           browserSdk: data.browserSdk,
           dateCreated: data.dateCreated,
           dynamicSdkLoaderOptions: data.dynamicSdkLoaderOptions,
-        });
+        };
       } catch (error) {
         logger.error("Error creating/updating client key:", error);
         throw error;

--- a/alchemy/src/sentry/project.ts
+++ b/alchemy/src/sentry/project.ts
@@ -57,9 +57,7 @@ export interface ProjectProps {
 /**
  * Output returned after Project creation/update
  */
-export interface Project
-  extends Omit<Resource<"sentry::Project">, "team">,
-    Omit<ProjectProps, "team"> {
+export interface Project extends Omit<ProjectProps, "team"> {
   /**
    * The ID of the project
    */
@@ -393,7 +391,7 @@ export const Project = Resource(
           Project,
           keyof ProjectProps
         > & { team: Project["team"] };
-        return this({
+        return {
           ...props,
           id: data.id,
           name: projectName,
@@ -430,7 +428,7 @@ export const Project = Resource(
           latestRelease: data.latestRelease,
           hasUserReports: data.hasUserReports,
           latestDeploys: data.latestDeploys,
-        });
+        } satisfies Project;
       } catch (error) {
         logger.error("Error creating/updating project:", error);
         throw error;

--- a/alchemy/src/sentry/team.ts
+++ b/alchemy/src/sentry/team.ts
@@ -42,7 +42,7 @@ export interface TeamProps {
 /**
  * Output returned after Team creation/update
  */
-export interface Team extends Resource<"sentry::Team">, TeamProps {
+export interface Team extends TeamProps {
   /**
    * The ID of the team
    */
@@ -230,7 +230,7 @@ export const Team = Resource(
         }
 
         const data = (await response.json()) as Omit<Team, keyof TeamProps>;
-        return this({
+        return {
           ...props,
           id: data.id,
           name: teamName,
@@ -243,7 +243,7 @@ export const Team = Resource(
           isPending: data.isPending,
           memberCount: data.memberCount,
           avatar: data.avatar,
-        });
+        };
       } catch (error) {
         logger.error("Error creating/updating team:", error);
         throw error;

--- a/alchemy/src/stripe/card.ts
+++ b/alchemy/src/stripe/card.ts
@@ -107,7 +107,7 @@ export interface CardProps {
 /**
  * Output from the Stripe card
  */
-export interface Card extends Resource<"stripe::Card">, CardProps {
+export interface Card extends CardProps {
   /**
    * The ID of the card
    */
@@ -292,7 +292,7 @@ export const Card = Resource(
         }
       }
 
-      return this({
+      return {
         id: card.id,
         object: card.object,
         customer: props.customer,
@@ -315,7 +315,7 @@ export const Card = Resource(
         defaultForCurrency: card.default_for_currency || undefined,
         metadata: card.metadata || undefined,
         tokenizationMethod: card.tokenization_method || undefined,
-      });
+      };
     } catch (error) {
       logger.error("Error creating/updating card:", error);
       throw error;

--- a/alchemy/src/stripe/coupon.ts
+++ b/alchemy/src/stripe/coupon.ts
@@ -89,7 +89,7 @@ export interface CouponProps {
 /**
  * Output from the Stripe coupon
  */
-export interface Coupon extends Resource<"stripe::Coupon">, CouponProps {
+export interface Coupon extends CouponProps {
   /**
    * The ID of the coupon
    */
@@ -257,7 +257,7 @@ export const Coupon = Resource(
         }
       }
 
-      return this({
+      return {
         id: coupon.id,
         object: coupon.object,
         duration: coupon.duration as CouponDuration,
@@ -273,7 +273,7 @@ export const Coupon = Resource(
         metadata: coupon.metadata || undefined,
         created: coupon.created,
         livemode: coupon.livemode,
-      });
+      };
     } catch (error) {
       logger.error("Error creating/updating coupon:", error);
       throw error;

--- a/alchemy/src/stripe/customer.ts
+++ b/alchemy/src/stripe/customer.ts
@@ -163,7 +163,7 @@ export interface CustomerProps {
 /**
  * Output from the Stripe customer
  */
-export interface Customer extends Resource<"stripe::Customer">, CustomerProps {
+export interface Customer extends CustomerProps {
   /**
    * The ID of the customer
    */
@@ -432,7 +432,7 @@ export const Customer = Resource(
         }
       }
 
-      return this({
+      return {
         id: customer.id,
         object: customer.object,
         address: customer.address
@@ -506,7 +506,7 @@ export const Customer = Resource(
         subscriptions: customer.subscriptions || undefined,
         taxExempt: customer.tax_exempt || undefined,
         taxIds: customer.tax_ids || undefined,
-      });
+      };
     } catch (error) {
       logger.error("Error creating/updating customer:", error);
       throw error;

--- a/alchemy/src/stripe/entitlements-feature.ts
+++ b/alchemy/src/stripe/entitlements-feature.ts
@@ -38,9 +38,7 @@ export interface EntitlementsFeatureProps {
 /**
  * Output from the Stripe entitlements feature
  */
-export interface EntitlementsFeature
-  extends Resource<"stripe::EntitlementsFeature">,
-    EntitlementsFeatureProps {
+export interface EntitlementsFeature extends EntitlementsFeatureProps {
   /**
    * The ID of the feature
    */
@@ -157,14 +155,14 @@ export const EntitlementsFeature = Resource(
         }
       }
 
-      return this({
+      return {
         id: feature.id,
         object: feature.object,
         name: feature.name,
         lookupKey: feature.lookup_key || undefined,
         metadata: feature.metadata || undefined,
         livemode: feature.livemode,
-      });
+      };
     } catch (error) {
       logger.error("Error creating/updating entitlements feature:", error);
       throw error;

--- a/alchemy/src/stripe/file.ts
+++ b/alchemy/src/stripe/file.ts
@@ -49,7 +49,7 @@ export interface FileProps {
 /**
  * Output from the Stripe file
  */
-export interface File extends Resource<"stripe::File"> {
+export interface File {
   /**
    * The ID of the file
    */
@@ -182,7 +182,7 @@ export const File = Resource(
         }
       }
 
-      return this({
+      return {
         id: file.id,
         object: file.object,
         created: file.created,
@@ -212,7 +212,7 @@ export const File = Resource(
         type: file.type || undefined,
         url: file.url || undefined,
         livemode: true,
-      });
+      };
     } catch (error) {
       logger.error("Error creating/retrieving file:", error);
       throw error;

--- a/alchemy/src/stripe/meter.ts
+++ b/alchemy/src/stripe/meter.ts
@@ -38,7 +38,7 @@ export interface MeterProps {
 /**
  * Output returned after Stripe Meter creation/update.
  */
-export interface Meter extends Resource<"stripe::Meter"> {
+export interface Meter {
   id: string;
   object: "billing.meter";
   displayName: string;
@@ -180,7 +180,7 @@ export const Meter = Resource(
     // Helper to map Stripe API response (snake_case) to Meter output interface (camelCase)
     const mapStripeObjectToMeterOutput = (
       stripeMeter: Stripe.Billing.Meter,
-    ): Omit<Meter, keyof Resource<"stripe::Meter">> => ({
+    ): Meter => ({
       id: stripeMeter.id,
       object: stripeMeter.object,
       displayName: stripeMeter.display_name,
@@ -327,6 +327,6 @@ export const Meter = Resource(
       }
     }
 
-    return this(mapStripeObjectToMeterOutput(stripeAPIResponse));
+    return mapStripeObjectToMeterOutput(stripeAPIResponse);
   },
 );

--- a/alchemy/src/stripe/portal-configuration.ts
+++ b/alchemy/src/stripe/portal-configuration.ts
@@ -202,9 +202,7 @@ export interface PortalConfigurationProps {
 /**
  * Output from the Stripe portal configuration
  */
-export interface PortalConfiguration
-  extends Resource<"stripe::PortalConfiguration">,
-    PortalConfigurationProps {
+export interface PortalConfiguration extends PortalConfigurationProps {
   /**
    * The ID of the configuration
    */
@@ -512,7 +510,7 @@ export const PortalConfiguration = Resource(
         }
       }
 
-      return this({
+      return {
         id: configuration.id,
         object: configuration.object,
         active: configuration.active,
@@ -604,7 +602,7 @@ export const PortalConfiguration = Resource(
         livemode: configuration.livemode,
         metadata: configuration.metadata || undefined,
         updated: configuration.updated,
-      });
+      };
     } catch (error) {
       logger.error("Error creating/updating portal configuration:", error);
       throw error;

--- a/alchemy/src/stripe/price.ts
+++ b/alchemy/src/stripe/price.ts
@@ -210,7 +210,7 @@ export interface PriceProps {
 /**
  * Output from the Stripe price
  */
-export interface Price extends Resource<"stripe::Price">, PriceProps {
+export interface Price extends PriceProps {
   /**
    * The ID of the price
    */
@@ -545,7 +545,7 @@ export const Price = Resource(
         : undefined;
 
       // Map Stripe API response to our output format
-      return this({
+      return {
         id: price.id,
         product:
           typeof price.product === "string" ? price.product : price.product.id,
@@ -565,7 +565,7 @@ export const Price = Resource(
         tiers: tiers,
         tiersMode: price.tiers_mode ?? undefined,
         transformQuantity: transformQuantity,
-      });
+      };
     } catch (error) {
       logger.error("Error creating/updating price:", error);
       throw error;

--- a/alchemy/src/stripe/product-feature.ts
+++ b/alchemy/src/stripe/product-feature.ts
@@ -37,9 +37,7 @@ export interface ProductFeatureProps {
 /**
  * Output from the Stripe product feature
  */
-export interface ProductFeature
-  extends Resource<"stripe::ProductFeature">,
-    ProductFeatureProps {
+export interface ProductFeature extends ProductFeatureProps {
   /**
    * The ID of the product feature
    */
@@ -137,7 +135,7 @@ export const ProductFeature = Resource(
         }
       }
 
-      return this({
+      return {
         id: productFeature.id,
         object: productFeature.object,
         product: props.product,
@@ -145,7 +143,7 @@ export const ProductFeature = Resource(
         entitlementFeatureObject:
           productFeature.entitlement_feature || undefined,
         livemode: productFeature.livemode,
-      });
+      };
     } catch (error) {
       logger.error("Error creating product feature:", error);
       throw error;

--- a/alchemy/src/stripe/product.ts
+++ b/alchemy/src/stripe/product.ts
@@ -80,7 +80,7 @@ export interface ProductProps {
 /**
  * Output from the Stripe product
  */
-export interface Product extends Resource<"stripe::Product">, ProductProps {
+export interface Product extends ProductProps {
   /**
    * The ID of the product
    */
@@ -233,7 +233,7 @@ export const Product = Resource(
         }
       }
 
-      return this({
+      return {
         id: product.id,
         name: product.name,
         description: product.description || undefined,
@@ -251,7 +251,7 @@ export const Product = Resource(
         livemode: product.livemode,
         updatedAt: product.updated,
         packageDimensions: product.package_dimensions || undefined,
-      });
+      };
     } catch (error) {
       logger.error("Error creating/updating product:", error);
       throw error;

--- a/alchemy/src/stripe/promotion-code.ts
+++ b/alchemy/src/stripe/promotion-code.ts
@@ -78,9 +78,7 @@ export interface PromotionCodeProps {
 /**
  * Output from the Stripe promotion code
  */
-export interface PromotionCode
-  extends Resource<"stripe::PromotionCode">,
-    PromotionCodeProps {
+export interface PromotionCode extends PromotionCodeProps {
   /**
    * The ID of the promotion code
    */
@@ -232,7 +230,7 @@ export const PromotionCode = Resource(
         }
       }
 
-      return this({
+      return {
         id: promotionCode.id,
         object: promotionCode.object,
         coupon:
@@ -261,7 +259,7 @@ export const PromotionCode = Resource(
         created: promotionCode.created,
         livemode: promotionCode.livemode,
         timesRedeemed: promotionCode.times_redeemed,
-      });
+      };
     } catch (error) {
       logger.error("Error creating/updating promotion code:", error);
       throw error;

--- a/alchemy/src/stripe/shipping-rate.ts
+++ b/alchemy/src/stripe/shipping-rate.ts
@@ -122,9 +122,7 @@ export interface ShippingRateProps {
 /**
  * Output from the Stripe shipping rate
  */
-export interface ShippingRate
-  extends Resource<"stripe::ShippingRate">,
-    ShippingRateProps {
+export interface ShippingRate extends ShippingRateProps {
   /**
    * The ID of the shipping rate
    */
@@ -306,7 +304,7 @@ export const ShippingRate = Resource(
         }
       }
 
-      return this({
+      return {
         id: shippingRate.id,
         object: shippingRate.object,
         displayName: shippingRate.display_name || "",
@@ -355,7 +353,7 @@ export const ShippingRate = Resource(
         type: shippingRate.type || undefined,
         created: shippingRate.created,
         livemode: shippingRate.livemode,
-      });
+      };
     } catch (error) {
       logger.error("Error creating/updating shipping rate:", error);
       throw error;

--- a/alchemy/src/stripe/tax-rate.ts
+++ b/alchemy/src/stripe/tax-rate.ts
@@ -67,7 +67,7 @@ export interface TaxRateProps {
 /**
  * Output from the Stripe tax rate
  */
-export interface TaxRate extends Resource<"stripe::TaxRate">, TaxRateProps {
+export interface TaxRate extends TaxRateProps {
   /**
    * The ID of the tax rate
    */
@@ -196,7 +196,7 @@ export const TaxRate = Resource(
         }
       }
 
-      return this({
+      return {
         id: taxRate.id,
         object: taxRate.object,
         displayName: taxRate.display_name,
@@ -211,7 +211,7 @@ export const TaxRate = Resource(
         taxType: taxRate.tax_type || undefined,
         created: taxRate.created,
         livemode: taxRate.livemode,
-      });
+      };
     } catch (error) {
       logger.error("Error creating/updating tax rate:", error);
       throw error;

--- a/alchemy/src/stripe/webhook.ts
+++ b/alchemy/src/stripe/webhook.ts
@@ -64,9 +64,7 @@ export interface WebhookEndpointProps {
 /**
  * Output from the Stripe webhook endpoint
  */
-export interface WebhookEndpoint
-  extends Resource<"stripe::WebhookEndpoint">,
-    WebhookEndpointProps {
+export interface WebhookEndpoint extends WebhookEndpointProps {
   /**
    * The ID of the webhook
    */
@@ -267,7 +265,7 @@ export const WebhookEndpoint = Resource(
         secret = this.output.secret;
       }
 
-      return this({
+      return {
         id: webhook.id,
         url: webhook.url,
         enabledEvents: webhook.enabled_events as EnabledEvent[],
@@ -282,7 +280,7 @@ export const WebhookEndpoint = Resource(
         livemode: webhook.livemode,
         updatedAt: webhook.created, // Using created timestamp as updated
         status: webhook.status,
-      });
+      };
     } catch (error) {
       logger.error("Error creating/updating webhook:", error);
       throw error;

--- a/alchemy/src/upstash/redis.ts
+++ b/alchemy/src/upstash/redis.ts
@@ -65,9 +65,7 @@ export interface UpstashRedisProps {
 /**
  * Output returned after UpstashRedis creation/update
  */
-export interface UpstashRedis
-  extends Resource<"upstash::Redis">,
-    UpstashRedisProps {
+export interface UpstashRedis extends UpstashRedisProps {
   /**
    * ID of the database
    */

--- a/alchemy/src/vercel/project-domain.ts
+++ b/alchemy/src/vercel/project-domain.ts
@@ -41,9 +41,7 @@ export interface ProjectDomainProps {
 /**
  * Output returned after ProjectDomain creation/update
  */
-export interface ProjectDomain
-  extends Resource<"vercel::ProjectDomain">,
-    ProjectDomainProps {
+export interface ProjectDomain extends ProjectDomainProps {
   apexName: string;
 
   /**

--- a/alchemy/src/vercel/project.ts
+++ b/alchemy/src/vercel/project.ts
@@ -240,7 +240,7 @@ export interface ProjectProps {
 /**
  * Output returned after Project creation/update
  */
-export interface Project extends Resource<"vercel::Project">, ProjectProps {
+export interface Project extends ProjectProps {
   /**
    * The ID of the project
    */
@@ -453,7 +453,7 @@ export const Project = Resource(
           await updateEnvironmentVariables(envApi, this.output, props);
         }
 
-        return this({
+        return {
           id: data.id,
           name: projectName,
           accountId: data.accountId,
@@ -461,7 +461,7 @@ export const Project = Resource(
           updatedAt: data.updatedAt,
           latestDeployment: data.latestDeployment,
           ...props,
-        });
+        };
       }
 
       case "create": {

--- a/alchemy/test/replace.test.ts
+++ b/alchemy/test/replace.test.ts
@@ -14,7 +14,7 @@ describe.sequential("Replace-Sequential", () => {
       const deleted: string[] = [];
       const failed = new Set();
 
-      interface Replacable extends Resource<`Replacable-sequential-${string}`> {
+      interface Replacable {
         name: string;
       }
 
@@ -53,9 +53,9 @@ describe.sequential("Replace-Sequential", () => {
               name: "child",
             });
           }
-          return this({
+          return {
             name: props.name,
-          });
+          };
         },
       );
 
@@ -117,7 +117,7 @@ describe.concurrent("Replace", () => {
       const deleted: string[] = [];
       const failed = new Set();
 
-      interface Replacable extends Resource<`Replacable-${string}`> {
+      interface Replacable {
         name: string;
       }
 
@@ -157,9 +157,9 @@ describe.concurrent("Replace", () => {
               name: "child",
             });
           }
-          return this({
+          return {
             name: props.name,
-          });
+          };
         },
       );
 
@@ -425,7 +425,7 @@ describe.concurrent("Replace", () => {
                 deleted.push(this.output.name);
                 return this.destroy();
               }
-              return this({ name: props.name });
+              return { name: props.name };
             },
           );
 
@@ -444,7 +444,7 @@ describe.concurrent("Replace", () => {
                 this.replace(true);
               }
               await Child("child", { name: `${props.name}-child` });
-              return this({ name: props.name });
+              return { name: props.name };
             },
           );
           try {
@@ -568,7 +568,7 @@ describe.concurrent("Replace", () => {
         options,
         async (scope) => {
           const deleted: { input: string; output: string }[] = [];
-          type MyResource = Resource<`MyResource-${string}`> & {
+          type MyResource = {
             name: string;
           };
           const MyResource = Resource(
@@ -587,7 +587,7 @@ describe.concurrent("Replace", () => {
               if (this.phase === "update") {
                 this.replace();
               }
-              return this({ name: `output-${props.name}` });
+              return { name: `output-${props.name}` };
             },
           );
           try {
@@ -610,7 +610,7 @@ describe.concurrent("Replace", () => {
         options,
         async (scope) => {
           const deleted: string[] = [];
-          interface Replacable extends Resource<`Replacable-${string}`> {
+          interface Replacable {
             name: string;
           }
           const Replacable = Resource(
@@ -628,7 +628,7 @@ describe.concurrent("Replace", () => {
               } else if (this.phase === "update") {
                 this.replace(true);
               }
-              return this({ name: props.name });
+              return { name: props.name };
             },
           );
           try {

--- a/alchemy/test/scope.test.ts
+++ b/alchemy/test/scope.test.ts
@@ -116,7 +116,7 @@ describe.concurrent("Scope", () => {
                 return this.destroy();
               }
               await Inner("inner", { fileName: "test-inner" });
-              return this({});
+              return {};
             },
           );
 
@@ -128,7 +128,7 @@ describe.concurrent("Scope", () => {
                 isDeleted = true;
                 return this.destroy();
               }
-              return this({});
+              return {};
             },
           );
           try {
@@ -140,7 +140,7 @@ describe.concurrent("Scope", () => {
             // @ts-expect-error - internal access to make sure we don't skip the outer scope
             expect(scope.isSkipped).toBe(false);
             // finalizing a scoped that was skipped should not delete nested resources
-            await outer[ResourceScope].finalize();
+            await (outer as any)[ResourceScope].finalize();
             expect(isDeleted).toBe(false);
           } finally {
             await destroy(scope);
@@ -163,7 +163,7 @@ describe.concurrent("Scope", () => {
               return this.destroy();
             }
             updates++;
-            return this(props);
+            return props;
           },
         );
         try {
@@ -196,7 +196,7 @@ describe.concurrent("Scope", () => {
               finished.add(id);
               return this.destroy();
             }
-            return this({});
+            return {};
           },
         );
         try {

--- a/alchemy/test/smoke.ts
+++ b/alchemy/test/smoke.ts
@@ -308,7 +308,8 @@ const tasks = new Listr(
 
                 if (phase.title === "Dev") {
                   task.title = `${example.name} - ${phase.title} (pending) ${pc.dim(`(${i}/${phases.length - 1})`)}`;
-                  await devMutex.lock(exec);
+                  // await devMutex.lock(exec);
+                  await exec();
                 } else {
                   await exec();
                 }

--- a/alchemy/test/smoke.ts
+++ b/alchemy/test/smoke.ts
@@ -84,14 +84,17 @@ const examples = (await discoverExamples()).filter(
   (e) => !skippedExamples.includes(e.name),
 );
 
-const testFilters: string[] = [];
+const exclude: string[] = [];
+const include: string[] = [];
 const fitlerTest = (name: string) =>
-  testFilters.length === 0 ||
-  testFilters.every((filter) => name.includes(filter));
+  (include.length === 0 || include.every((filter) => name.includes(filter))) &&
+  (exclude.length === 0 || exclude.every((filter) => !name.includes(filter)));
 
 for (let i = 0; i < process.argv.length; i++) {
   if (process.argv[i] === "-t") {
-    testFilters.push(process.argv[i + 1]);
+    include.push(process.argv[i + 1]);
+  } else if (process.argv[i] === "-x") {
+    exclude.push(process.argv[i + 1]);
   }
 }
 

--- a/scripts/generate-aws-control-types.ts
+++ b/scripts/generate-aws-control-types.ts
@@ -202,7 +202,7 @@ function generateReadOnlyPropertiesObject(
 function generateResourceType(
   resourceType: ResourceType,
   resourceName: string,
-  serviceName: string,
+  _serviceName: string,
 ): string {
   const lines: string[] = [];
 
@@ -211,9 +211,7 @@ function generateResourceType(
     lines.push(`/** ${resourceType.Documentation} */`);
   }
 
-  lines.push(
-    `type ${resourceName} = AlchemyResource<"AWS::${serviceName}::${resourceName}"> & ${resourceName}Props & {`,
-  );
+  lines.push(`type ${resourceName} = ${resourceName}Props & {`);
 
   // Track which properties we've already added from attributes
   const addedProperties = new Set<string>();

--- a/scripts/generate-aws-control.ts
+++ b/scripts/generate-aws-control.ts
@@ -170,9 +170,7 @@ function generateResourceType(
     lines.push(`/** ${resourceType.Documentation} */`);
   }
 
-  lines.push(
-    `type ${resourceName} = Resource<"AWS::${resourceName}"> & ${resourceName}Props & {`,
-  );
+  lines.push(`type ${resourceName} = ${resourceName}Props & {`);
 
   // Track which properties we've already added from attributes
   const addedProperties = new Set<string>();


### PR DESCRIPTION
This change simplifies Resources:

1. No longer need to use `return this({..})` syntax, instead resources just return an object
2. Resource types no longer need to extend the `Resource` interface. There are no more required properties.
3. Symbols are no longer exposed in our types. Symbols are still applied to resources at runtime but are not needed in the types which should fix monorepo typing errors.