### PR TITLE
feat(cloudflare)!: scope workflow names with app and stage

### DIFF
--- a/alchemy/src/cloudflare/worker.ts
+++ b/alchemy/src/cloudflare/worker.ts
@@ -1081,6 +1081,10 @@ const _Worker = Resource(
           binding.type === "workflow" &&
           (!binding.scriptName || binding.scriptName === workerName)
         ) {
+          if (!binding.workflowName) {
+            binding.workflowName = this.scope
+              .createPhysicalName(binding.id, "-", 64);
+          }
           workflows.push(binding);
         } else if (
           binding.type === "durable_object_namespace" &&

--- a/alchemy/src/cloudflare/workflow.ts
+++ b/alchemy/src/cloudflare/workflow.ts
@@ -8,7 +8,7 @@ export interface WorkflowProps {
    *
    * @maxLength 64
    * @minLength 1
-   * @default - className if provided, otherwise id
+   * @default - ${app}-${id}-${stage}
    */
   workflowName?: string;
   /**
@@ -56,7 +56,7 @@ export type Workflow<PARAMS = unknown> = {
    */
   _PARAMS: PARAMS;
   id: string;
-  workflowName: string;
+  workflowName?: string;
   className: string;
   scriptName?: string;
   limits?: {
@@ -84,14 +84,13 @@ export function Workflow<PARAMS = unknown>(
   id: string,
   props: WorkflowProps = {},
 ): Workflow<PARAMS> {
-  const workflowName = props.workflowName ?? props.className ?? id;
-  const className = props.className ?? workflowName;
+  const className = props.className ?? props.workflowName ?? id;
 
   return {
     type: "workflow",
     _PARAMS: undefined!,
     id,
-    workflowName,
+    workflowName: props.workflowName,
     className,
     scriptName: props.scriptName,
     limits: props.limits,


### PR DESCRIPTION
## Summary

- Scopes Cloudflare Workflow names with app and stage via `createPhysicalName`
- Makes `workflowName` optional in the `Workflow` type, deferring name generation to the Worker resource

## Status

**WIP** — Reverted from main due to TS build errors. The core issue is that `wrangler.json.ts` receives unresolved workflow bindings (before `Worker` populates `workflowName`), so `workflowName` can be `undefined` where `string` is expected.

Needs design work to ensure workflow name resolution happens before all consumers.

## Original PR
#1380

🤖 Generated with [Claude Code](https://claude.com/claude-code)