### PR TITLE
fix(cloudflare): set ALCHEMY_ROOT for dev command in Website

### DIFF
--- a/alchemy/src/cloudflare/website.ts
+++ b/alchemy/src/cloudflare/website.ts
@@ -334,6 +334,7 @@ export async function Website<B extends Bindings>(
         // NOTE: we must set this to ensure the user does not accidentally set `NODE_ENV=production`
         // which breaks `vite dev` (it won't, for example, re-write `process.env.TSS_APP_BASE` in the `.js` client side bundle)
         NODE_ENV: "development",
+        ALCHEMY_ROOT: Scope.current.rootDir,
       },
     });
   }

--- a/example-monorepo/package.json
+++ b/example-monorepo/package.json
@@ -5,7 +5,8 @@
     "build": "tsc -b",
     "dev": "tsc -b && turbo run dev",
     "deploy": "tsc -b && turbo run deploy --ui=stream",
-    "destroy": "tsc -b && turbo run destroy --ui=stream"
+    "destroy": "tsc -b && turbo run destroy --ui=stream",
+    "link:alchemy": "cd ../alchemy && bun tsc -b && bun link && cd ../example-monorepo && bun i && cp .env.example .env"
   },
   "type": "module",
   "packageManager": "bun@1.2.21",
@@ -22,6 +23,7 @@
     }
   },
   "devDependencies": {
+    "alchemy": "link:alchemy",
     "turbo": "^2.5.6"
   },
   "dependencies": {


### PR DESCRIPTION
We were not setting `ALCHEMY_ROOT` when running dev command which broke dev mode in split-app monorepos.

Fixes https://github.com/sam-goodwin/alchemy/issues/1025