### PR TITLE
fix(cloudflare): Get the tunnel token when it's not returned by the first API call

### DIFF
--- a/alchemy/src/cloudflare/tunnel.ts
+++ b/alchemy/src/cloudflare/tunnel.ts
@@ -566,7 +566,6 @@ export const Tunnel = Resource(
           (error.message.includes("already have a tunnel with this name") ||
             error.message.includes("already exists"))
         ) {
-          console.log(error);
           logger.log(`Tunnel '${name}' already exists, adopting it`);
 
           // Find the existing tunnel by name


### PR DESCRIPTION
This fix from my dev tunnel work never actually made it to main and it is necessary to use tunnels reliably as documented