### PR TITLE
fix(cloudflare): add missing R2Object export

### DIFF
--- a/alchemy/src/cloudflare/bucket.ts
+++ b/alchemy/src/cloudflare/bucket.ts
@@ -252,7 +252,7 @@ export type R2ObjectMetadata = {
   size: number;
 };
 
-export type R2Object = R2ObjectMetadata & {
+export type R2ObjectContent = R2ObjectMetadata & {
   arrayBuffer(): Promise<ArrayBuffer>;
   bytes(): Promise<Uint8Array>;
   text(): Promise<string>;
@@ -283,7 +283,7 @@ export type R2Objects = {
 
 export type R2Bucket = _R2Bucket & {
   head(key: string): Promise<R2ObjectMetadata | null>;
-  get(key: string): Promise<R2Object | null>;
+  get(key: string): Promise<R2ObjectContent | null>;
   put(
     key: string,
     value:
@@ -481,7 +481,7 @@ export async function R2Bucket(
   };
 }
 
-const parseR2Object = (key: string, response: Response): R2Object => ({
+const parseR2Object = (key: string, response: Response): R2ObjectContent => ({
   etag: response.headers.get("ETag")!,
   uploaded: parseDate(response.headers),
   key,

--- a/alchemy/src/cloudflare/index.ts
+++ b/alchemy/src/cloudflare/index.ts
@@ -13,6 +13,7 @@ export * from "./astro/astro.ts";
 export * from "./bindings.ts";
 export * from "./bound.ts";
 export * from "./browser-rendering.ts";
+export * from "./bucket-object.ts";
 export * from "./bucket.ts";
 export * from "./certificate-pack.ts";
 export * from "./cloudflare-env-proxy.ts";
@@ -69,3 +70,4 @@ export * from "./worker.ts";
 export { Workflow } from "./workflow.ts";
 export * from "./wrangler.json.ts";
 export * from "./zone.ts";
+


### PR DESCRIPTION
I forgot to export R2Object in #1016, so this PR fixes that. I also renamed a type in the bucket resource that conflicted with the R2Object resource. I’m unsure if this counts as a breaking change or if the new name is right.