### PR TITLE
Fix: Ignore timestamps when comparing props for consistency

### DIFF
--- a/alchemy/src/apply.ts
+++ b/alchemy/src/apply.ts
@@ -144,16 +144,20 @@ async function _apply<Out extends ResourceAttributes>(
       ) {
         // Remove timestamps from props before comparing, as they can cause non-deterministic differences
         const stripNonDeterministic = (obj: any): any => {
-          if (!obj || typeof obj !== 'object') return obj;
+          if (!obj || typeof obj !== "object") return obj;
           if (Array.isArray(obj)) return obj.map(stripNonDeterministic);
           const { updatedAt, createdAt, ...rest } = obj;
           return Object.fromEntries(
-            Object.entries(rest).map(([k, v]) => [k, stripNonDeterministic(v)])
+            Object.entries(rest).map(([k, v]) => [k, stripNonDeterministic(v)]),
           );
         };
-        const oldProps = await serialize(scope, stripNonDeterministic(state.props), {
-          encrypt: false,
-        });
+        const oldProps = await serialize(
+          scope,
+          stripNonDeterministic(state.props),
+          {
+            encrypt: false,
+          },
+        );
         const newProps = await serialize(scope, stripNonDeterministic(props), {
           encrypt: false,
         });

--- a/alchemy/src/apply.ts
+++ b/alchemy/src/apply.ts
@@ -142,10 +142,19 @@ async function _apply<Out extends ResourceAttributes>(
       async function inputsAreEqual(
         state: State<string, ResourceProps | undefined, Resource>,
       ) {
-        const oldProps = await serialize(scope, state.props, {
+        // Remove timestamps from props before comparing, as they can cause non-deterministic differences
+        const stripNonDeterministic = (obj: any): any => {
+          if (!obj || typeof obj !== 'object') return obj;
+          if (Array.isArray(obj)) return obj.map(stripNonDeterministic);
+          const { updatedAt, createdAt, ...rest } = obj;
+          return Object.fromEntries(
+            Object.entries(rest).map(([k, v]) => [k, stripNonDeterministic(v)])
+          );
+        };
+        const oldProps = await serialize(scope, stripNonDeterministic(state.props), {
           encrypt: false,
         });
-        const newProps = await serialize(scope, props, {
+        const newProps = await serialize(scope, stripNonDeterministic(props), {
           encrypt: false,
         });
         return JSON.stringify(oldProps) === JSON.stringify(newProps);

--- a/alchemy/src/util/cli.ts
+++ b/alchemy/src/util/cli.ts
@@ -81,7 +81,7 @@ export const createDummyLogger = (): LoggerApi => {
 export const createFallbackLogger = (alchemyInfo: AlchemyInfo): LoggerApi => {
   if (alchemyInfo.phase !== "read") {
     console.log(dedent`
-      ${colorize("Alchemy", "cyanBright")} (v${packageJson.version})
+      ${colorize("Alchemy", "cyanBright")} (v${packageJson.version}) [local]
       App: ${alchemyInfo.appName}
       Phase: ${alchemyInfo.phase}
       Stage: ${alchemyInfo.stage}


### PR DESCRIPTION
Prevents getting stuck in a 'Resource ... is not in a stable state after...' loop.