### PR TITLE
fix(cli): correct destroy command description

### DIFF
--- a/alchemy/bin/commands/destroy.ts
+++ b/alchemy/bin/commands/destroy.ts
@@ -8,7 +8,7 @@ import { loggedProcedure } from "../trpc.ts";
 
 export const destroy = loggedProcedure
   .meta({
-    description: "deploy an alchemy project",
+    description: "destroy an alchemy project",
   })
   .input(z.tuple([entrypoint, z.object(execArgs)]))
   .mutation(async ({ input: [main, options] }) =>


### PR DESCRIPTION
## Summary
The meta commands `deploy` and `destroy` have the same description:

>  deploy [options] [Path to the entrypoint file]   deploy an alchemy project
>  destroy [options] [Path to the entrypoint file]  deploy an alchemy project

Description for `destroy` command should be "**destroy** the alchemy project"