### PR TITLE
fix(core): lowercase generated physical names

### DIFF
--- a/alchemy/src/cloudflare/website.ts
+++ b/alchemy/src/cloudflare/website.ts
@@ -156,7 +156,7 @@ export async function Website<B extends Bindings>(
   props: WebsiteProps<B>,
 ) {
   const {
-    name = Scope.current.createPhysicalName(id).toLowerCase(),
+    name = Scope.current.createPhysicalName(id),
     build: buildProps,
     assets,
     dev,

--- a/alchemy/src/cloudflare/worker.ts
+++ b/alchemy/src/cloudflare/worker.ts
@@ -851,9 +851,7 @@ const _Worker = Resource(
   ) {
     let adopt = props.adopt ?? this.scope.adopt;
     const workerName =
-      props.name ??
-      this.output?.name ??
-      this.scope.createPhysicalName(id).toLowerCase();
+      props.name ?? this.output?.name ?? this.scope.createPhysicalName(id);
     if (this.phase === "create" && !props.adopt) {
       // it is possible that this worker already exists and was created by the old Website wrapper with a nested scope
       // we need to detect this and set adopt=true so that the previous version will be adopted seamlessly

--- a/alchemy/src/scope.ts
+++ b/alchemy/src/scope.ts
@@ -336,7 +336,8 @@ export class Scope {
     const stage = this.stage;
     return [app, ...this.chain.slice(2), id, stage]
       .map((s) => s.replaceAll(/[^a-z0-9_-]/gi, delimiter))
-      .join(delimiter);
+      .join(delimiter)
+      .toLowerCase();
   }
 
   public async spawn<


### PR DESCRIPTION
Closes #1251 and addresses a follow-up comment in #1135.

The problem was that while we were lowercasing the default worker generated name for the `Worker` resource, we weren't doing that for the `Website` resource, which affected generated wrangler.jsonc files.

