### PR TITLE
chore: pathe everywhere

### DIFF
--- a/alchemy-web/src/pages/og/[...route].png.ts
+++ b/alchemy-web/src/pages/og/[...route].png.ts
@@ -9,7 +9,7 @@ import {
   unlink,
   writeFile,
 } from "node:fs/promises";
-import { dirname, join } from "node:path";
+import { dirname, join } from "pathe";
 import { chromium, type Browser } from "playwright";
 
 export const prerender = true;

--- a/alchemy/test/esbuild.test.ts
+++ b/alchemy/test/esbuild.test.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs/promises";
 import os from "node:os";
-import { posix as path } from "node:path";
+import { posix as path } from "pathe";
 import { expect } from "vitest";
 import { alchemy } from "../src/alchemy.ts";
 import { Bundle } from "../src/esbuild/bundle.ts";

--- a/scripts/bump.ts
+++ b/scripts/bump.ts
@@ -1,7 +1,7 @@
 import { $ } from "bun";
 import { generate } from "changelogithub";
 import { readFile, writeFile } from "node:fs/promises";
-import { join } from "node:path";
+import { join } from "pathe";
 
 export async function generateReleaseNotes(tag: string) {
   console.log(`Generating release notes for version ${tag}`);


### PR DESCRIPTION
- moves pathe to the catalog
- moves alchemy-web to pathe
- moves scripts to pathe
- adds a biome rule to ban imports of `node:path`
- replaces all `node:path` instances with `pathe`

- also added prettier as a dev dep because something was using it (that should probably be refactored, but whatever)