### PR TITLE
chore(docs): import type function from alchemy

### DIFF
--- a/alchemy-web/src/content/docs/providers/cloudflare/worker.mdx
+++ b/alchemy-web/src/content/docs/providers/cloudflare/worker.mdx
@@ -805,7 +805,8 @@ In your `alchemy.run.ts` script, import the `type MyRPC` and set it as the `rpc`
 
 ```diff lang='ts'
 // alchemy.run.ts
-import { Worker, type } from "alchemy/cloudflare";
+import { type } from "alchemy";
+import { Worker } from "alchemy/cloudflare";
 import type MyRPC from "./src/rpc.ts";
 
 export const rpcWorker = await Worker("rpc", {


### PR DESCRIPTION
Updated the Cloudflare Worker RPC example to import the type function from `alchemy` instead of `alchemy/cloudflare`