### PR TITLE
fix(prisma-postgres): use connection.database.name in connection string

### DIFF
--- a/alchemy/src/prisma-postgres/connection.ts
+++ b/alchemy/src/prisma-postgres/connection.ts
@@ -143,7 +143,7 @@ export const Connection = Resource(
       createdAt: connection.createdAt,
       prismaConnectionString: secret(connection.connectionString),
       connectionString: secret(
-        `postgres://${connection.user}:${connection.pass}@${connection.host}/${connection.database}`,
+        `postgres://${connection.user}:${connection.pass}@${connection.host}/${connection.database.name}`,
       ),
       database: database,
       host: connection.host,

--- a/alchemy/test/prisma-postgres/connection.test.ts
+++ b/alchemy/test/prisma-postgres/connection.test.ts
@@ -41,6 +41,9 @@ describe("Prisma Database Connection", async () => {
       expect(connection.database).toBe(database.id);
       expect(connection.createdAt).toBeDefined();
       expect(connection.connectionString.unencrypted).toBeDefined();
+      expect(connection.prismaConnectionString.unencrypted).toBeDefined();
+      expect(connection.host).toBeDefined();
+      expect(connection.user).toBeDefined();
     } finally {
       await alchemy.destroy(scope);
 


### PR DESCRIPTION
## Summary

Fixed the Prisma Postgres connection string construction to use `connection.database.name` instead of `connection.database`.

## Changes

- **connection.ts**: Fixed connection string to correctly access the database name via `connection.database.name`
- **connection.test.ts**: Added additional test assertions for `prismaConnectionString`, `host`, and `user` properties

## Code Example

```typescript
// Before (incorrect)
connectionString: secret(
  \`postgres://\${connection.user}:\${connection.pass}@\${connection.host}/\${connection.database}\`,
),

// After (correct)
connectionString: secret(
  \`postgres://\${connection.user}:\${connection.pass}@\${connection.host}/\${connection.database.name}\`,
),
```

## Testing

- [x] Test passes with valid Prisma service token