### PR TITLE
fix(docs): fix CI guide formatting and import order

### DIFF
--- a/alchemy-web/src/content/docs/guides/ci.mdx
+++ b/alchemy-web/src/content/docs/guides/ci.mdx
@@ -5,7 +5,7 @@ sidebar:
   order: 0
 ---
 
-import { Steps, Tabs, TabItem, Code } from "@astrojs/starlight/components";
+import { Code, Steps, TabItem, Tabs } from "@astrojs/starlight/components";
 import yaml from "yaml";
 
 export function DeployWorkflow({ manager = "bun" }) {
@@ -226,17 +226,16 @@ As part of this guide, we'll:
    +    owner: "your-username",
    +    repository: "your-repo",
    +    issueNumber: Number(process.env.PULL_REQUEST),
-   +    body: `
-   +     ## 🚀 Preview Deployed
+   +    body: `## 🚀 Preview Deployed
    +
-   +     Your changes have been deployed to a preview environment:
+   +Your changes have been deployed to a preview environment:
    +
-   +     **🌐 Website:** ${website.url}
+   +**🌐 Website:** ${website.url}
    +
-   +     Built from commit ${process.env.GITHUB_SHA?.slice(0, 7)}
+   +Built from commit ${process.env.GITHUB_SHA?.slice(0, 7)}
    +
-   +     ---
-   +     <sub>🤖 This comment updates automatically with each push.</sub>`,
+   +---
+   +<sub>🤖 This comment updates automatically with each push.</sub>`,
    +  });
    +}
    


### PR DESCRIPTION
## Changes

- Sort imports from `@astrojs/starlight/components` alphabetically
- Fix template literal indentation in PR comment example

## Details

The multi-line template literal in the GitHub issue comment example had unnecessary leading whitespace which would cause the rendered markdown to not display correctly. This PR fixes the indentation so the template literal content renders properly.