### PR TITLE
Fix-build-args

### DIFF
--- a/alchemy/src/docker/image.ts
+++ b/alchemy/src/docker/image.ts
@@ -190,7 +190,7 @@ export const Image = Resource(
 
       // Add build arguments
       for (const [key, value] of Object.entries(buildOptions)) {
-        buildArgs.push("--build-arg", `${key}="${value}"`);
+        buildArgs.push("--build-arg", `${key}=${value}`);
       }
 
       buildArgs.push("-f", dockerfile);

--- a/examples/cloudflare-container/Dockerfile
+++ b/examples/cloudflare-container/Dockerfile
@@ -1,6 +1,9 @@
 # syntax=docker/dockerfile:1
 
-FROM golang:1.24-alpine AS build
+# deliberately use an unset arg to ensure arg functionality works
+ARG IMAGE_VERSION
+
+FROM golang:${IMAGE_VERSION} AS build
 
 # Set destination for COPY
 WORKDIR /app

--- a/examples/cloudflare-container/alchemy.run.ts
+++ b/examples/cloudflare-container/alchemy.run.ts
@@ -16,6 +16,9 @@ const container = await Container<MyContainer>("container", {
   build: {
     context: import.meta.dirname,
     dockerfile: "Dockerfile",
+    args: {
+      IMAGE_VERSION: "1.24-alpine",
+    },
   },
 });
 


### PR DESCRIPTION
Quoting docker args is bad, the quotes get passed through to the Dockerfile breaking the number one use case for args. This removes the quotes and adds args to the examples test

This will fail

```
ARG BASE_DOCKERFILE
ARG BASE_DOCKERFILE_TAG
FROM ${BASE_DOCKERFILE}:${BASE_DOCKERFILE_TAG}
```

with error

```
 - InvalidDefaultArgInFrom: Default value for ARG ${BASE_DOCKERFILE}:${BASE_DOCKERFILE_TAG} results in empty or invalid base image name (line 4)
Dockerfile:4
--------------------
   2 |     ARG BASE_DOCKERFILE
   3 |     ARG BASE_DOCKERFILE_TAG
   4 | >>> FROM ${BASE_DOCKERFILE}:${BASE_DOCKERFILE_TAG}
   5 |     
   6 |     USER 1000:1000
--------------------
ERROR: failed to solve: failed to parse stage name "\"andrewjefferson/mineflare-base\":\"cd5796be9936\"": invalid reference format
```

<img width="507" height="234" alt="image" src="https://github.com/user-attachments/assets/31a830ff-b68c-410d-a2c0-4477227a6a6e" />
