### PR TITLE
fix(cloudflare): remove incorrect `observability.logging` key

### DIFF
--- a/alchemy/src/cloudflare/container.ts
+++ b/alchemy/src/cloudflare/container.ts
@@ -562,9 +562,6 @@ export const ContainerApplication = Resource(
         logs: {
           enabled: true,
         },
-        logging: {
-          enabled: true,
-        },
       },
     };
     if (this.phase === "update" && this.output?.id) {
@@ -1037,9 +1034,6 @@ interface CreateRolloutApplicationResponse {
     image: string;
     observability?: {
       logs?: {
-        enabled: boolean;
-      };
-      logging?: {
         enabled: boolean;
       };
     };


### PR DESCRIPTION
My `Container` updates were failing due to:

```console
Error: Failed to create container application: [1000] {"error":"VALIDATE_INPUT","details":{"configuration.observability":"unrecognized key(s) in object: 'logging'"}}
    at updateContainerApplication (/home/runner/work/monorepo/monorepo/node_modules/.pnpm/alchemy@0.77.5_@cloudflare+vite-plugin@1.14.2_bufferutil@4.0.9_utf-8-validate@5.0.10_vi_5d226c81737c37bcee7023523c0969b9/node_modules/alchemy/src/cloudflare/container.ts:989:9)
    at process.processTicksAndRejections (node:internal/process/task_queues:103:5)
    at async create.<anonymous> (/home/runner/work/monorepo/monorepo/node_modules/.pnpm/alchemy@0.77.5_@cloudflare+vite-plugin@1.14.2_bufferutil@4.0.9_utf-8-validate@5.0.10_vi_5d226c81737c37bcee7023523c0969b9/node_modules/alchemy/src/cloudflare/container.ts:571:27)
    at async Scope.<anonymous> (/home/runner/work/monorepo/monorepo/node_modules/.pnpm/alchemy@0.77.5_@cloudflare+vite-plugin@1.14.2_bufferutil@4.0.9_utf-8-validate@5.0.10_vi_5d226c81737c37bcee7023523c0969b9/node_modules/alchemy/src/apply.ts:278:15)
    at async _alchemy.run (/home/runner/work/monorepo/monorepo/node_modules/.pnpm/alchemy@0.77.5_@cloudflare+vite-plugin@1.14.2_bufferutil@4.0.9_utf-8-validate@5.0.10_vi_5d226c81737c37bcee7023523c0969b9/node_modules/alchemy/src/alchemy.ts:465:12)
    at async _apply (/home/runner/work/monorepo/monorepo/node_modules/.pnpm/alchemy@0.77.5_@cloudflare+vite-plugin@1.14.2_bufferutil@4.0.9_utf-8-validate@5.0.10_vi_5d226c81737c37bcee7023523c0969b9/node_modules/alchemy/src/apply.ts:269:16)
    at async <anonymous> (/home/runner/work/monorepo/monorepo/node_modules/.pnpm/alchemy@0.77.5_@cloudflare+vite-plugin@1.14.2_bufferutil@4.0.9_utf-8-validate@5.0.10_vi_5d226c81737c37bcee7023523c0969b9/node_modules/alchemy/src/cloudflare/worker.ts:1316:22)
    at async Promise.all (index 0)
    at async Promise.all (index 0)
    at async provisionResources (/home/runner/work/monorepo/monorepo/node_modules/.pnpm/alchemy@0.77.5_@cloudflare+vite-plugin@1.14.2_bufferutil@4.0.9_utf-8-validate@5.0.10_vi_5d226c81737c37bcee7023523c0969b9/node_modules/alchemy/src/cloudflare/worker.ts:1312:5)
```