### PR TITLE
fix(util): preserve primitive arrays in `camelToSnakeObjectDeep`

### DIFF
--- a/alchemy/src/util/camel-to-snake.ts
+++ b/alchemy/src/util/camel-to-snake.ts
@@ -14,7 +14,11 @@ export function camelToSnakeObjectDeep<T extends object | undefined>(
               .replace(/([a-z])([A-Z])/g, "$1_$2") // Handle normal camelCase: "fooBar" -> "foo_Bar"
               .toLowerCase(),
             Array.isArray(value)
-              ? value.map(camelToSnakeObjectDeep)
+              ? value.map((element) =>
+                  typeof element === "object" && element !== null
+                    ? camelToSnakeObjectDeep(element)
+                    : element,
+                )
               : typeof value === "object" && value !== null
                 ? camelToSnakeObjectDeep(value)
                 : value,


### PR DESCRIPTION
Fixes alchemy-run/alchemy#1230.

`camelToSnakeObjectDeep` currently assumes every array contains objects and recursively converts each element. When an array contains primitives (notably `string[]` like Cloudflare `observability.*.destinations`), each string is treated as an object and gets expanded into numeric-keyed maps.

This change only recurses into non-null object elements inside arrays, leaving primitives untouched while preserving deep conversion for arrays of objects.

Example:
- Before: `{ destinations: ['foo'] }` -> `{ destinations: [{0:'f',1:'o',2:'o'}] }`
- After: `{ destinations: ['foo'] }` -> `{ destinations: ['foo'] }`