### PR TITLE
fix(state): set sqlite busy_timeout to 5s

### DIFF
--- a/alchemy/src/state/sqlite-state-store.ts
+++ b/alchemy/src/state/sqlite-state-store.ts
@@ -162,6 +162,7 @@ async function createBunSQLiteDatabase(
     create: true,
     ...bunOptions,
   });
+  client.exec("PRAGMA busy_timeout = 5000;");
   client.exec("PRAGMA journal_mode = WAL;");
   const db = drizzle(client, {
     schema,
@@ -192,6 +193,7 @@ async function createLibSQLDatabase(
   const { migrate } = await import("drizzle-orm/libsql/migrator");
   const schema = await import("./schema.js");
   const client = createClient({ url, ...options });
+  await client.execute("PRAGMA busy_timeout = 5000;");
   await client.execute("PRAGMA journal_mode = WAL;");
   const db = drizzle(client, {
     schema,


### PR DESCRIPTION
When running multiple apps sharing the same SQLite state store file, concurrent access causes errors. This has been biting us in a monorepo setup with `alchemy dev`.

```
LibsqlError: SQLITE_BUSY_RECOVERY: database is locked
```

This PR adds an arbitrary 5s delay before SQLite returns an error.