### PR TITLE
fix: Propagate request abort signal to Miniflare worker proxy

### DIFF
--- a/alchemy/src/cloudflare/miniflare/miniflare-worker-proxy.ts
+++ b/alchemy/src/cloudflare/miniflare/miniflare-worker-proxy.ts
@@ -35,7 +35,9 @@ export async function createMiniflareWorkerProxy(options: {
       const response = await handleFetch(req, res);
       writeMiniflareResponseToNode(response, res);
     } catch (error) {
-      console.error(error);
+      if (!(error instanceof DOMException && error.name === "AbortError")) {
+        console.error(error);
+      }
       const response = MiniflareWorkerProxyError.fromUnknown(error).toResponse(
         options.mode,
       );


### PR DESCRIPTION
This PR fixes request-abort behavior for Cloudflare Workers running via Alchemy Worker resource in local dev mode.
Please see [this discord thread](https://discord.com/channels/1359694195782320389/1469365830029545700) for an example of the CF worker code not working.

### Root cause
When a client disconnected from a streaming response (for example SSE), Worker-side abort handling was not triggered in local dev.

`req.signal.addEventListener("abort", ...)` did not fire and cleanup tied to disconnect could be missed.

The root cause was in the local Miniflare HTTP proxy path: client disconnect state was not explicitly translated into a forwarded abort signal for the dispatched worker request.

### This change:
- Adds disconnect-aware abort signal wiring in `miniflare-worker-proxy.ts`

### Tests
For some reason (obscure to me), the issue only happened during Alchemy dev mode, and I couldn't re-create it in a test while using Alchemy "test" mode. Test mode was just working fine without the patch.

### Usage of AI:
I did run GPT 5.3 Codex to find the issue, and generate the fix. I reviewed the code and tested it myself.