### PR TITLE
Add previews_enabled configuration option for Workers

### DIFF
--- a/alchemy/src/cloudflare/worker-metadata.ts
+++ b/alchemy/src/cloudflare/worker-metadata.ts
@@ -204,7 +204,6 @@ export interface WorkerMetadata {
     };
   };
   logpush?: boolean;
-  previews_enabled?: boolean;
   migrations?: SingleStepMigration;
   main_module?: string;
   body_part?: string;
@@ -353,9 +352,6 @@ export async function prepareWorkerMetadata(
       enabled: observability?.enabled !== false,
     },
     logpush: props.logpush ?? false,
-    ...(props.previews_enabled !== undefined && {
-      previews_enabled: props.previews_enabled,
-    }),
     // TODO(sam): base64 encode instead? 0 collision risk vs readability.
     tags: [
       // encode a mapping table of Durable Object stable ID -> binding name

--- a/alchemy/src/cloudflare/worker-subdomain.ts
+++ b/alchemy/src/cloudflare/worker-subdomain.ts
@@ -35,6 +35,15 @@ interface WorkerSubdomainProps extends CloudflareApiOptions {
    * @internal
    */
   dev?: boolean;
+  /**
+   * Whether to enable preview URLs for this worker.
+   *
+   * When `undefined`, defaults to `true` (matching the behavior of enabling
+   * the workers.dev subdomain).
+   *
+   * @see https://developers.cloudflare.com/workers/configuration/previews/
+   */
+  previewsEnabled?: boolean;
 }
 
 export interface WorkerSubdomain {
@@ -64,7 +73,7 @@ export const WorkerSubdomain = Resource(
       }
       return this.destroy();
     }
-    await enableWorkerSubdomain(api, props.scriptName);
+    await enableWorkerSubdomain(api, props.scriptName, props.previewsEnabled);
     const subdomain = await getAccountSubdomain(api);
     const base = `${subdomain}.workers.dev`;
     let url: string;
@@ -102,6 +111,7 @@ export async function disableWorkerSubdomain(
 export async function enableWorkerSubdomain(
   api: CloudflareApi,
   scriptName: string,
+  previewsEnabled?: boolean,
 ) {
   await withExponentialBackoff(
     () =>
@@ -111,7 +121,7 @@ export async function enableWorkerSubdomain(
           `/accounts/${api.accountId}/workers/scripts/${scriptName}/subdomain`,
           {
             enabled: true,
-            previews_enabled: true,
+            previews_enabled: previewsEnabled ?? true,
           },
         ),
       ),

--- a/alchemy/src/cloudflare/worker.ts
+++ b/alchemy/src/cloudflare/worker.ts
@@ -198,14 +198,15 @@ export interface BaseWorkerProps<
   /**
    * Whether to enable preview URLs for this worker.
    *
-   * Must be set to `false` when the worker uses Durable Objects, otherwise
-   * the Cloudflare API will reject the upload with error code 100331.
+   * Preview URLs are not supported for Workers that use Durable Objects.
+   * Set to `false` when using Durable Objects.
    *
-   * Only included in the upload metadata when explicitly set.
+   * When not set, defaults to the value of the `url` prop (matching
+   * Wrangler's behavior where `preview_urls` defaults to `workers_dev`).
    *
-   * @see https://developers.cloudflare.com/workers/configuration/previews/#limitations
+   * @see https://developers.cloudflare.com/workers/configuration/previews/
    */
-  previews_enabled?: boolean;
+  preview_urls?: boolean;
 
   /**
    * Whether to adopt the Worker if it already exists when creating
@@ -1526,6 +1527,7 @@ async function provisionResources<B extends Bindings>(
         ? WorkerSubdomain("url", {
             scriptName: options.name,
             previewVersionId: props.version ? options.result?.id : undefined,
+            previewsEnabled: props.preview_urls,
             retain: !!props.version,
             dev: options.local,
             ...input.api,


### PR DESCRIPTION
## Summary

- Adds optional `preview_urls` boolean to `BaseWorkerProps` (matching Wrangler's config name)
- Threads through to `WorkerSubdomain`, which calls the Cloudflare subdomain API: `POST /accounts/{id}/workers/scripts/{name}/subdomain` with `{ enabled, previews_enabled }`
- Previously `enableWorkerSubdomain` hardcoded `previews_enabled: true` — now respects the user's setting

## Why this approach?

Preview URLs are **not** part of the multipart upload metadata (unlike `logpush`). They're managed via a separate POST to the `/subdomain` endpoint — this is exactly how [Wrangler handles it](https://github.com/cloudflare/workers-sdk/blob/main/packages/wrangler/src/triggers/deploy.ts). The first commit in this PR incorrectly added it to metadata; the second commit fixes this.

## Usage

```ts
const worker = await Worker("my-worker", {
  entrypoint: "./src/worker.ts",
  preview_urls: false, // Required when using Durable Objects
  bindings: {
    MY_DO: DurableObjectNamespace("my-do", {
      className: "MyDurableObject",
    }),
  },
});
```

## Files changed

- **`worker.ts`** — Added `preview_urls?: boolean` to `BaseWorkerProps`, passed to `WorkerSubdomain`
- **`worker-subdomain.ts`** — Added `previewsEnabled` prop, threaded to `enableWorkerSubdomain()` instead of hardcoding `true`
- **`worker-metadata.ts`** — No net changes (reverted incorrect metadata approach)

## References

- [Cloudflare Preview URLs docs](https://developers.cloudflare.com/workers/configuration/previews/)
- [Limitation: no preview URLs with Durable Objects](https://developers.cloudflare.com/workers/configuration/previews/#limitations)
- [Wrangler config: `preview_urls`](https://developers.cloudflare.com/workers/wrangler/configuration/)

## Test plan

- [ ] Deploy a Worker with Durable Objects and `preview_urls: false` — succeeds
- [ ] Deploy a Worker without the flag — behavior unchanged (defaults to `true`)
- [ ] Deploy a Worker with `preview_urls: true` — preview URLs enabled