### PR TITLE
feat(cli): globally disable telemetry

### DIFF
--- a/alchemy/bin/alchemy.ts
+++ b/alchemy/bin/alchemy.ts
@@ -8,6 +8,7 @@ import { init } from "./commands/init.ts";
 import { login } from "./commands/login.ts";
 import { logout } from "./commands/logout.ts";
 import { run } from "./commands/run.ts";
+import { telemetry } from "./commands/telemetry.ts";
 import { getPackageVersion } from "./services/get-package-version.ts";
 import { t } from "./trpc.ts";
 
@@ -21,6 +22,7 @@ const router = t.router({
   logout,
   configure,
   run,
+  telemetry,
 });
 
 export type AppRouter = typeof router;

--- a/alchemy/bin/commands/telemetry.ts
+++ b/alchemy/bin/commands/telemetry.ts
@@ -1,0 +1,33 @@
+import * as prompts from "@clack/prompts";
+import pc from "picocolors";
+import {
+  setGlobalTelemetryDisabled,
+  setGlobalTelemetryEnabled,
+} from "../../src/util/telemetry.ts";
+import { t } from "../trpc.ts";
+
+export const telemetry = t.router({
+  disable: t.procedure
+    .meta({
+      description: "disable telemetry",
+    })
+    .mutation(async () => {
+      prompts.intro(pc.cyan("🧪 Telemetry"));
+      await setGlobalTelemetryDisabled();
+      prompts.outro(
+        `Telemetry disabled. ${pc.dim(`To re-enable, run ${pc.bold("alchemy telemetry enable")}`)}`,
+      );
+    }),
+
+  enable: t.procedure
+    .meta({
+      description: "enable telemetry",
+    })
+    .mutation(async () => {
+      prompts.intro(pc.cyan("🧪 Telemetry"));
+      await setGlobalTelemetryEnabled();
+      prompts.outro(
+        `Telemetry enabled. ${pc.dim(`To disable, run ${pc.bold("alchemy telemetry disable")}`)}`,
+      );
+    }),
+});

--- a/alchemy/src/util/telemetry.ts
+++ b/alchemy/src/util/telemetry.ts
@@ -1,6 +1,6 @@
 import envPaths from "env-paths";
 import { exec } from "node:child_process";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import fs from "node:fs/promises";
 import os from "node:os";
 import path from "pathe";
 import pkg from "../../package.json" with { type: "json" };
@@ -9,11 +9,13 @@ import { Scope } from "../scope.ts";
 import { logger } from "./logger.ts";
 import { memoize } from "./memoize.ts";
 
-export const CONFIG_PATH = path.join(os.homedir(), ".alchemy", "id");
-export const CONFIG_PATH_LEGACY = path.join(
+const ALCHEMY_DIR = path.join(os.homedir(), ".alchemy");
+const ID_PATH = path.join(ALCHEMY_DIR, "id");
+const ID_PATH_LEGACY = path.join(
   envPaths("alchemy", { suffix: "" }).config,
   "id",
 );
+const DISABLED_PATH = path.join(ALCHEMY_DIR, "telemetry-disabled");
 
 export const TELEMETRY_DISABLED =
   !!process.env.ALCHEMY_TELEMETRY_DISABLED || !!process.env.DO_NOT_TRACK;
@@ -23,26 +25,43 @@ export const TELEMETRY_API_URL =
 export const SUPPRESS_TELEMETRY_ERRORS =
   !!process.env.ALCHEMY_TELEMETRY_SUPPRESS_ERRORS;
 
+export const getGlobalTelemetryDisabled = memoize(async () => {
+  const disabled = await fs
+    .readFile(DISABLED_PATH, "utf-8")
+    .then((data) => data.trim() === "true")
+    .catch(() => false);
+  return disabled;
+});
+
+export async function setGlobalTelemetryDisabled() {
+  await fs.mkdir(ALCHEMY_DIR, { recursive: true });
+  await fs.writeFile(DISABLED_PATH, "true");
+}
+
+export async function setGlobalTelemetryEnabled() {
+  await fs.rm(DISABLED_PATH, { force: true });
+}
+
 async function getOrCreateUserId() {
   async function readUserId(path: string) {
     try {
-      return (await readFile(path, "utf-8")).trim();
+      return (await fs.readFile(path, "utf-8")).trim();
     } catch {
       return null;
     }
   }
 
-  const id = await readUserId(CONFIG_PATH);
+  const id = await readUserId(ID_PATH);
   if (id) {
     return id;
   }
 
-  const legacyId = await readUserId(CONFIG_PATH_LEGACY);
+  const legacyId = await readUserId(ID_PATH_LEGACY);
 
   try {
     const id = legacyId ?? crypto.randomUUID();
-    await mkdir(path.dirname(CONFIG_PATH), { recursive: true });
-    await writeFile(CONFIG_PATH, id);
+    await fs.mkdir(ALCHEMY_DIR, { recursive: true });
+    await fs.writeFile(ID_PATH, id);
     if (!legacyId) {
       console.warn(
         [
@@ -236,6 +255,14 @@ export type AlchemyTelemetryData = {
   duration: number;
 };
 
+async function isTelemetryDisabled() {
+  return (
+    Scope.getScope()?.noTrack ||
+    TELEMETRY_DISABLED ||
+    (await getGlobalTelemetryDisabled())
+  );
+}
+
 export async function createAndSendEvent(
   data:
     | CliTelemetryData
@@ -244,7 +271,7 @@ export async function createAndSendEvent(
     | AlchemyTelemetryData,
   error?: Error,
 ) {
-  if (Scope.getScope()?.noTrack || TELEMETRY_DISABLED) {
+  if (await isTelemetryDisabled()) {
     return;
   }
   try {


### PR DESCRIPTION
Run `alchemy telemetry <enable/disable>` to set tracking globally on your machine.

When disabled, a file is created at `os.homedir()/.alchemy/telemetry-disabled`.

## Question

Would it be better to merge these into one file, `os.homedir()/.alchemy/telemetry.json`? This is definitely me being neurotic but I don't like how this looks:

<img width="561" height="179" alt="image" src="https://github.com/user-attachments/assets/2abf533d-2f67-4838-aa82-52d37c70c6ec" />
