### PR TITLE
feat(cloudflare): add AI Search namespace + standalone binding support

### DIFF
--- a/alchemy-web/src/content/docs/guides/cloudflare-ai-search.mdx
+++ b/alchemy-web/src/content/docs/guides/cloudflare-ai-search.mdx
@@ -1,0 +1,230 @@
+---
+title: AI Search
+description: Learn how to deploy a knowledge base with Cloudflare AI Search and a Worker using Alchemy.
+sidebar:
+  order: 15
+---
+
+import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
+
+This guide walks you through creating an AI Search knowledge base with a Cloudflare Worker that provides semantic search and RAG-powered chat completions.
+
+:::note
+For complete API references, see the [AiSearch](/providers/cloudflare/ai-search) and [AiSearchNamespace](/providers/cloudflare/ai-search-namespace) documentation.
+:::
+
+:::caution[Requirements]
+- `@cloudflare/workers-types` ≥ `4.20260417.1`
+
+AI Search bindings are not natively supported by Miniflare; in `alchemy dev` they are proxied to the deployed instance via the `remote-binding-proxy` worker. If you haven't deployed yet, the binding will error until the first deploy.
+:::
+
+<Steps>
+
+1. **Install Dependencies**
+
+   <Tabs syncKey="pkgManager">
+     <TabItem label="bun">
+       ```sh
+       bun add alchemy
+       ```
+     </TabItem>
+     <TabItem label="npm">
+       ```sh
+       npm install alchemy
+       ```
+     </TabItem>
+     <TabItem label="pnpm">
+       ```sh
+       pnpm add alchemy
+       ```
+     </TabItem>
+     <TabItem label="yarn">
+       ```sh
+       yarn add alchemy
+       ```
+     </TabItem>
+   </Tabs>
+
+2. **Credentials**
+
+   Set your Cloudflare API token in your environment:
+
+   ```sh
+   export CLOUDFLARE_API_TOKEN=your-api-token
+   ```
+
+   You can create a user API token at [dash.cloudflare.com/profile/api-tokens](https://dash.cloudflare.com/profile/api-tokens) with the **AI Search Edit** and **Workers Scripts Edit** permissions. (This is the token Alchemy uses to manage AI Search instances; it is separate from the service token Cloudflare provisions internally to grant AI Search access to an R2 bucket — see [Service Token](/providers/cloudflare/ai-search#service-token) in the AiSearch reference.)
+
+3. **Create `alchemy.run.ts`**
+
+   Create a deployment script that provisions an AI Search instance and a Worker:
+
+   ```ts title="alchemy.run.ts"
+   import alchemy from "alchemy";
+   import { AiSearch, AiSearchNamespace, Worker } from "alchemy/cloudflare";
+
+   const app = await alchemy("ai-search-app");
+
+   // Create a namespace for organizing instances
+   const ns = await AiSearchNamespace("docs", {
+     name: "my-docs",
+     adopt: true,
+   });
+
+   // Create an AI Search instance (built-in storage, no R2 needed)
+   const search = await AiSearch("knowledge-base", {
+     name: "knowledge-base",
+     adopt: true,
+   });
+
+   // Deploy a Worker with both binding types.
+   export const worker = await Worker("api", {
+     entrypoint: "./src/worker.ts",
+     url: true,
+     bindings: {
+       SEARCH: search, // Single instance binding
+       DOCS: ns,        // Namespace binding for dynamic access
+     },
+   });
+
+   console.log({ url: worker.url });
+
+   await app.finalize();
+   ```
+
+4. **Implement the Worker**
+
+   Create a Worker that handles search queries, file uploads, and chat completions:
+
+   ```ts title="src/worker.ts"
+   import type { worker } from "../alchemy.run";
+
+   export default {
+     async fetch(request: Request, env: typeof worker.Env): Promise<Response> {
+       const url = new URL(request.url);
+
+       // Upload a document
+       if (url.pathname === "/upload" && request.method === "POST") {
+         const formData = await request.formData();
+         const file = formData.get("file") as File;
+         if (!file) return new Response("No file", { status: 400 });
+
+         const item = await env.SEARCH.items.upload(file.name, file);
+         return Response.json({ uploaded: item });
+       }
+
+       // Search — simple lookup uses `query`.
+       if (url.pathname === "/search") {
+         const query = url.searchParams.get("q");
+         if (!query) return new Response("?q= required", { status: 400 });
+
+         const results = await env.SEARCH.search({ query });
+         return Response.json(results);
+       }
+
+       // Chat completions (streaming) — chat-style context uses `messages`.
+       if (url.pathname === "/chat") {
+         const query = url.searchParams.get("q");
+         if (!query) return new Response("?q= required", { status: 400 });
+
+         const stream = await env.SEARCH.chatCompletions({
+           messages: [{ role: "user", content: query }],
+           stream: true,
+         });
+
+         return new Response(stream, {
+           headers: { "content-type": "text/event-stream" },
+         });
+       }
+
+       // List instances in namespace
+       if (url.pathname === "/instances") {
+         const list = await env.DOCS.list();
+         return Response.json(list);
+       }
+
+       return new Response(
+         "Endpoints:\n" +
+         "  POST /upload     — Upload a document\n" +
+         "  GET  /search?q=  — Search documents\n" +
+         "  GET  /chat?q=    — Chat with documents (streaming)\n" +
+         "  GET  /instances  — List AI Search instances\n",
+       );
+     },
+   };
+   ```
+
+5. **Deploy**
+
+   Run the `alchemy.run.ts` script to deploy:
+
+   <Tabs syncKey="pkgManager">
+     <TabItem label="bun">
+       ```sh
+       bun ./alchemy.run
+       ```
+     </TabItem>
+     <TabItem label="npm">
+       ```sh
+       npx tsx ./alchemy.run
+       ```
+     </TabItem>
+     <TabItem label="pnpm">
+       ```sh
+       pnpm tsx ./alchemy.run
+       ```
+     </TabItem>
+     <TabItem label="yarn">
+       ```sh
+       yarn tsx ./alchemy.run
+       ```
+     </TabItem>
+   </Tabs>
+
+   It should log out the Worker URL:
+   ```sh
+   { url: "https://api.your-subdomain.workers.dev" }
+   ```
+
+6. **Upload and Search**
+
+   Upload a document and search it:
+
+   ```sh
+   # Upload a document
+   curl -F "file=@guide.pdf" https://api.your-subdomain.workers.dev/upload
+
+   # Search (wait a moment for indexing)
+   curl "https://api.your-subdomain.workers.dev/search?q=how+does+caching+work"
+
+   # Chat with streaming response
+   curl "https://api.your-subdomain.workers.dev/chat?q=explain+caching"
+   ```
+
+7. **Tear Down**
+
+   <Tabs syncKey="pkgManager">
+     <TabItem label="bun">
+       ```sh
+       bun ./alchemy.run --destroy
+       ```
+     </TabItem>
+     <TabItem label="npm">
+       ```sh
+       npx tsx ./alchemy.run --destroy
+       ```
+     </TabItem>
+     <TabItem label="pnpm">
+       ```sh
+       pnpm tsx ./alchemy.run --destroy
+       ```
+     </TabItem>
+     <TabItem label="yarn">
+       ```sh
+       yarn tsx ./alchemy.run --destroy
+       ```
+     </TabItem>
+   </Tabs>
+
+</Steps>

--- a/alchemy-web/src/content/docs/providers/cloudflare/ai-search-namespace.md
+++ b/alchemy-web/src/content/docs/providers/cloudflare/ai-search-namespace.md
@@ -1,0 +1,219 @@
+---
+title: AiSearchNamespace
+description: Create and manage Cloudflare AI Search namespaces for grouping and isolating search instances.
+---
+
+The AiSearchNamespace resource creates and manages [Cloudflare AI Search](https://developers.cloudflare.com/ai-search/) namespaces. Namespaces group AI Search instances together, providing logical isolation and scoped access control. Instance names are unique within their namespace.
+
+When used as a Worker binding, `AiSearchNamespace` provides a `ai_search_namespaces` binding that gives the Worker dynamic access to all instances within the namespace -- enabling runtime creation, deletion, search, and chat operations.
+
+:::note[Requirements]
+- `@cloudflare/workers-types` ≥ `4.20260417.1`
+- The `default` namespace is reserved by Cloudflare. It is created automatically on every account and cannot be created, updated, or deleted via the API. To bind to it, pass `adopt: true`.
+:::
+
+## Minimal Example
+
+```ts
+import { AiSearchNamespace } from "alchemy/cloudflare";
+
+const ns = await AiSearchNamespace("production", {
+  name: "production",
+});
+```
+
+## Use as Worker Binding
+
+The primary use case for `AiSearchNamespace` is as a Worker binding. This gives your Worker dynamic access to all instances in the namespace at runtime:
+
+```ts
+import { Worker, AiSearchNamespace } from "alchemy/cloudflare";
+
+const ns = await AiSearchNamespace("docs", {
+  name: "docs",
+});
+
+await Worker("api", {
+  entrypoint: "./src/worker.ts",
+  bindings: {
+    DOCS: ns, // Namespace binding
+  },
+});
+```
+
+```ts
+// src/worker.ts
+export default {
+  async fetch(request, env) {
+    // Access an instance within the namespace. For a one-off lookup the
+    // simpler `query` shape is preferred; use `messages` for multi-turn /
+    // chat-style context.
+    const results = await env.DOCS.get("my-blog").search({
+      query: "How does caching work?",
+    });
+
+    // List all instances in the namespace
+    const instances = await env.DOCS.list();
+
+    // Create a new instance at runtime (no redeployment needed).
+    // `index_method` defaults to hybrid (vector + keyword); override for
+    // keyword-only or vector-only indexing.
+    const tenant = await env.DOCS.create({ id: "tenant-123" });
+    await tenant.items.upload("faq.md", "# FAQ\n\n...");
+
+    // Delete an instance
+    await env.DOCS.delete("old-docs");
+
+    return Response.json(results);
+  },
+};
+```
+
+## Use Cases
+
+### Multi-language Content
+
+One instance per language, accessed through a single binding:
+
+```ts
+import { AiSearchNamespace, Worker } from "alchemy/cloudflare";
+
+const blog = await AiSearchNamespace("blog", { name: "blog" });
+
+await Worker("api", {
+  entrypoint: "./src/worker.ts",
+  bindings: { BLOG: blog },
+});
+```
+
+```ts
+// src/worker.ts
+export default {
+  async fetch(request, env) {
+    const lang = new URL(request.url).searchParams.get("lang") || "en";
+    const q = new URL(request.url).searchParams.get("q") ?? "";
+    const results = await env.BLOG.get(`blog-${lang}`).search({ query: q });
+    return Response.json(results);
+  },
+};
+```
+
+### Per-tenant SaaS
+
+Dynamically create isolated instances per tenant without redeployment:
+
+```ts
+// src/worker.ts
+export default {
+  async fetch(request, env) {
+    const tenantId = request.headers.get("x-tenant-id");
+    const url = new URL(request.url);
+
+    if (url.pathname === "/onboard" && request.method === "POST") {
+      await env.TENANTS.create({ id: `tenant-${tenantId}` });
+      return new Response("Onboarded");
+    }
+
+    if (url.pathname === "/search") {
+      const results = await env.TENANTS.get(`tenant-${tenantId}`).search({
+        query: url.searchParams.get("q") ?? "",
+      });
+      return Response.json(results);
+    }
+
+    return new Response("Not found", { status: 404 });
+  },
+};
+```
+
+## With AiSearch Instances
+
+Create instances in a specific namespace using the `namespace` prop on [AiSearch](/providers/cloudflare/ai-search):
+
+```ts
+import { AiSearch, AiSearchNamespace, R2Bucket } from "alchemy/cloudflare";
+
+const ns = await AiSearchNamespace("production", {
+  name: "production",
+});
+
+const bucket = await R2Bucket("docs", { name: "my-docs" });
+
+const search = await AiSearch("docs-search", {
+  source: bucket,
+  namespace: ns,
+});
+```
+
+## Both Binding Types in One Worker
+
+You can use both namespace bindings (dynamic multi-instance) and single instance bindings (direct access) in the same Worker:
+
+```ts
+import { Worker, AiSearch, AiSearchNamespace } from "alchemy/cloudflare";
+
+const ns = await AiSearchNamespace("docs", { name: "docs" });
+const blog = await AiSearch("blog-search", { name: "blog" });
+
+await Worker("api", {
+  entrypoint: "./src/worker.ts",
+  bindings: {
+    DOCS: ns,         // Namespace binding — dynamic access
+    BLOG_SEARCH: blog, // Single instance binding — direct access
+  },
+});
+```
+
+## Configuration
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `name` | `string` | auto-generated | Namespace name (pattern: `^[a-z0-9]([a-z0-9-]{0,26}[a-z0-9])?$`) |
+| `description` | `string` | — | Optional description (max 256 characters) |
+| `delete` | `boolean` | `true` | Delete namespace on removal. Namespace must be empty. |
+| `adopt` | `boolean` | `false` | Adopt existing namespace |
+
+## Output Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `type` | `"ai_search_namespace"` | Resource type identifier |
+| `id` | `string` | Stable identifier (equal to `namespace`) |
+| `namespace` | `string` | The namespace name |
+| `description` | `string \| null` | Namespace description, or `null` if unset/cleared |
+| `createdAt` | `string` | Creation timestamp (ISO 8601) |
+
+## Type Guard
+
+To narrow an unknown binding or resource to an `AiSearchNamespace`, use `isAiSearchNamespace`:
+
+```ts
+import { isAiSearchNamespace } from "alchemy/cloudflare";
+
+if (isAiSearchNamespace(binding)) {
+  // binding is narrowed to AiSearchNamespace
+  console.log(binding.namespace);
+}
+```
+
+## Clearing a description
+
+Descriptions follow three-way semantics on update:
+
+- **Absent from props** (`undefined`): leave the current description untouched. Useful when you don't want to overwrite out-of-band edits made from the Cloudflare dashboard.
+- **String value**: set the description to that value.
+- **`null`**: explicitly clear a previously-set description.
+
+```ts
+// Set initially
+await AiSearchNamespace("ns", {
+  name: "docs",
+  description: "Documentation namespace",
+});
+
+// Later: clear the description
+await AiSearchNamespace("ns", {
+  name: "docs",
+  description: null, // explicit null clears the description
+});
+```

--- a/alchemy-web/src/content/docs/providers/cloudflare/ai-search.md
+++ b/alchemy-web/src/content/docs/providers/cloudflare/ai-search.md
@@ -3,7 +3,21 @@ title: AiSearch
 description: Learn how to create and configure Cloudflare AI Search instances for RAG-powered semantic search using Alchemy.
 ---
 
-The AiSearch resource lets you create and manage [Cloudflare AI Search](https://developers.cloudflare.com/ai-search/) instances (formerly AutoRAG). AI Search automatically indexes your data from R2 buckets or web crawlers, creates vector embeddings, and provides natural language search with AI-generated responses.
+The AiSearch resource lets you create and manage [Cloudflare AI Search](https://developers.cloudflare.com/ai-search/) instances (formerly AutoRAG). AI Search automatically indexes your data from R2 buckets, web crawlers, or manual file uploads, creates vector embeddings, and provides natural language search with AI-generated responses.
+
+:::note[Requirements]
+- `@cloudflare/workers-types` ≥ `4.20260417.1`
+- Single-instance `ai_search` bindings only work for instances in the `default` namespace. For non-default namespaces, bind the enclosing [AiSearchNamespace](/providers/cloudflare/ai-search-namespace) and use `env.BINDING.get(name)`.
+:::
+
+## Query shapes
+
+The search / chatCompletions APIs accept two equivalent request shapes:
+
+- **`query: string`** — a simple text query, ideal for one-off lookups.
+- **`messages: Array<{role, content}>`** — a chat-style conversation array, ideal for RAG and multi-turn context.
+
+You can pass either `query` OR `messages`, not both. The examples in this page mix both styles.
 
 ## Minimal Example
 
@@ -19,9 +33,89 @@ const search = await AiSearch("docs-search", {
 });
 ```
 
-## Using AI Search from a Worker
+## Built-in Storage (No Source)
 
-AI Search instances are accessed through the `AI` binding using `env.AI.autorag(name)`. Pass `search.id` as a binding so your worker knows the actual instance name (which may be auto-generated based on your app and stage):
+Create an AI Search instance with built-in storage for manual file uploads via the binding. No source or token is needed:
+
+```ts
+import { AiSearch } from "alchemy/cloudflare";
+
+const search = await AiSearch("docs-search", {
+  name: "my-knowledge-base",
+});
+```
+
+Items can be uploaded through the AI Search binding at runtime. The `upload()` method accepts a `ReadableStream`, `Blob`, or `string` for content:
+
+```ts
+// In your Worker (where DOCS is bound to the AiSearch instance)
+// Upload a markdown document as a string
+await env.DOCS.items.upload("faq.md", "# FAQ\n\nQ: ...");
+
+// Upload a Blob (e.g. from a fetch response or form data)
+const file = (await request.formData()).get("file") as File;
+await env.DOCS.items.upload(file.name, file);
+```
+
+## Using AI Search Bindings (Recommended)
+
+AI Search instances can be bound directly to Workers as `ai_search` bindings, providing first-class access to search, chat, items, and jobs APIs:
+
+```ts
+import { Worker, AiSearch } from "alchemy/cloudflare";
+
+const search = await AiSearch("docs-search", {
+  name: "my-docs",
+});
+
+await Worker("api", {
+  entrypoint: "./src/worker.ts",
+  bindings: {
+    DOCS: search, // Direct AI Search binding
+  },
+});
+```
+
+```ts
+// src/worker.ts
+export default {
+  async fetch(request, env) {
+    // Simple lookup: pass `query`. For multi-turn / chat-style context,
+    // pass `messages: [{ role, content }, …]` instead (see Query shapes above).
+    const results = await env.DOCS.search({
+      query: "How does caching work?",
+    });
+    return Response.json(results);
+  },
+};
+```
+
+:::tip[Namespace Binding]
+For dynamic multi-instance access (per-tenant SaaS, multi-language content, AI agents), use the [AiSearchNamespace](/providers/cloudflare/ai-search-namespace) binding instead. See the [AiSearchNamespace docs](/providers/cloudflare/ai-search-namespace) for details.
+:::
+
+## Namespaces
+
+AI Search instances belong to namespaces. By default, instances are created in the `"default"` namespace. Use the `namespace` prop to place instances in a specific namespace:
+
+```ts
+import { AiSearch, AiSearchNamespace } from "alchemy/cloudflare";
+
+const ns = await AiSearchNamespace("production", {
+  name: "production",
+});
+
+const search = await AiSearch("docs-search", {
+  source: bucket,
+  namespace: ns, // or namespace: "production"
+});
+```
+
+See [AiSearchNamespace](/providers/cloudflare/ai-search-namespace) for managing namespaces.
+
+## Using AI Search via the AI Binding (Legacy)
+
+AI Search instances can also be accessed through the `AI` binding using `env.AI.autorag(name)`. This is scoped to the default namespace only:
 
 ```ts
 import { Worker, Ai, AiSearch, R2Bucket } from "alchemy/cloudflare";
@@ -65,9 +159,9 @@ export default {
 If you don't provide an explicit `name`, Alchemy generates one using `${app}-${stage}-${id}` (e.g., `myapp-dev-docs-search`). Always use `search.id` as a binding for portability across environments, or pass an explicit `name` if you need a predictable value.
 :::
 
-## RAG Response Generation
+## RAG Response Generation (legacy `AI` binding)
 
-Use `aiSearch()` to get AI-generated responses along with source documents:
+Use the legacy `AI` binding's `autorag(id).aiSearch()` to get AI-generated responses along with source documents. For the modern `ai_search` / `ai_search_namespaces` bindings, use `search()` / `chatCompletions()` on the binding directly instead (see [the docs](https://developers.cloudflare.com/ai-search/api/search/workers-binding/)).
 
 ```ts
 // src/worker.ts
@@ -236,7 +330,9 @@ const search = await AiSearch("cached-search", {
 
 ## Service Token
 
-AI Search requires a service token with specific permissions to access resources in your account. Alchemy handles this automatically:
+Service tokens are **only required for R2 bucket sources**. Web crawler and built-in storage instances do not need tokens.
+
+When using an R2 source, Alchemy handles token management automatically:
 
 1. **If tokens already exist**: Alchemy detects existing AI Search service tokens in your account and lets AI Search auto-select one. No new token is created.
 
@@ -278,9 +374,12 @@ See [AiSearchToken](/providers/cloudflare/ai-search-token) for more details.
 | Property | Type | Default | Description |
 |----------|------|---------|-------------|
 | `name` | `string` | auto-generated | Instance name (1-32 characters) |
-| `source` | `R2Bucket \| AiSearchR2Source \| AiSearchWebCrawlerSource` | required | Data source (bucket or config) |
+| `source` | `R2Bucket \| AiSearchR2Source \| AiSearchWebCrawlerSource` | — | Data source. Omit for built-in storage (upload-only). |
+| `namespace` | `string \| AiSearchNamespace` | `"default"` | Namespace the instance belongs to |
 | `aiSearchModel` | `string` | `@cf/meta/llama-3.3-70b-instruct-fp8-fast` | Text generation model |
 | `embeddingModel` | `string` | `@cf/baai/bge-m3` | Embedding model |
+| `indexMethod` | `{ vector?: boolean; keyword?: boolean }` | vector-only | Controls which storage backends are used. Set both to `true` for hybrid search. |
+| `fusionMethod` | `"max" \| "rrf"` | `"rrf"` | Fusion method for combining vector and keyword results |
 | `chunk` | `boolean` | `true` | Enable document chunking |
 | `chunkSize` | `number` | `256` | Chunk size (minimum 64) |
 | `chunkOverlap` | `number` | `10` | Overlap between chunks (0-30) |
@@ -293,7 +392,40 @@ See [AiSearchToken](/providers/cloudflare/ai-search-token) for more details.
 | `cache` | `boolean` | `false` | Enable similarity caching |
 | `cacheThreshold` | `"super_strict_match" \| "close_enough" \| "flexible_friend" \| "anything_goes"` | `"close_enough"` | Cache similarity threshold |
 | `metadata` | `Record<string, unknown>` | — | Custom metadata |
-| `indexOnCreate` | `boolean` | `true` | Index source documents when the instance is created |
-| `token` | `AiSearchToken` | auto-created | Service token (or use `tokenId` with an existing token UUID) |
+| `indexOnCreate` | `boolean` | `true` | Index source documents on creation (only when source is provided) |
+| `token` | `AiSearchToken` | auto-created for R2 | Service token (only needed for R2 sources) |
 | `delete` | `boolean` | `true` | Delete instance on removal |
 | `adopt` | `boolean` | `false` | Adopt existing instance |
+
+## Output Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `id` | `string` | Instance name on Cloudflare (equal to `name`) |
+| `name` | `string` | Instance name (what `ai_search` bindings emit as `instance_name`) |
+| `namespace` | `string` | Namespace the instance lives in (defaults to `"default"`) |
+| `createdAt` | `string` | Creation timestamp (ISO 8601) |
+| `modifiedAt` | `string` | Last-modified timestamp |
+| `internalId` | `string` | Cloudflare-internal identifier for the instance |
+| `vectorizeName` | `string` | Underlying Vectorize index name (legacy instances only) |
+| `tokenId` | `string \| undefined` | Service-token id (only present for R2-backed instances) |
+| `source` | `string \| undefined` | Resolved data source (bucket name for R2, domain for web-crawler, `undefined` for sourceless) |
+| `type` | `"r2" \| "web-crawler" \| undefined` | Source type, or `undefined` for sourceless (built-in storage) instances |
+
+## Type Guard
+
+To narrow an unknown binding or resource to an `AiSearch`, use `isAiSearch`:
+
+```ts
+import { isAiSearch } from "alchemy/cloudflare";
+
+if (isAiSearch(binding)) {
+  // binding is narrowed to AiSearch
+  console.log(binding.name, binding.namespace);
+}
+```
+
+## See also
+
+- [Cloudflare AI Search — Workers binding reference](https://developers.cloudflare.com/ai-search/api/search/workers-binding/)
+- [Cloudflare AI Search — Overview](https://developers.cloudflare.com/ai-search/)

--- a/alchemy/src/cloudflare/ai-search-namespace.ts
+++ b/alchemy/src/cloudflare/ai-search-namespace.ts
@@ -1,0 +1,439 @@
+import type { Context } from "../context.ts";
+import { Resource, ResourceKind } from "../resource.ts";
+import { logger } from "../util/logger.ts";
+import { poll } from "../util/poll.ts";
+import { CloudflareApiError } from "./api-error.ts";
+import { extractCloudflareResult } from "./api-response.ts";
+import {
+  createCloudflareApi,
+  type CloudflareApi,
+  type CloudflareApiOptions,
+} from "./api.ts";
+
+/**
+ * Properties for creating or updating an AI Search Namespace
+ */
+export interface AiSearchNamespaceProps extends CloudflareApiOptions {
+  /**
+   * Name of the namespace.
+   * Must match pattern: `^[a-z0-9]([a-z0-9-]{0,26}[a-z0-9])?$`
+   *
+   * @default `${app}-${stage}-${id}`
+   */
+  name?: string;
+
+  /**
+   * Optional description for the namespace (max 256 characters).
+   *
+   * Pass `null` to explicitly clear a previously-set description on update.
+   * Leaving this field undefined (absent from props) will NOT touch the
+   * existing description on update.
+   */
+  description?: string | null;
+
+  /**
+   * Whether to adopt an existing namespace with the same name if it exists
+   *
+   * @default false
+   */
+  adopt?: boolean;
+
+  /**
+   * Whether to delete the namespace when removed from Alchemy.
+   * Namespace must be empty (no instances) to be deleted.
+   *
+   * @default true
+   */
+  delete?: boolean;
+}
+
+/**
+ * Type guard for AiSearchNamespace
+ */
+export function isAiSearchNamespace(
+  resource: unknown,
+): resource is AiSearchNamespace {
+  return (
+    typeof resource === "object" &&
+    resource !== null &&
+    (resource as any)[ResourceKind] === "cloudflare::AiSearchNamespace"
+  );
+}
+
+/**
+ * Output returned after AI Search Namespace creation/update
+ */
+export type AiSearchNamespace = Omit<
+  AiSearchNamespaceProps,
+  "delete" | "adopt" | "description" | "name"
+> & {
+  /**
+   * Resource type identifier for binding resolution
+   */
+  type: "ai_search_namespace";
+
+  /**
+   * The stable identifier of the namespace (equal to `namespace`).
+   * Present because Alchemy's resource model expects every output to carry an `id`.
+   */
+  id: string;
+
+  /**
+   * The name of the namespace.
+   */
+  namespace: string;
+
+  /**
+   * Optional description of the namespace
+   */
+  description: string | null;
+
+  /**
+   * Time at which the namespace was created
+   */
+  createdAt: string;
+};
+
+/**
+ * API response for AI Search namespace
+ * @internal
+ */
+interface AiSearchNamespaceApiResponse {
+  name: string;
+  description: string | null;
+  created_at: string;
+}
+
+/**
+ * An AI Search Namespace groups AI Search instances together,
+ * providing logical isolation and scoped access control.
+ *
+ * Namespaces are a first-class concept in the AI Search binding model.
+ * Instance names are unique within their namespace: `UNIQUE(account_id, namespace, name)`.
+ *
+ * @see https://developers.cloudflare.com/ai-search/
+ *
+ * @example
+ * ## Create a namespace
+ *
+ * ```ts
+ * const ns = await AiSearchNamespace("production", {
+ *   name: "production",
+ * });
+ * ```
+ *
+ * @example
+ * ## Use as a Worker binding
+ *
+ * ```ts
+ * const ns = await AiSearchNamespace("docs", {
+ *   name: "docs",
+ * });
+ *
+ * const worker = await Worker("my-worker", {
+ *   bindings: {
+ *     DOCS: ns,
+ *   },
+ *   // ...
+ * });
+ * ```
+ *
+ * @example
+ * ## Adopt an existing namespace
+ *
+ * ```ts
+ * const ns = await AiSearchNamespace("existing", {
+ *   name: "production",
+ *   adopt: true,
+ * });
+ * ```
+ */
+export const AiSearchNamespace = Resource(
+  "cloudflare::AiSearchNamespace",
+  async function (
+    this: Context<AiSearchNamespace>,
+    id: string,
+    props: AiSearchNamespaceProps = {},
+  ): Promise<AiSearchNamespace> {
+    const adopt = props.adopt ?? this.scope.adopt;
+
+    const namespace =
+      props.name ??
+      this.output?.namespace ??
+      this.scope.createPhysicalName(id, "-", 28);
+
+    // Validate namespace name against CF's documented pattern. We do this
+    // before any API calls so users get a clear local error rather than a
+    // generic API 400. Also guards against `createPhysicalName` truncation
+    // producing a name that begins/ends with "-".
+    //
+    // Skip validation during delete: `this.output?.namespace` is always a
+    // previously-accepted name (came from `toOutput(result)`), so there's
+    // nothing to re-validate. Critically, this also prevents a failed
+    // create (which throws from this guard without persisting state) from
+    // tripping the same guard during scope teardown — destroy would have
+    // nothing to delete anyway.
+    if (
+      this.phase !== "delete" &&
+      !/^[a-z0-9]([a-z0-9-]{0,26}[a-z0-9])?$/.test(namespace)
+    ) {
+      throw new Error(
+        `AI Search namespace name "${namespace}" is invalid. ` +
+          "Must match pattern: ^[a-z0-9]([a-z0-9-]{0,26}[a-z0-9])?$ " +
+          "(1-28 chars, lowercase alphanumerics and hyphens, cannot start or end with a hyphen).",
+      );
+    }
+
+    // The `default` namespace is reserved by Cloudflare — it is created
+    // automatically on every account and cannot be created, updated, or
+    // deleted via the API. Only allow binding to it via `adopt: true`.
+    if (namespace === "default" && !adopt && this.phase !== "delete") {
+      throw new Error(
+        'The "default" AI Search namespace is reserved by Cloudflare. ' +
+          "Use `adopt: true` to bind to it (it cannot be created, renamed, or deleted via the API).",
+      );
+    }
+
+    if (this.scope.local) {
+      // Local development mode — return mock output
+      return {
+        type: "ai_search_namespace",
+        id: namespace,
+        namespace,
+        description: props.description ?? null,
+        createdAt: new Date().toISOString(),
+      };
+    }
+
+    const api = await createCloudflareApi(props);
+
+    if (this.phase === "delete") {
+      const namespaceName = this.output?.namespace;
+      if (namespaceName && props.delete !== false) {
+        await deleteAiSearchNamespace(api, namespaceName);
+      }
+      return this.destroy();
+    }
+
+    // Immutable name — replace if changed. We use the default
+    // (pending-deletion) replace strategy: the old namespace is queued for
+    // deletion and flushed at scope finalize, matching the convention used
+    // by other Cloudflare resources in this repo. Forcing immediate
+    // deletion (`replace(true)`) interacts poorly with Cloudflare's
+    // namespace-delete consistency window and causes the old namespace to
+    // still appear in subsequent GETs.
+    if (this.phase === "update" && this.output?.namespace !== namespace) {
+      return this.replace();
+    }
+
+    if (this.phase === "update" && this.output) {
+      // Three-way semantics on `description`:
+      //   - absent (undefined)  → do not touch (preserves out-of-band edits)
+      //   - string              → set to that value
+      //   - null                → clear (explicit opt-in to clearing)
+      // We only PUT when the value differs from current state.
+      const hasDescriptionProp = "description" in props;
+      if (hasDescriptionProp && props.description !== this.output.description) {
+        const updated = await updateAiSearchNamespace(api, namespace, {
+          description: props.description,
+        });
+        return toOutput(updated);
+      }
+      return this.output;
+    }
+
+    // Adopting the reserved `default` namespace is a no-op creation: emit a
+    // warn so the behavior is visible (delete is silently skipped later).
+    if (namespace === "default" && adopt) {
+      logger.warn(
+        `Adopting the reserved AI Search "default" namespace. It will not be deleted on teardown.`,
+      );
+    }
+
+    // Create (with adopt via pre-flight check when enabled)
+    const hasDescriptionProp = "description" in props;
+    let result: AiSearchNamespaceApiResponse;
+    if (adopt) {
+      // Pre-flight: if namespace exists, adopt it; otherwise create.
+      // `getAiSearchNamespace` internally returns `undefined` on 404 and
+      // rethrows all other errors (auth, 5xx, network) — no catch needed here.
+      const existing = await getAiSearchNamespace(api, namespace);
+      if (existing) {
+        if (hasDescriptionProp && props.description !== existing.description) {
+          result = await updateAiSearchNamespace(api, namespace, {
+            description: props.description,
+          });
+        } else {
+          result = existing;
+        }
+      } else if (namespace === "default") {
+        // The `default` namespace is implicit — treat GET 404 as "exists but
+        // not queryable" and return a synthetic adoption record. Use the
+        // current timestamp rather than epoch 0 to avoid a misleading
+        // "1970-01-01" createdAt in the state file.
+        result = {
+          name: "default",
+          description: null,
+          created_at: new Date().toISOString(),
+        };
+      } else {
+        result = await createAiSearchNamespace(api, {
+          name: namespace,
+          description: props.description ?? undefined,
+        });
+      }
+    } else {
+      try {
+        result = await createAiSearchNamespace(api, {
+          name: namespace,
+          description: props.description ?? undefined,
+        });
+      } catch (error) {
+        // Wrap "already exists" errors with AGENTS.md-style messaging that
+        // points at `adopt: true`.
+        if (
+          error instanceof CloudflareApiError &&
+          (error.status === 400 || error.status === 409)
+        ) {
+          const existing = await getAiSearchNamespace(api, namespace);
+          if (existing) {
+            throw new Error(
+              `AI Search namespace "${namespace}" already exists. Use \`adopt: true\` to adopt it.`,
+              { cause: error },
+            );
+          }
+        }
+        throw error;
+      }
+    }
+
+    return toOutput(result);
+  },
+);
+
+function toOutput(result: AiSearchNamespaceApiResponse): AiSearchNamespace {
+  return {
+    type: "ai_search_namespace",
+    id: result.name,
+    namespace: result.name,
+    description: result.description ?? null,
+    createdAt: result.created_at,
+  };
+}
+
+// ─── API Helper Functions ────────────────────────────────────────────────────
+
+/**
+ * Create an AI Search namespace
+ */
+export async function createAiSearchNamespace(
+  api: CloudflareApi,
+  payload: { name: string; description?: string | null },
+): Promise<AiSearchNamespaceApiResponse> {
+  return await extractCloudflareResult<AiSearchNamespaceApiResponse>(
+    `create AI Search namespace "${payload.name}"`,
+    api.post(`/accounts/${api.accountId}/ai-search/namespaces`, payload),
+  );
+}
+
+/**
+ * Get an AI Search namespace by name
+ */
+export async function getAiSearchNamespace(
+  api: CloudflareApi,
+  name: string,
+): Promise<AiSearchNamespaceApiResponse | undefined> {
+  try {
+    return await extractCloudflareResult<AiSearchNamespaceApiResponse>(
+      `get AI Search namespace "${name}"`,
+      api.get(`/accounts/${api.accountId}/ai-search/namespaces/${name}`),
+    );
+  } catch (error) {
+    if (error instanceof CloudflareApiError && error.status === 404) {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+/**
+ * Update an AI Search namespace.
+ *
+ * `description: null` clears a previously-set description. `description`
+ * absent from the payload leaves the current value untouched.
+ */
+export async function updateAiSearchNamespace(
+  api: CloudflareApi,
+  name: string,
+  payload: { description?: string | null },
+): Promise<AiSearchNamespaceApiResponse> {
+  return await extractCloudflareResult<AiSearchNamespaceApiResponse>(
+    `update AI Search namespace "${name}"`,
+    api.put(`/accounts/${api.accountId}/ai-search/namespaces/${name}`, payload),
+  );
+}
+
+/**
+ * Delete an AI Search namespace. Namespace must be empty (no instances).
+ * The reserved `default` namespace cannot be deleted and is skipped.
+ */
+export async function deleteAiSearchNamespace(
+  api: CloudflareApi,
+  name: string,
+): Promise<void> {
+  // The `default` namespace is reserved and cannot be deleted by the API.
+  // Skip silently to allow clean teardown of resources that adopted it.
+  if (name === "default") {
+    return;
+  }
+  try {
+    await extractCloudflareResult(
+      `delete AI Search namespace "${name}"`,
+      api.delete(`/accounts/${api.accountId}/ai-search/namespaces/${name}`),
+    );
+  } catch (error) {
+    if (error instanceof CloudflareApiError) {
+      if (error.status === 404) {
+        return;
+      }
+      // Namespace is likely non-empty — wrap with a clearer message.
+      if (error.status === 400 || error.status === 409) {
+        throw new Error(
+          `Cannot delete AI Search namespace "${name}". ` +
+            "The namespace may contain instances — delete all instances first, " +
+            "or use { delete: false } on the AiSearchNamespace resource to preserve it.",
+          { cause: error },
+        );
+      }
+    }
+    throw error;
+  }
+
+  // Cloudflare's namespace DELETE is eventually consistent — same-colo
+  // GETs are invalidated immediately via the edge cache, cross-colo GETs
+  // can surface the stale row for up to 60s (KV TTL). Wait until the
+  // namespace is truly gone so destroy phase presents a strongly-
+  // consistent contract to callers (user teardown assertions,
+  // downstream resources, rename-triggered replace flows).
+  await poll({
+    description: `wait for AI Search namespace "${name}" deletion to propagate`,
+    fn: () =>
+      api.get(`/accounts/${api.accountId}/ai-search/namespaces/${name}`),
+    predicate: (res) => res.status === 404,
+    initialDelay: 500,
+    maxDelay: 3000,
+    timeout: 90_000,
+  });
+}
+
+/**
+ * List all AI Search namespaces in an account
+ */
+export async function listAiSearchNamespaces(
+  api: CloudflareApi,
+): Promise<AiSearchNamespaceApiResponse[]> {
+  return await extractCloudflareResult<AiSearchNamespaceApiResponse[]>(
+    "list AI Search namespaces",
+    api.get(`/accounts/${api.accountId}/ai-search/namespaces`),
+  );
+}

--- a/alchemy/src/cloudflare/ai-search-token.ts
+++ b/alchemy/src/cloudflare/ai-search-token.ts
@@ -291,22 +291,56 @@ export async function listAiSearchTokens(
 }
 
 /**
- * Delete an AI Search token
+ * Delete an AI Search token.
+ *
+ * Retries briefly on `7076 token_in_use_by_instances` to cover residual
+ * cross-colo lag (CF's server retries the guard internally once after
+ * 500ms; the spurious-409 window is typically sub-second). We layer two
+ * client-side retries with 1s + 2s delays on top.
+ *
+ * A persistent 409 after the short retry window means the token is
+ * genuinely still referenced by another AI Search instance. We throw an
+ * actionable error rather than silently leaking the token — shared tokens
+ * should be modeled explicitly via an `AiSearchToken` resource.
  */
 export async function deleteAiSearchToken(
   api: CloudflareApi,
   tokenId: string,
 ): Promise<void> {
-  try {
-    await extractCloudflareResult(
-      `delete AI Search token "${tokenId}"`,
-      api.delete(`/accounts/${api.accountId}/ai-search/tokens/${tokenId}`),
-    );
-  } catch (error) {
-    if (error instanceof CloudflareApiError && error.status === 404) {
+  const retryDelaysMs = [1000, 2000]; // 2 retries, ~3s total
+  for (let attempt = 0; attempt <= retryDelaysMs.length; attempt++) {
+    try {
+      await extractCloudflareResult(
+        `delete AI Search token "${tokenId}"`,
+        api.delete(`/accounts/${api.accountId}/ai-search/tokens/${tokenId}`),
+      );
       return;
+    } catch (error) {
+      if (error instanceof CloudflareApiError && error.status === 404) {
+        return;
+      }
+      const isTokenInUse =
+        error instanceof CloudflareApiError &&
+        error.status === 409 &&
+        Array.isArray(error.errorData) &&
+        error.errorData.some((e: { code?: number }) => e?.code === 7076);
+      if (isTokenInUse && attempt < retryDelaysMs.length) {
+        await new Promise((resolve) =>
+          setTimeout(resolve, retryDelaysMs[attempt]),
+        );
+        continue;
+      }
+      if (isTokenInUse) {
+        throw new Error(
+          `AI Search token "${tokenId}" is still referenced by another instance. ` +
+            "If the token is intentionally shared across instances, manage it " +
+            "explicitly via an `AiSearchToken` resource with `delete: false`, " +
+            "or delete all referencing instances before deleting the token.",
+          { cause: error },
+        );
+      }
+      throw error;
     }
-    throw error;
   }
 }
 

--- a/alchemy/src/cloudflare/ai-search.ts
+++ b/alchemy/src/cloudflare/ai-search.ts
@@ -1,5 +1,5 @@
 import type { Context } from "../context.ts";
-import { Resource } from "../resource.ts";
+import { Resource, ResourceKind } from "../resource.ts";
 import { logger } from "../util/logger.ts";
 import { poll } from "../util/poll.ts";
 import { sleep } from "../util/sleep.ts";
@@ -7,6 +7,10 @@ import {
   snakeToCamelObjectDeep,
   type SnakeToCamel,
 } from "../util/snake-to-camel.ts";
+import {
+  type AiSearchNamespace,
+  isAiSearchNamespace,
+} from "./ai-search-namespace.ts";
 import { AiSearchToken } from "./ai-search-token.ts";
 import { CloudflareApiError, isCloudflareApiError } from "./api-error.ts";
 import {
@@ -37,9 +41,49 @@ interface BaseAiSearchProps extends CloudflareApiOptions {
 
   /**
    * Data source for indexing.
-   * Can be an R2Bucket directly, an R2 source config, or a web crawler config.
+   *
+   * Accepts three forms:
+   * - **R2Bucket (shorthand)**: pass an `R2Bucket` resource directly for
+   *   default indexing. `prefix`, `includePaths`, and `excludePaths` cannot
+   *   be set in this form — use the full R2 config form below.
+   * - **R2 config**: `{ type: "r2", bucket, prefix?, includePaths?, excludePaths?, jurisdiction? }`.
+   * - **Web crawler**: `{ type: "web-crawler", domain, ... }`.
+   *
+   * When omitted, creates a built-in storage instance for manual file uploads
+   * (via the Items API or the AI Search binding).
    */
-  source: R2Bucket | AiSearchR2Source | AiSearchWebCrawlerSource;
+  source?: R2Bucket | AiSearchR2Source | AiSearchWebCrawlerSource;
+
+  /**
+   * The namespace this instance belongs to.
+   * Can be a namespace name string or an AiSearchNamespace resource.
+   *
+   * @remarks
+   * Single-instance Worker bindings (`bindings: { MY: aiSearch }`) can only
+   * bind instances in the `default` namespace. To bind instances in a
+   * non-default namespace, use an `AiSearchNamespace` binding instead and
+   * access the instance via `env.NS.get(name)`.
+   *
+   * Changing `namespace` on an existing instance triggers a replace
+   * (delete + create) because namespaces are immutable on the Cloudflare
+   * side.
+   *
+   * @default "default"
+   */
+  namespace?: string | AiSearchNamespace;
+
+  /**
+   * Controls which storage backends are used during indexing.
+   * Defaults to vector-only. Set both `vector` and `keyword` to `true` for hybrid search.
+   */
+  indexMethod?: { vector?: boolean; keyword?: boolean };
+
+  /**
+   * Fusion method for combining vector and keyword results.
+   *
+   * @default "rrf"
+   */
+  fusionMethod?: "max" | "rrf";
 
   /**
    * Text generation model for AI responses
@@ -142,7 +186,8 @@ interface BaseAiSearchProps extends CloudflareApiOptions {
   metadata?: Record<string, unknown>;
 
   /**
-   * Whether to index the source documents when the AI Search instance is created
+   * Whether to index the source documents when the AI Search instance is created.
+   * Only applicable when a source is provided.
    * @default true
    */
   indexOnCreate?: boolean;
@@ -249,13 +294,73 @@ export interface AiSearchWebCrawlerSource {
   };
 }
 
+/**
+ * Type guard for AiSearch
+ */
+export function isAiSearch(resource: unknown): resource is AiSearch {
+  return (
+    typeof resource === "object" &&
+    resource !== null &&
+    (resource as any)[ResourceKind] === "cloudflare::AiSearch"
+  );
+}
+
 export type AiSearch = SnakeToCamel<AiSearch.ApiResponse> & {
   /**
-   * The name of the AI Search instance (this is an alias for the `id` property)
+   * The instance name on the Cloudflare side. Equal to `id`. This is what
+   * gets emitted as `instance_name` in single-instance `ai_search` bindings.
    */
   name: string;
+
+  /**
+   * The namespace this instance belongs to.
+   *
+   * Optional for backwards compatibility with state files that predate
+   * namespace support; at write-time this is always populated (defaults to
+   * `"default"` when the user did not specify a namespace).
+   */
+  namespace?: string;
 };
 
+/**
+ * An AI Search instance: a managed search index with optional built-in
+ * storage and optional external data source (R2 or web crawler).
+ *
+ * @see https://developers.cloudflare.com/ai-search/
+ *
+ * @example
+ * ## Built-in storage (no source)
+ *
+ * Creates an instance whose content is uploaded directly via the items API.
+ *
+ * ```ts
+ * const kb = await AiSearch("knowledge-base", {
+ *   name: "knowledge-base",
+ * });
+ * ```
+ *
+ * @example
+ * ## R2-backed instance
+ *
+ * ```ts
+ * const bucket = await R2Bucket("docs");
+ * const search = await AiSearch("docs-search", {
+ *   name: "docs-search",
+ *   source: bucket,
+ * });
+ * ```
+ *
+ * @example
+ * ## Instance in a custom namespace
+ *
+ * ```ts
+ * const ns = await AiSearchNamespace("tenants", { name: "tenants" });
+ * const search = await AiSearch("tenant-a", {
+ *   name: "tenant-a",
+ *   namespace: ns,
+ * });
+ * ```
+ */
 export const AiSearch = Resource(
   "cloudflare::AiSearch",
   async function (
@@ -263,8 +368,38 @@ export const AiSearch = Resource(
     id: string,
     props: AiSearchProps,
   ): Promise<AiSearch> {
-    const api = await createCloudflareApi(props);
     const adopt = props.adopt ?? this.scope.adopt;
+
+    // Resolve namespace: AiSearchNamespace resource → string, default to "default"
+    const namespace = resolveNamespace(props.namespace);
+
+    if (this.scope.local) {
+      // Local development mode — return a mock shape so `alchemy dev` does
+      // not hit the real Cloudflare API. Matches the AiSearchNamespace
+      // local-mode pattern and satisfies AGENTS.md requirements.
+      const name =
+        props.name ??
+        this.output?.name ??
+        this.scope.createPhysicalName(id, "-", 32);
+      const now = new Date().toISOString();
+      // `AiSearch` is `SnakeToCamel<ApiResponse>` intersected with extras —
+      // all non-required fields are optional, so we only populate what's
+      // needed. No `as unknown as` escape hatch required.
+      const mock: AiSearch = {
+        id: name,
+        name,
+        namespace,
+        accountId: "local",
+        accountTag: "local",
+        createdAt: now,
+        internalId: name,
+        modifiedAt: now,
+        vectorizeName: "",
+      };
+      return mock;
+    }
+
+    const api = await createCloudflareApi(props);
 
     const validateBucketSource = async (
       bucket: R2Bucket | string,
@@ -288,16 +423,25 @@ export const AiSearch = Resource(
         await getBucket(api, name, { jurisdiction });
       } catch (error) {
         throw new Error(
-          `Failed to validate R2 bucket "${name}" (${jurisdiction}) for AI search "${id}": ${error instanceof Error ? error.message : String(error)}`,
+          `Failed to validate R2 bucket "${name}" (${jurisdiction}) for AI search "${id}": ${
+            error instanceof Error ? error.message : String(error)
+          }`,
           { cause: error },
         );
       }
     };
     const normalizeSource = async (
-      source: R2Bucket | AiSearchR2Source | AiSearchWebCrawlerSource,
+      source:
+        | R2Bucket
+        | AiSearchR2Source
+        | AiSearchWebCrawlerSource
+        | undefined,
     ): Promise<
-      (AiSearchR2Source & { bucket: string }) | AiSearchWebCrawlerSource
+      | (AiSearchR2Source & { bucket: string })
+      | AiSearchWebCrawlerSource
+      | undefined
     > => {
+      if (!source) return undefined;
       if (isBucket(source)) {
         await validateBucketSource(source, source.jurisdiction);
         return {
@@ -334,14 +478,34 @@ export const AiSearch = Resource(
         );
       }
     };
-    const normalizeTokenId = async (): Promise<string> => {
+    /**
+     * Only resolve token for R2 sources. Web-crawler and built-in storage
+     * instances do not require a token.
+     */
+    const normalizeTokenId = async (
+      source:
+        | (AiSearchR2Source & { bucket: string })
+        | AiSearchWebCrawlerSource
+        | undefined,
+    ): Promise<string | undefined> => {
+      // Token only needed for R2 sources
+      if (!source || source.type !== "r2") {
+        return undefined;
+      }
       if ("tokenId" in props) {
         validateTokenId(props.tokenId);
         return props.tokenId;
-      } else if (props.token) {
+      } else if ("token" in props && props.token) {
         validateTokenId(props.token.tokenId);
         return props.token.tokenId;
       } else {
+        // Auto-created tokens are an implementation detail of this resource —
+        // `adopt: true` so updates reuse a prior auto-created token with the
+        // same stable child id. We forward `delete: false` when the user
+        // preserves the instance, because Cloudflare rejects token deletion
+        // while the token is still referenced by the preserved instance
+        // (error 7076 `token_in_use_by_instances`). When the instance IS
+        // being deleted normally, the token deletes with it.
         const token = await AiSearchToken("token", {
           baseUrl: props.baseUrl,
           profile: props.profile,
@@ -349,8 +513,8 @@ export const AiSearch = Resource(
           apiToken: props.apiToken,
           accountId: props.accountId,
           email: props.email,
-          adopt: props.adopt,
-          delete: props.delete,
+          adopt: true,
+          ...(props.delete === false ? { delete: false } : {}),
         });
         return token.tokenId;
       }
@@ -358,8 +522,11 @@ export const AiSearch = Resource(
 
     if (this.phase === "delete") {
       if (props.delete !== false && this.output?.id) {
-        await deleteIndex(api, this.output.vectorizeName);
-        await deleteAiSearchInstance(api, this.output.id);
+        if (this.output.vectorizeName) {
+          await deleteIndex(api, this.output.vectorizeName);
+        }
+        const deleteNs = this.output.namespace ?? "default";
+        await deleteAiSearchInstance(api, deleteNs, this.output.id);
       }
       return this.destroy();
     }
@@ -370,35 +537,40 @@ export const AiSearch = Resource(
         `AI Search instance name must be 1-32 characters, got ${name.length} ("${name}")`,
       );
     }
-    const [source, tokenId] = await Promise.all([
-      normalizeSource(props.source),
-      normalizeTokenId(),
-    ]);
+
+    const source = await normalizeSource(props.source);
+    const tokenId = await normalizeTokenId(source);
 
     const payload: AiSearch.ApiPayload = {
       id: name,
-      source: source.type === "r2" ? source.bucket : source.domain,
-      type: source.type,
+      source: source
+        ? source.type === "r2"
+          ? source.bucket
+          : source.domain
+        : undefined,
+      type: source?.type,
       ai_search_model: props.aiSearchModel,
-      source_params: {
-        include_items: source.includePaths,
-        exclude_items: source.excludePaths,
-        ...(source.type === "r2"
-          ? {
-              r2_jurisdiction:
-                source.jurisdiction !== "default"
-                  ? source.jurisdiction
-                  : undefined,
-              prefix: source.prefix,
-            }
-          : {
-              web_crawler: {
-                parse_type: source.parseType,
-                parse_options: source.parseOptions,
-                store_options: source.storeOptions,
-              },
-            }),
-      },
+      source_params: source
+        ? {
+            include_items: source.includePaths,
+            exclude_items: source.excludePaths,
+            ...(source.type === "r2"
+              ? {
+                  r2_jurisdiction:
+                    source.jurisdiction !== "default"
+                      ? source.jurisdiction
+                      : undefined,
+                  prefix: source.prefix,
+                }
+              : {
+                  web_crawler: {
+                    parse_type: source.parseType,
+                    parse_options: source.parseOptions,
+                    store_options: source.storeOptions,
+                  },
+                }),
+          }
+        : undefined,
       embedding_model: props.embeddingModel,
       chunk: props.chunk,
       chunk_size: props.chunkSize,
@@ -413,6 +585,8 @@ export const AiSearch = Resource(
       cache_threshold: props.cacheThreshold,
       metadata: props.metadata,
       token_id: tokenId,
+      index_method: props.indexMethod,
+      fusion_method: props.fusionMethod,
     };
 
     let instance: AiSearch.ApiResponse;
@@ -431,29 +605,73 @@ export const AiSearch = Resource(
           (payload.type === "web-crawler" &&
             "sourceDomain" in this.output &&
             payload.source !== this.output.sourceDomain));
-      if (replace || replaceLegacy) {
+      // Namespace is immutable: moving an instance between namespaces must
+      // replace (delete old, create new) rather than attempt an in-place
+      // update against a non-existent `PUT /namespaces/{new}/instances/{id}`.
+      // Default to "default" for legacy state files that predate the
+      // namespace prop.
+      const currentNamespace =
+        ("namespace" in this.output && this.output.namespace) || "default";
+      const namespaceChanged = currentNamespace !== namespace;
+      if (replace || replaceLegacy || namespaceChanged) {
         return this.replace(true);
       }
-      instance = await updateAiSearchInstance(api, this.output.id, payload);
+      instance = await updateAiSearchInstance(
+        api,
+        namespace,
+        this.output.id,
+        payload,
+      );
     } else {
-      try {
-        instance = await createAiSearchInstance(api, payload);
-      } catch (error) {
-        const isAlreadyExistsError =
-          error instanceof CloudflareApiError &&
-          error.status === 400 &&
-          (error.errorData as CloudflareApiErrorPayload[]).some(
-            (error) => error.code === 7022,
+      // Pre-flight adopt: if `adopt: true` and an instance already exists,
+      // adopt it directly via GET→PUT. This avoids racing on 400/7022 error
+      // codes and the fragile `errorData as CloudflareApiErrorPayload[]` cast.
+      if (adopt) {
+        const existing = await getAiSearchInstance(api, namespace, name).catch(
+          (e: unknown) => {
+            if (e instanceof CloudflareApiError && e.status === 404) {
+              return undefined;
+            }
+            throw e;
+          },
+        );
+        if (existing) {
+          instance = await updateAiSearchInstance(
+            api,
+            namespace,
+            existing.id,
+            payload,
           );
-        if (isAlreadyExistsError && adopt) {
-          instance = await getAiSearchInstance(api, name);
-          instance = await updateAiSearchInstance(api, instance.id, payload);
         } else {
+          instance = await createAiSearchInstance(api, namespace, payload);
+        }
+      } else {
+        try {
+          instance = await createAiSearchInstance(api, namespace, payload);
+        } catch (error) {
+          // Wrap "already exists" errors with a clearer message pointing at
+          // the adoption path (AGENTS.md convention).
+          const errorData = Array.isArray(
+            (error as CloudflareApiError | undefined)?.errorData,
+          )
+            ? ((error as CloudflareApiError)
+                .errorData as CloudflareApiErrorPayload[])
+            : [];
+          const isAlreadyExistsError =
+            error instanceof CloudflareApiError &&
+            error.status === 400 &&
+            errorData.some((e) => e.code === 7022);
+          if (isAlreadyExistsError) {
+            throw new Error(
+              `AI Search instance "${name}" already exists in namespace "${namespace}". Use \`adopt: true\` to adopt it.`,
+              { cause: error },
+            );
+          }
           throw error;
         }
       }
-      if (props.indexOnCreate !== false) {
-        await runAiSearchJob(api, instance.id, (message) =>
+      if (props.indexOnCreate !== false && source) {
+        await runAiSearchJob(api, namespace, instance.id, (message) =>
           logger.task(id, {
             prefix: "index",
             prefixColor: "gray",
@@ -461,14 +679,32 @@ export const AiSearch = Resource(
             message,
           }),
         );
+      } else if (props.indexOnCreate === true && !source) {
+        logger.warn(
+          `AI Search "${id}": \`indexOnCreate: true\` has no effect because no \`source\` was provided.`,
+        );
       }
     }
     return {
       ...snakeToCamelObjectDeep(instance),
       name: instance.id,
+      // The API response may include a `namespace` field; explicitly use the
+      // resolved local value to ensure the output always matches the prop
+      // (and defaults to "default" when unspecified).
+      namespace,
     };
   },
 );
+
+/**
+ * Resolve a namespace prop to a string name.
+ */
+function resolveNamespace(ns: string | AiSearchNamespace | undefined): string {
+  if (!ns) return "default";
+  if (typeof ns === "string") return ns;
+  if (isAiSearchNamespace(ns)) return ns.namespace;
+  return "default";
+}
 
 /**
  * Validate that a domain string is a valid domain format (not a URL).
@@ -576,8 +812,8 @@ export declare namespace AiSearch {
 
   interface ApiPayload {
     id: string;
-    source: string;
-    type: "r2" | "web-crawler";
+    source?: string;
+    type?: "r2" | "web-crawler";
     ai_gateway_id?: string;
     ai_search_model?: Model;
     cache?: boolean;
@@ -599,6 +835,8 @@ export declare namespace AiSearch {
     }>;
     embedding_model?: EmbeddingModel;
     hybrid_search_enabled?: boolean;
+    index_method?: { vector?: boolean; keyword?: boolean };
+    fusion_method?: "max" | "rrf";
     max_num_results?: number;
     metadata?: {
       created_from_aisearch_wizard?: boolean;
@@ -670,9 +908,10 @@ export declare namespace AiSearch {
     created_at: string;
     internal_id: string;
     modified_at: string;
-    source: string;
-    type: "r2" | "web-crawler";
+    source?: string;
+    type?: "r2" | "web-crawler";
     vectorize_name: string;
+    namespace?: string;
     ai_gateway_id?: string;
     ai_search_model?: Model;
     cache?: boolean; // default: true
@@ -693,6 +932,8 @@ export declare namespace AiSearch {
     enable?: boolean;
     engine_version?: number; // default: 1
     hybrid_search_enabled?: boolean;
+    index_method?: { vector?: boolean; keyword?: boolean };
+    fusion_method?: "max" | "rrf";
     last_activity?: string;
     max_num_results?: number; // maximum: 50, minimum: 1, default: 10
     metadata?: {
@@ -782,54 +1023,71 @@ export declare namespace AiSearch {
   }
 }
 
+// ─── Namespace-scoped API Helper Functions ───────────────────────────────────
+
+/**
+ * Base path for namespace-scoped instance operations
+ */
+function aiSearchInstanceBasePath(
+  api: CloudflareApi,
+  namespace: string,
+): string {
+  return `/accounts/${api.accountId}/ai-search/namespaces/${namespace}/instances`;
+}
+
 export async function listAiSearchInstances(
   api: CloudflareApi,
+  namespace = "default",
 ): Promise<AiSearch.ApiResponse[]> {
   return await extractCloudflareResult<AiSearch.ApiResponse[]>(
     "list AI Search instances",
-    api.get(`/accounts/${api.accountId}/ai-search/instances`),
+    api.get(aiSearchInstanceBasePath(api, namespace)),
   );
 }
 
 export async function createAiSearchInstance(
   api: CloudflareApi,
+  namespace: string,
   payload: AiSearch.ApiPayload,
 ): Promise<AiSearch.ApiResponse> {
   return await extractCloudflareResult<AiSearch.ApiResponse>(
     `create AI Search instance "${payload.id}"`,
-    api.post(`/accounts/${api.accountId}/ai-search/instances`, payload),
+    api.post(aiSearchInstanceBasePath(api, namespace), payload),
   );
 }
 
 export async function getAiSearchInstance(
   api: CloudflareApi,
+  namespace: string,
   id: string,
 ): Promise<AiSearch.ApiResponse> {
   return await extractCloudflareResult<AiSearch.ApiResponse>(
     `get AI Search instance "${id}"`,
-    api.get(`/accounts/${api.accountId}/ai-search/instances/${id}`),
+    api.get(`${aiSearchInstanceBasePath(api, namespace)}/${id}`),
   );
 }
 
 export async function updateAiSearchInstance(
   api: CloudflareApi,
+  namespace: string,
   id: string,
   payload: AiSearch.ApiPayload,
 ): Promise<AiSearch.ApiResponse> {
   return await extractCloudflareResult<AiSearch.ApiResponse>(
     `update AI Search instance "${id}"`,
-    api.put(`/accounts/${api.accountId}/ai-search/instances/${id}`, payload),
+    api.put(`${aiSearchInstanceBasePath(api, namespace)}/${id}`, payload),
   );
 }
 
 export async function deleteAiSearchInstance(
   api: CloudflareApi,
+  namespace: string,
   id: string,
 ): Promise<void> {
   try {
     await extractCloudflareResult(
       `delete AI Search instance "${id}"`,
-      api.delete(`/accounts/${api.accountId}/ai-search/instances/${id}`),
+      api.delete(`${aiSearchInstanceBasePath(api, namespace)}/${id}`),
     );
   } catch (error) {
     if (error instanceof CloudflareApiError && error.status === 404) {
@@ -837,7 +1095,26 @@ export async function deleteAiSearchInstance(
     }
     throw error;
   }
+
+  // Cloudflare's DELETE returns 204 before the instance fully disappears
+  // from the backing services. A subsequent GET can return the stale row
+  // for a bounded window — same-colo is invalidated immediately via the
+  // edge cache, cross-colo is bounded by a 60s KV TTL.
+  //
+  // Actively wait here so the destroy phase presents a strongly-
+  // consistent "instance is gone" guarantee to its callers (child token
+  // delete, user-facing teardown assertions, dependent resources).
+  await poll({
+    description: `wait for AI Search instance "${id}" deletion to propagate`,
+    fn: () => api.get(`${aiSearchInstanceBasePath(api, namespace)}/${id}`),
+    predicate: (res) => res.status === 404,
+    initialDelay: 500,
+    maxDelay: 5000,
+    timeout: 90_000,
+  });
 }
+
+// ─── Job API Helper Functions ────────────────────────────────────────────────
 
 interface AiSearchJobApiResponse {
   id: string;
@@ -850,24 +1127,24 @@ interface AiSearchJobApiResponse {
 
 export async function listAiSearchJobs(
   api: CloudflareApi,
+  namespace: string,
   aiSearchId: string,
 ): Promise<AiSearchJobApiResponse[]> {
   return await extractCloudflareResult<AiSearchJobApiResponse[]>(
     `list AI Search jobs for instance "${aiSearchId}"`,
-    api.get(
-      `/accounts/${api.accountId}/ai-search/instances/${aiSearchId}/jobs`,
-    ),
+    api.get(`${aiSearchInstanceBasePath(api, namespace)}/${aiSearchId}/jobs`),
   );
 }
 
 export async function createAiSearchJob(
   api: CloudflareApi,
+  namespace: string,
   aiSearchId: string,
 ): Promise<AiSearchJobApiResponse> {
   return await extractCloudflareResult<AiSearchJobApiResponse>(
     `create AI Search job for instance "${aiSearchId}"`,
     api.post(
-      `/accounts/${api.accountId}/ai-search/instances/${aiSearchId}/jobs`,
+      `${aiSearchInstanceBasePath(api, namespace)}/${aiSearchId}/jobs`,
       {},
     ),
   );
@@ -875,13 +1152,14 @@ export async function createAiSearchJob(
 
 export async function getAiSearchJob(
   api: CloudflareApi,
+  namespace: string,
   aiSearchId: string,
   jobId: string,
 ): Promise<AiSearchJobApiResponse> {
   return await extractCloudflareResult<AiSearchJobApiResponse>(
     `get AI Search job "${jobId}" for instance "${aiSearchId}"`,
     api.get(
-      `/accounts/${api.accountId}/ai-search/instances/${aiSearchId}/jobs/${jobId}`,
+      `${aiSearchInstanceBasePath(api, namespace)}/${aiSearchId}/jobs/${jobId}`,
     ),
   );
 }
@@ -895,6 +1173,7 @@ interface AiSearchJobLogItem {
 
 export async function listAiSearchJobLogs(
   api: CloudflareApi,
+  namespace: string,
   aiSearchId: string,
   jobId: string,
 ): Promise<AiSearchJobLogItem[]> {
@@ -902,7 +1181,7 @@ export async function listAiSearchJobLogs(
     return await extractCloudflareResult<AiSearchJobLogItem[]>(
       `list AI Search job logs for job "${jobId}" for instance "${aiSearchId}"`,
       api.get(
-        `/accounts/${api.accountId}/ai-search/instances/${aiSearchId}/jobs/${jobId}/logs?per_page=500`,
+        `${aiSearchInstanceBasePath(api, namespace)}/${aiSearchId}/jobs/${jobId}/logs?per_page=500`,
       ),
     );
   } catch (error) {
@@ -917,16 +1196,17 @@ export async function listAiSearchJobLogs(
 
 export async function runAiSearchJob(
   api: CloudflareApi,
+  namespace: string,
   aiSearchId: string,
   log: (message: string) => void,
 ): Promise<void> {
   log("Preparing to index...");
-  const job = await createAiSearchJob(api, aiSearchId);
+  const job = await createAiSearchJob(api, namespace, aiSearchId);
   let lastLogId = 0;
   let done = false;
   const resultPromise = poll({
     description: `run AI Search job "${job.id}" for instance "${aiSearchId}"`,
-    fn: () => getAiSearchJob(api, aiSearchId, job.id),
+    fn: () => getAiSearchJob(api, namespace, aiSearchId, job.id),
     predicate: (result) => result.ended_at !== null,
   });
   pollLogs();
@@ -936,7 +1216,7 @@ export async function runAiSearchJob(
   log(`Sync completed: ${result.end_reason}`);
 
   async function pollLogs() {
-    const logs = await listAiSearchJobLogs(api, aiSearchId, job.id);
+    const logs = await listAiSearchJobLogs(api, namespace, aiSearchId, job.id);
     for (let i = logs.length - 1; i >= 0; i--) {
       const item = logs[i];
       if (item.id > lastLogId) {

--- a/alchemy/src/cloudflare/bindings.ts
+++ b/alchemy/src/cloudflare/bindings.ts
@@ -5,6 +5,8 @@
  */
 import type { Secret } from "../secret.ts";
 import type { Ai } from "./ai.ts";
+import type { AiSearchNamespace } from "./ai-search-namespace.ts";
+import type { AiSearch } from "./ai-search.ts";
 import type { AnalyticsEngineDataset } from "./analytics-engine.ts";
 import type { Assets } from "./assets.ts";
 import type { Bound } from "./bound.ts";
@@ -49,6 +51,8 @@ export declare namespace Bindings {
  */
 export type Binding =
   | Ai
+  | AiSearch
+  | AiSearchNamespace
   | Assets
   | Container
   | CloudflareSecret
@@ -120,6 +124,8 @@ export function Json<const T>(value: T): Json<T> {
  */
 export type WorkerBindingSpec =
   | WorkerBindingAI
+  | WorkerBindingAiSearch
+  | WorkerBindingAiSearchNamespace
   | WorkerBindingAnalyticsEngine
   | WorkerBindingAssets
   | WorkerBindingBrowserRendering
@@ -159,6 +165,33 @@ export interface WorkerBindingAI {
   name: string;
   /** Type identifier for AI binding */
   type: "ai";
+}
+
+/**
+ * AI Search single instance binding type.
+ * Binds directly to one specific AI Search instance (always scoped to default namespace).
+ */
+export interface WorkerBindingAiSearch {
+  /** The name of the binding */
+  name: string;
+  /** Type identifier for AI Search single instance binding */
+  type: "ai_search";
+  /** The AI Search instance name */
+  instance_name: string;
+}
+
+/**
+ * AI Search namespace binding type.
+ * Scoped to a user-defined namespace of AI Search instances.
+ * Grants full access (CRUD + search + chat) to all instances within the namespace.
+ */
+export interface WorkerBindingAiSearchNamespace {
+  /** The name of the binding */
+  name: string;
+  /** Type identifier for AI Search namespace binding */
+  type: "ai_search_namespace";
+  /** The namespace name */
+  namespace: string;
 }
 
 /**

--- a/alchemy/src/cloudflare/bound.ts
+++ b/alchemy/src/cloudflare/bound.ts
@@ -1,6 +1,9 @@
+/// <reference types="@cloudflare/workers-types" />
 import type { Pipeline } from "cloudflare:pipelines";
 import type { Secret } from "../secret.ts";
 import type { Ai as _Ai } from "./ai.ts";
+import type { AiSearchNamespace as _AiSearchNamespace } from "./ai-search-namespace.ts";
+import type { AiSearch as _AiSearch } from "./ai-search.ts";
 import type { AnalyticsEngineDataset as _AnalyticsEngineDataset } from "./analytics-engine.ts";
 import type { Assets } from "./assets.ts";
 import type { Binding, Json, Self } from "./bindings.ts";
@@ -9,6 +12,7 @@ import type { R2Bucket as _R2Bucket } from "./bucket.ts";
 import type { Container as _Container } from "./container.ts";
 import type { D1Database as _D1Database } from "./d1-database.ts";
 import type { DurableObjectNamespace as _DurableObjectNamespace } from "./durable-object-namespace.ts";
+import type { EmailSender as _EmailSender } from "./email-sender.ts";
 import type { HyperdriveRef } from "./hyperdrive-ref.ts";
 import type { Hyperdrive as _Hyperdrive } from "./hyperdrive.ts";
 import type { Images as _Images } from "./images.ts";
@@ -18,7 +22,6 @@ import type { RateLimit as _RateLimit } from "./rate-limit.ts";
 import type { SecretKey } from "./secret-key.ts";
 import type { SecretRef as CloudflareSecretRef } from "./secret-ref.ts";
 import type { Secret as CloudflareSecret } from "./secret.ts";
-import type { EmailSender as _EmailSender } from "./email-sender.ts";
 import type { VectorizeIndex as _VectorizeIndex } from "./vectorize-index.ts";
 import type { VersionMetadata as _VersionMetadata } from "./version-metadata.ts";
 import type { VpcService as _VpcService } from "./vpc-service.ts";
@@ -39,78 +42,88 @@ type BoundWorker<
   >]: Rpc.Provider<RPC, "fetch" | "connect">[property];
 };
 
-export type Bound<T extends Binding> =
-  T extends _DurableObjectNamespace<infer O>
-    ? DurableObjectNamespace<O & Rpc.DurableObjectBranded>
-    : T extends { type: "kv_namespace" }
-      ? KVNamespace
-      : T extends WorkerStub<infer RPC>
-        ? BoundWorker<RPC>
-        : T extends _Worker<any, infer RPC> | WorkerRef<infer RPC>
+// NOTE: AiSearch / AiSearchNamespace MUST come FIRST in this conditional
+// chain, before any structural discriminator like `{ type: "kv_namespace" }`.
+// `AiSearch.type` is the data-source type (`"r2" | "web-crawler"`), NOT a
+// binding-type discriminator — so we match by *resource-type import* via the
+// `_AiSearch` / `_AiSearchNamespace` aliases (underscore-prefixed to avoid
+// colliding with the identically-named Cloudflare runtime classes on the
+// right-hand side of the conditional).
+export type Bound<T extends Binding> = T extends _AiSearch
+  ? AiSearchInstance
+  : T extends _AiSearchNamespace
+    ? AiSearchNamespace
+    : T extends _DurableObjectNamespace<infer O>
+      ? DurableObjectNamespace<O & Rpc.DurableObjectBranded>
+      : T extends { type: "kv_namespace" }
+        ? KVNamespace
+        : T extends WorkerStub<infer RPC>
           ? BoundWorker<RPC>
-          : T extends { type: "service" }
-            ? Service
-            : T extends _R2Bucket
-              ? R2Bucket
-              : T extends _Hyperdrive | HyperdriveRef
-                ? Hyperdrive
-                : T extends Secret
-                  ? string
-                  : T extends CloudflareSecret | CloudflareSecretRef
-                    ? SecretsStoreSecret
-                    : T extends _EmailSender
-                      ? SendEmail
-                      : T extends SecretKey
-                        ? CryptoKey
-                        : T extends Assets
-                          ? Service
-                          : T extends _Workflow<infer P>
-                            ? Workflow<P>
-                            : T extends _D1Database
-                              ? D1Database
-                              : T extends DispatchNamespace
-                                ? DispatchNamespace
-                                : T extends _WorkerLoader
-                                  ? WorkerLoader
-                                  : T extends _VectorizeIndex
-                                    ? VectorizeIndex
-                                    : T extends _Queue<infer Body>
-                                      ? Queue<Body>
-                                      : T extends _AnalyticsEngineDataset
-                                        ? AnalyticsEngineDataset
-                                        : T extends _Pipeline<infer R>
-                                          ? Pipeline<R>
-                                          : T extends _RateLimit
-                                            ? RateLimit
-                                            : T extends string
-                                              ? T
-                                              : T extends BrowserRendering
-                                                ? Fetcher
-                                                : T extends _Ai<infer M>
-                                                  ? Ai<M>
-                                                  : T extends _Images
-                                                    ? ImagesBinding
-                                                    : T extends _VersionMetadata
-                                                      ? WorkerVersionMetadata
-                                                      : T extends
-                                                            | _Worker.DevDomain
-                                                            | _Worker.DevUrl
-                                                        ? string
-                                                        : T extends Self
-                                                          ? Service
-                                                          : T extends Json<
-                                                                infer T
-                                                              >
-                                                            ? T
-                                                            : T extends _Container<
-                                                                  infer Obj
+          : T extends _Worker<any, infer RPC> | WorkerRef<infer RPC>
+            ? BoundWorker<RPC>
+            : T extends { type: "service" }
+              ? Service
+              : T extends _R2Bucket
+                ? R2Bucket
+                : T extends _Hyperdrive | HyperdriveRef
+                  ? Hyperdrive
+                  : T extends Secret
+                    ? string
+                    : T extends CloudflareSecret | CloudflareSecretRef
+                      ? SecretsStoreSecret
+                      : T extends _EmailSender
+                        ? SendEmail
+                        : T extends SecretKey
+                          ? CryptoKey
+                          : T extends Assets
+                            ? Service
+                            : T extends _Workflow<infer P>
+                              ? Workflow<P>
+                              : T extends _D1Database
+                                ? D1Database
+                                : T extends DispatchNamespace
+                                  ? DispatchNamespace
+                                  : T extends _WorkerLoader
+                                    ? WorkerLoader
+                                    : T extends _VectorizeIndex
+                                      ? VectorizeIndex
+                                      : T extends _Queue<infer Body>
+                                        ? Queue<Body>
+                                        : T extends _AnalyticsEngineDataset
+                                          ? AnalyticsEngineDataset
+                                          : T extends _Pipeline<infer R>
+                                            ? Pipeline<R>
+                                            : T extends _RateLimit
+                                              ? RateLimit
+                                              : T extends string
+                                                ? T
+                                                : T extends BrowserRendering
+                                                  ? Fetcher
+                                                  : T extends _Ai<infer M>
+                                                    ? Ai<M>
+                                                    : T extends _Images
+                                                      ? ImagesBinding
+                                                      : T extends _VersionMetadata
+                                                        ? WorkerVersionMetadata
+                                                        : T extends
+                                                              | _Worker.DevDomain
+                                                              | _Worker.DevUrl
+                                                          ? string
+                                                          : T extends Self
+                                                            ? Service
+                                                            : T extends Json<
+                                                                  infer T
                                                                 >
-                                                              ? DurableObjectNamespace<
-                                                                  Obj &
-                                                                    Rpc.DurableObjectBranded
-                                                                >
-                                                              : T extends _VpcService
-                                                                ? Fetcher
-                                                                : T extends undefined
-                                                                  ? undefined
-                                                                  : Service;
+                                                              ? T
+                                                              : T extends _Container<
+                                                                    infer Obj
+                                                                  >
+                                                                ? DurableObjectNamespace<
+                                                                    Obj &
+                                                                      Rpc.DurableObjectBranded
+                                                                  >
+                                                                : T extends _VpcService
+                                                                  ? Fetcher
+                                                                  : T extends undefined
+                                                                    ? undefined
+                                                                    : Service;

--- a/alchemy/src/cloudflare/index.ts
+++ b/alchemy/src/cloudflare/index.ts
@@ -4,6 +4,7 @@ export * from "./account-api-token.ts";
 export * from "./account-id.ts";
 export * from "./ai-crawler.ts";
 export * from "./ai-gateway.ts";
+export * from "./ai-search-namespace.ts";
 export * from "./ai-search-token.ts";
 export * from "./ai-search.ts";
 export * from "./ai.ts";

--- a/alchemy/src/cloudflare/miniflare/build-worker-options.ts
+++ b/alchemy/src/cloudflare/miniflare/build-worker-options.ts
@@ -4,6 +4,8 @@ import { assertNever } from "../../util/assert-never.ts";
 import { reservePort } from "../../util/find-open-port.ts";
 import type { HTTPServer } from "../../util/http.ts";
 import { logger } from "../../util/logger.ts";
+import { isAiSearchNamespace } from "../ai-search-namespace.ts";
+import { isAiSearch } from "../ai-search.ts";
 import type { CloudflareApi } from "../api.ts";
 import type {
   Binding,
@@ -38,6 +40,8 @@ type RemoteBinding =
       {
         type:
           | "ai"
+          | "ai_search"
+          | "ai_search_namespace"
           | "browser"
           | "dispatch_namespace"
           | "mtls_certificate"
@@ -88,6 +92,29 @@ export const buildWorkerOptions = async (
   for (const [key, binding] of Object.entries(input.bindings ?? {})) {
     if (typeof binding === "string") {
       (options.bindings ??= {})[key] = binding;
+      continue;
+    }
+    if (isAiSearch(binding)) {
+      // AI Search instance bindings are not supported natively by Miniflare;
+      // proxy them to the deployed instance (same mechanism used by `ai`,
+      // `vectorize`, etc.). Instance bindings are always scoped to the
+      // default namespace on the CF side, so the namespace need not be
+      // surfaced in the remote-proxy metadata.
+      remoteBindings.push({
+        type: "ai_search",
+        name: key,
+        instance_name: binding.name,
+        raw: true,
+      });
+      continue;
+    }
+    if (isAiSearchNamespace(binding)) {
+      remoteBindings.push({
+        type: "ai_search_namespace",
+        name: key,
+        namespace: binding.namespace,
+        raw: true,
+      });
       continue;
     }
     if (binding.type === "cloudflare::Worker::Self") {
@@ -524,6 +551,18 @@ export const buildWorkerOptions = async (
         case "vpc_service":
           (options.vpcServices ??= {})[binding.name] = {
             service_id: binding.service_id,
+            remoteProxyConnectionString: remoteProxy.connectionString,
+          };
+          break;
+        case "ai_search":
+          (options.aiSearchInstances ??= {})[binding.name] = {
+            instance_name: binding.instance_name,
+            remoteProxyConnectionString: remoteProxy.connectionString,
+          };
+          break;
+        case "ai_search_namespace":
+          (options.aiSearchNamespaces ??= {})[binding.name] = {
+            namespace: binding.namespace,
             remoteProxyConnectionString: remoteProxy.connectionString,
           };
           break;

--- a/alchemy/src/cloudflare/worker-metadata.ts
+++ b/alchemy/src/cloudflare/worker-metadata.ts
@@ -2,6 +2,8 @@ import { assertNever } from "../util/assert-never.ts";
 import { camelToSnakeObjectDeep } from "../util/camel-to-snake.ts";
 import { logger } from "../util/logger.ts";
 import { memoize } from "../util/memoize.ts";
+import { isAiSearchNamespace } from "./ai-search-namespace.ts";
+import { isAiSearch } from "./ai-search.ts";
 import { extractCloudflareResult } from "./api-response.ts";
 import type { CloudflareApi } from "./api.ts";
 import type {
@@ -418,7 +420,29 @@ export async function prepareWorkerMetadata(
   for (const [bindingName, binding] of Object.entries(bindings)) {
     // Create a copy of the binding to avoid modifying the original
 
-    if (typeof binding === "string") {
+    if (isAiSearch(binding)) {
+      // Single-instance bindings (ai_search) are always scoped to the `default` namespace.
+      if (binding.namespace !== undefined && binding.namespace !== "default") {
+        throw new Error(
+          `Worker binding "${bindingName}" uses a single-instance AiSearch binding (type: "ai_search"), ` +
+            `but the bound AiSearch instance "${binding.name}" is in namespace "${binding.namespace}". ` +
+            `Single-instance bindings only support the "default" namespace.\n` +
+            `Fix: either (1) create the AiSearch without a custom namespace, or ` +
+            `(2) bind the enclosing AiSearchNamespace and use \`env.${bindingName}.get("${binding.name}")\`.`,
+        );
+      }
+      meta.bindings.push({
+        type: "ai_search",
+        name: bindingName,
+        instance_name: binding.name,
+      });
+    } else if (isAiSearchNamespace(binding)) {
+      meta.bindings.push({
+        type: "ai_search_namespace",
+        name: bindingName,
+        namespace: binding.namespace,
+      });
+    } else if (typeof binding === "string") {
       meta.bindings.push({
         type: "plain_text",
         name: bindingName,

--- a/alchemy/src/cloudflare/wrangler.json.ts
+++ b/alchemy/src/cloudflare/wrangler.json.ts
@@ -6,6 +6,8 @@ import { Resource } from "../resource.ts";
 import { Scope } from "../scope.ts";
 import { isSecret } from "../secret.ts";
 import { assertNever } from "../util/assert-never.ts";
+import { isAiSearchNamespace } from "./ai-search-namespace.ts";
+import { isAiSearch } from "./ai-search.ts";
 import { createCloudflareApi } from "./api.ts";
 import type { Bindings } from "./bindings.ts";
 import { getCloudflareRegistryWithAccountNamespace } from "./container.ts";
@@ -289,6 +291,8 @@ async function processBindings(
   const containers: WranglerJsonConfig["containers"] = [];
   const workerLoaders: WranglerJsonConfig["worker_loaders"] = [];
   const vpcServices: WranglerJsonConfig["vpc_services"] = [];
+  const aiSearchInstances: WranglerJsonConfig["ai_search"] = [];
+  const aiSearchNamespaces: WranglerJsonConfig["ai_search_namespaces"] = [];
 
   for (const eventSource of eventSources ?? []) {
     if (isQueueEventSource(eventSource)) {
@@ -321,6 +325,26 @@ async function processBindings(
     } else if (writeSecrets && isSecret(binding)) {
       spec.vars ??= {};
       spec.vars[bindingName] = binding as any;
+    } else if (isAiSearch(binding)) {
+      // AI Search discriminates via ResourceKind (isAiSearch) rather than
+      // binding.type — `AiSearch.type` is the *source* type ("r2" |
+      // "web-crawler") and so would collide with `r2_bucket` string
+      // matching below. Checking here at the top of the chain mirrors the
+      // ordering in worker-metadata.ts.
+      aiSearchInstances.push({
+        binding: bindingName,
+        instance_name: binding.name,
+        // AI Search is not natively supported by Miniflare — emitting
+        // `remote: true` lets `wrangler dev` proxy to the deployed
+        // instance (matches vectorize / browser / ai / vpc_service).
+        remote: true,
+      });
+    } else if (isAiSearchNamespace(binding)) {
+      aiSearchNamespaces.push({
+        binding: bindingName,
+        namespace: binding.namespace,
+        remote: true,
+      });
     } else if (binding.type === "cloudflare::Worker::Self") {
       // Self(service) binding
       services.push({
@@ -645,5 +669,13 @@ async function processBindings(
 
   if (workerLoaders.length > 0) {
     spec.worker_loaders = workerLoaders;
+  }
+
+  if (aiSearchInstances.length > 0) {
+    spec.ai_search = aiSearchInstances;
+  }
+
+  if (aiSearchNamespaces.length > 0) {
+    spec.ai_search_namespaces = aiSearchNamespaces;
   }
 }

--- a/alchemy/test/cloudflare/ai-search.test.ts
+++ b/alchemy/test/cloudflare/ai-search.test.ts
@@ -1,7 +1,12 @@
 import "../../src/test/vitest.ts";
 
-import { assert, describe, expect } from "vitest";
+import { describe, expect } from "vitest";
 import { alchemy } from "../../src/alchemy.ts";
+import {
+  AiSearchNamespace,
+  deleteAiSearchNamespace,
+  getAiSearchNamespace,
+} from "../../src/cloudflare/ai-search-namespace.ts";
 import { AiSearchToken } from "../../src/cloudflare/ai-search-token.ts";
 import {
   AiSearch,
@@ -23,6 +28,15 @@ const test = alchemy.test(import.meta, {
   prefix: BRANCH_PREFIX,
 });
 
+/**
+ * Cleanup-safe error filter: swallow 404s (resource already gone), re-throw
+ * everything else so real API errors (auth, 5xx, rate limit) surface in CI.
+ * Replaces the dangerous `.catch(() => {})` pattern.
+ */
+function ignore404(e: unknown): void {
+  if ((e as { status?: number })?.status !== 404) throw e;
+}
+
 describe("AiSearchToken Resource", () => {
   const testId = `${BRANCH_PREFIX}-ai-token`;
 
@@ -32,7 +46,7 @@ describe("AiSearchToken Resource", () => {
     try {
       // Create an AI Search token
       token = await AiSearchToken("test-token", {
-        name: `${testId}`,
+        name: testId,
       });
 
       expect(token.tokenId).toBeTruthy();
@@ -51,11 +65,21 @@ describe("AiSearchToken Resource", () => {
     } finally {
       await destroy(scope);
 
-      // Verify AI Search token was deleted
+      // Verify AI Search token was deleted. CF's delete is eventually
+      // consistent — poll for up to 60s.
       if (token?.tokenId) {
-        const getDeletedResponse = await api.get(
-          `/accounts/${api.accountId}/ai-search/tokens/${token.tokenId}`,
-        );
+        const capturedTokenId = token.tokenId;
+        const getDeletedResponse = await poll({
+          description: "wait for AI Search token deletion to propagate",
+          fn: () =>
+            api.get(
+              `/accounts/${api.accountId}/ai-search/tokens/${capturedTokenId}`,
+            ),
+          predicate: (res) => res.status === 404,
+          initialDelay: 500,
+          maxDelay: 3000,
+          timeout: 30_000,
+        });
         expect(getDeletedResponse.status).toEqual(404);
       }
     }
@@ -96,10 +120,11 @@ describe("AiSearch Resource", () => {
       expect(aiSearch.type).toEqual("r2");
       expect(aiSearch.source).toEqual(bucketName);
       expect(aiSearch.tokenId).toBeTruthy();
+      expect(aiSearch.namespace).toEqual("default");
       // Note: internalId and vectorizeName may not be immediately available
 
       // Verify instance was created by querying the API directly
-      const instance = await getAiSearchInstance(api, instanceName);
+      const instance = await getAiSearchInstance(api, "default", instanceName);
       expect(instance.id).toEqual(instanceName);
       expect(instance.type).toEqual("r2");
 
@@ -122,18 +147,38 @@ describe("AiSearch Resource", () => {
       expect(aiSearch.scoreThreshold).toEqual(0.5);
       expect(aiSearch.reranking).toEqual(true);
 
-      // Verify instance was updated
-      const updatedInstance = await getAiSearchInstance(api, instanceName);
+      // Verify instance was updated. Cloudflare's instance PUT is
+      // eventually consistent — poll briefly for the new values.
+      const updatedInstance = await poll({
+        description: "wait for AI Search instance PUT to propagate",
+        fn: () => getAiSearchInstance(api, "default", instanceName),
+        predicate: (r) =>
+          r.max_num_results === 20 &&
+          r.score_threshold === 0.5 &&
+          r.reranking === true,
+        initialDelay: 500,
+        maxDelay: 3000,
+        timeout: 30_000,
+      });
       expect(updatedInstance.max_num_results).toEqual(20);
       expect(updatedInstance.score_threshold).toEqual(0.5);
       expect(updatedInstance.reranking).toEqual(true);
     } finally {
       await destroy(scope);
 
-      // Verify instance was deleted
-      const getResponse = await api.get(
-        `/accounts/${api.accountId}/ai-search/instances/${instanceName}`,
-      );
+      // Verify instance was deleted (namespace-scoped endpoint). CF's
+      // delete is eventually consistent — poll until the GET flips to 404.
+      const getResponse = await poll({
+        description: "wait for instance deletion to propagate",
+        fn: () =>
+          api.get(
+            `/accounts/${api.accountId}/ai-search/namespaces/default/instances/${instanceName}`,
+          ),
+        predicate: (res) => res.status === 404,
+        initialDelay: 500,
+        maxDelay: 3000,
+        timeout: 30_000,
+      });
       expect(getResponse.status).toEqual(404);
     }
   });
@@ -165,6 +210,7 @@ describe("AiSearch Resource", () => {
       expect(aiSearch.id).toEqual(instanceName);
       expect(aiSearch.type).toEqual("r2");
       expect(aiSearch.source).toEqual(bucketName);
+      expect(aiSearch.namespace).toEqual("default");
     } finally {
       await destroy(scope);
     }
@@ -173,30 +219,30 @@ describe("AiSearch Resource", () => {
   test("create AI Search with invalid domain", async (scope) => {
     const instanceName = `${testId}-invalid`;
 
-    let aiSearch: AiSearch | undefined;
-
     try {
-      aiSearch = await AiSearch("invalid-search", {
-        name: instanceName,
-        source: {
-          type: "web-crawler",
-          domain: "invalid-domain.com",
-        },
-        adopt: true,
-      });
-    } catch (error) {
-      assert(error instanceof Error);
-      expect(error.message).toContain(
-        "The domain needs to belong to this account.",
-      );
+      // Explicitly assert the Promise rejects with the expected message. The
+      // previous `try/catch` variant silently passed if `AiSearch()` resolved.
+      await expect(
+        AiSearch("invalid-search", {
+          name: instanceName,
+          source: {
+            type: "web-crawler",
+            domain: "invalid-domain.com",
+          },
+          adopt: true,
+        }),
+      ).rejects.toThrow(/The domain needs to belong to this account\./);
     } finally {
       await destroy(scope);
     }
   });
 
   test("create AI Search with R2Bucket shorthand", async (scope) => {
-    const instanceName = `${testId}-shorthand`;
-    const bucketName = `${testId}-shorthand-bucket`;
+    // Keep the suffix short — `${testId}` already uses BRANCH_PREFIX which
+    // varies in length between environments; AI Search instance names are
+    // capped at 32 chars by Cloudflare.
+    const instanceName = `${testId}-sh`;
+    const bucketName = `${testId}-sh-bucket`;
 
     let aiSearch: AiSearch | undefined;
 
@@ -218,6 +264,7 @@ describe("AiSearch Resource", () => {
       expect(aiSearch.type).toEqual("r2");
       expect(aiSearch.source).toEqual(bucketName);
       expect(aiSearch.tokenId).toBeTruthy();
+      expect(aiSearch.namespace).toEqual("default");
     } finally {
       await destroy(scope);
     }
@@ -254,6 +301,7 @@ describe("AiSearch Resource", () => {
 
       expect(aiSearch.id).toEqual(instanceName);
       expect(aiSearch.tokenId).toEqual(token.tokenId);
+      expect(aiSearch.namespace).toEqual("default");
     } finally {
       await destroy(scope);
     }
@@ -293,12 +341,17 @@ describe("AiSearch Resource", () => {
       expect(aiSearch.maxNumResults).toEqual(15);
       expect(aiSearch.scoreThreshold).toEqual(0.3);
       expect(aiSearch.rewriteQuery).toEqual(true);
+      expect(aiSearch.namespace).toEqual("default");
     } finally {
       await destroy(scope);
     }
   });
 
-  test("adopt existing AI Search instance", async (scope) => {
+  test("adopt preserves underlying AiSearch instance (createdAt + internalId stable)", async (scope) => {
+    // Catches silent-recreate regressions: adoption must reuse the same
+    // underlying Cloudflare resource, not destroy-then-recreate. The only
+    // way to reliably prove this is to verify the server-assigned
+    // createdAt and internalId are identical across the two calls.
     const instanceName = `${testId}-adopt`;
     const bucketName = `${testId}-adopt-bucket`;
 
@@ -320,6 +373,8 @@ describe("AiSearch Resource", () => {
       });
 
       expect(aiSearch1.id).toEqual(instanceName);
+      const originalCreatedAt = aiSearch1.createdAt;
+      const originalInternalId = aiSearch1.internalId;
 
       // Create second instance with same name - should adopt
       const aiSearch2 = await AiSearch("adopt-search-2", {
@@ -336,6 +391,12 @@ describe("AiSearch Resource", () => {
       // Should have adopted and updated
       expect(aiSearch2.id).toEqual(instanceName);
       expect(aiSearch2.maxNumResults).toEqual(25);
+      expect(aiSearch2.namespace).toEqual("default");
+      // Adoption preserves the underlying resource: createdAt + internalId
+      // must match the original exactly. If the resource had been silently
+      // recreated, the server would have issued new values.
+      expect(aiSearch2.createdAt).toEqual(originalCreatedAt);
+      expect(aiSearch2.internalId).toEqual(originalInternalId);
     } finally {
       await destroy(scope);
     }
@@ -366,10 +427,10 @@ describe("AiSearch Resource", () => {
       await destroy(scope);
 
       // Instance should still exist
-      const instance = await getAiSearchInstance(api, instanceName);
+      const instance = await getAiSearchInstance(api, "default", instanceName);
       expect(instance.id).toEqual(instanceName);
     } finally {
-      await deleteAiSearchInstance(api, instanceName);
+      await deleteAiSearchInstance(api, "default", instanceName);
     }
   });
 
@@ -382,13 +443,16 @@ describe("AiSearch Resource", () => {
       const workerName = `${testId}-rag-worker`;
 
       try {
-        // 1. Create bucket with test content
+        // 1. Create bucket with test content.
+        // NOTE: `delete: false` (and `empty: true` is intentionally not set)
+        // because AI Search holds a reference to the bucket — attempting
+        // to delete or empty the bucket while an AI Search instance is
+        // indexing it races with the indexing job and flakes CI. We leak
+        // the test buckets into the account; they're cleaned up out-of-band.
         const bucket = await R2Bucket("rag-bucket", {
           name: bucketName,
           adopt: true,
-          // we can't seem to delete a bucket used by AI search
           delete: false,
-          // empty: true, // Empty bucket on deletion since we upload docs
         });
 
         await bucket.put(
@@ -461,25 +525,40 @@ Schedule regular vet checkups and keep vaccinations current.
 
         expect(worker.url).toBeTruthy();
 
-        await new Promise((resolve) => setTimeout(resolve, 2000));
-
-        // 5. Verify RAG response
+        // 5. Verify RAG response. `poll.initialDelay` handles the initial
+        // warm-up (was previously preceded by a bare `setTimeout(2000)` magic
+        // sleep; removed in favor of letting `poll` drive the cadence).
+        // The fetch itself can return HTML error pages (e.g. 404 from a not-
+        // yet-ready worker) — tolerate JSON parse errors as "not ready".
+        type RagResponse = {
+          success: boolean;
+          hasResponse?: boolean;
+          responseLength?: number;
+          sourceCount?: number;
+        };
         const data = await poll({
           description: "wait for AI Search to be ready",
-          fn: async () => {
+          fn: async (): Promise<RagResponse> => {
             const url = new URL(worker.url!);
             url.searchParams.set("q", "installation");
-            const response = await fetch(url);
-            return (await response.json()) as {
-              success: boolean;
-              hasResponse: boolean;
-              responseLength: number;
-              sourceCount: number;
-            };
+            try {
+              const response = await fetch(url);
+              const contentType = response.headers.get("content-type") ?? "";
+              if (!contentType.includes("application/json")) {
+                return { success: false };
+              }
+              return (await response.json()) as RagResponse;
+            } catch {
+              return { success: false };
+            }
           },
-          predicate: (result) => result.success && result.sourceCount > 0,
+          predicate: (result) =>
+            result.success === true && (result.sourceCount ?? 0) > 0,
           initialDelay: 5000,
           maxDelay: 10_000,
+          // Explicit timeout — produces a clearer failure than vitest's
+          // outer test timeout (which just reports "test timed out").
+          timeout: 8 * 60_000,
         });
 
         expect(data.success).toBe(true);
@@ -489,8 +568,541 @@ Schedule regular vet checkups and keep vaccinations current.
         expect(data.sourceCount).toBeGreaterThan(0);
       } finally {
         await destroy(scope);
+
+        // Verify instance was deleted. CF's instance delete is eventually
+        // consistent — same-colo is immediate (edge cache invalidation),
+        // cross-colo is bounded to ~60s (KV TTL).
+        const getResponse = await poll({
+          description: "wait for RAG instance deletion to propagate",
+          fn: () =>
+            api.get(
+              `/accounts/${api.accountId}/ai-search/namespaces/default/instances/${instanceName}`,
+            ),
+          predicate: (res) => res.status === 404,
+          initialDelay: 500,
+          maxDelay: 5000,
+          timeout: 90_000,
+        });
+        expect(getResponse.status).toEqual(404);
       }
     },
     60_000 * 10,
   );
+
+  test("create sourceless AI Search instance (built-in storage)", async (scope) => {
+    const instanceName = `${testId}-nosrc`;
+
+    let aiSearch: AiSearch | undefined;
+
+    try {
+      // Create AI Search instance without a source (built-in storage)
+      aiSearch = await AiSearch("nosrc-search", {
+        name: instanceName,
+        adopt: true,
+      });
+
+      expect(aiSearch.id).toEqual(instanceName);
+      expect(aiSearch.namespace).toEqual("default");
+      // Sourceless instances don't have a user-facing source
+      expect(aiSearch.source).toBeFalsy();
+
+      // Verify instance was created
+      const instance = await getAiSearchInstance(api, "default", instanceName);
+      expect(instance.id).toEqual(instanceName);
+      expect(instance.source).toBeFalsy();
+    } finally {
+      await destroy(scope);
+    }
+  });
+
+  test("create AI Search instance in custom namespace", async (scope) => {
+    const namespaceName = `${testId}-ns`;
+    const instanceName = `${testId}-ns-inst`;
+
+    try {
+      // Create a namespace
+      const ns = await AiSearchNamespace("test-ns", {
+        name: namespaceName,
+        adopt: true,
+      });
+
+      expect(ns.namespace).toEqual(namespaceName);
+      expect(ns.type).toEqual("ai_search_namespace");
+
+      // Create instance in that namespace
+      const aiSearch = await AiSearch("ns-search", {
+        name: instanceName,
+        namespace: ns,
+        adopt: true,
+      });
+
+      expect(aiSearch.id).toEqual(instanceName);
+      expect(aiSearch.namespace).toEqual(namespaceName);
+
+      // Verify instance exists in the namespace
+      const instance = await getAiSearchInstance(
+        api,
+        namespaceName,
+        instanceName,
+      );
+      expect(instance.id).toEqual(instanceName);
+    } finally {
+      await destroy(scope);
+
+      // Clean up namespace (should be empty after instance deletion)
+      await deleteAiSearchNamespace(api, namespaceName);
+    }
+  });
+});
+
+describe("AiSearchNamespace Resource", () => {
+  const testId = `${BRANCH_PREFIX}-ai-ns`;
+
+  test("create and delete AI Search namespace", async (scope) => {
+    const namespaceName = `${testId}-crud`;
+
+    try {
+      const ns = await AiSearchNamespace("crud-ns", {
+        name: namespaceName,
+        description: "Test namespace",
+      });
+
+      expect(ns.type).toEqual("ai_search_namespace");
+      expect(ns.namespace).toEqual(namespaceName);
+      expect(ns.description).toEqual("Test namespace");
+      expect(ns.createdAt).toBeTruthy();
+
+      // Verify namespace was created by querying the API directly
+      const existing = await getAiSearchNamespace(api, namespaceName);
+      expect(existing).toBeTruthy();
+      expect(existing!.name).toEqual(namespaceName);
+    } finally {
+      await destroy(scope);
+
+      // Verify namespace was deleted. Cloudflare's namespace delete is
+      // eventually consistent — poll briefly until the GET returns
+      // `undefined` (helper maps 404 → undefined) before asserting.
+      const deleted = await poll({
+        description: "wait for namespace deletion to propagate",
+        fn: () => getAiSearchNamespace(api, namespaceName),
+        predicate: (r) => r === undefined,
+        initialDelay: 500,
+        maxDelay: 3000,
+        timeout: 30_000,
+      });
+      expect(deleted).toBeUndefined();
+    }
+  });
+
+  test("adopt existing AI Search namespace", async (scope) => {
+    const namespaceName = `${testId}-adopt`;
+
+    try {
+      // Create initial namespace
+      const ns1 = await AiSearchNamespace("adopt-ns-1", {
+        name: namespaceName,
+      });
+
+      expect(ns1.namespace).toEqual(namespaceName);
+
+      // Create second namespace with same name - should adopt
+      const ns2 = await AiSearchNamespace("adopt-ns-2", {
+        name: namespaceName,
+        description: "Adopted namespace",
+        adopt: true,
+      });
+
+      expect(ns2.namespace).toEqual(namespaceName);
+      expect(ns2.description).toEqual("Adopted namespace");
+    } finally {
+      await destroy(scope);
+
+      // Clean up
+      await deleteAiSearchNamespace(api, namespaceName);
+    }
+  });
+
+  test("adopt preserves underlying resource (createdAt match)", async (scope) => {
+    const namespaceName = `${testId}-av`;
+
+    try {
+      // Create initial namespace, capture createdAt
+      const ns1 = await AiSearchNamespace("adopt-verify-1", {
+        name: namespaceName,
+      });
+      expect(ns1.namespace).toEqual(namespaceName);
+      const originalCreatedAt = ns1.createdAt;
+
+      // Second create with adopt: true — should adopt the SAME underlying namespace,
+      // not create a new one. The createdAt must remain identical.
+      const ns2 = await AiSearchNamespace("adopt-verify-2", {
+        name: namespaceName,
+        adopt: true,
+      });
+
+      expect(ns2.namespace).toEqual(namespaceName);
+      expect(ns2.createdAt).toEqual(originalCreatedAt);
+    } finally {
+      await destroy(scope);
+      await deleteAiSearchNamespace(api, namespaceName);
+    }
+  });
+
+  test("rename triggers replace (old deleted, new created)", async (scope) => {
+    const originalName = `${testId}-ra`;
+    const renamedName = `${testId}-rb`;
+
+    try {
+      // Create namespace with initial name
+      const ns1 = await AiSearchNamespace("rename-ns", {
+        name: originalName,
+      });
+      expect(ns1.namespace).toEqual(originalName);
+      await scope.finalize();
+
+      // Verify initial namespace exists
+      const initialExists = await getAiSearchNamespace(api, originalName);
+      expect(initialExists).toBeTruthy();
+
+      // Rename — triggers this.replace()
+      const ns2 = await AiSearchNamespace("rename-ns", {
+        name: renamedName,
+      });
+      expect(ns2.namespace).toEqual(renamedName);
+      await scope.finalize();
+
+      // Original must be gone, new one present. The delete fires during
+      // scope.finalize() (pending-deletion flush), but CF's namespace
+      // delete is eventually consistent — poll briefly.
+      const oldExists = await poll({
+        description: "wait for old namespace deletion to propagate",
+        fn: () => getAiSearchNamespace(api, originalName),
+        predicate: (r) => r === undefined,
+        initialDelay: 500,
+        maxDelay: 3000,
+        timeout: 30_000,
+      });
+      expect(oldExists).toBeUndefined();
+      const newExists = await getAiSearchNamespace(api, renamedName);
+      expect(newExists).toBeTruthy();
+    } finally {
+      await destroy(scope);
+      // Cleanup both just in case
+      await deleteAiSearchNamespace(api, originalName).catch(ignore404);
+      await deleteAiSearchNamespace(api, renamedName).catch(ignore404);
+    }
+  });
+
+  test("description round-trips through the API (set → update → clear with null)", async (scope) => {
+    // Covers the three-way semantics on `description`:
+    //   - absent (undefined)  → do not touch
+    //   - string              → set
+    //   - null                → clear
+    const namespaceName = `${testId}-desc`;
+
+    try {
+      // (1) Create with an initial description
+      const ns1 = await AiSearchNamespace("desc-ns", {
+        name: namespaceName,
+        description: "initial description",
+      });
+      expect(ns1.description).toEqual("initial description");
+
+      // Verify via API read that it was persisted server-side, not just
+      // mirrored in Alchemy output.
+      const apiView1 = await getAiSearchNamespace(api, namespaceName);
+      expect(apiView1?.description).toEqual("initial description");
+
+      // (2) Update with a new description — must PUT.
+      const ns2 = await AiSearchNamespace("desc-ns", {
+        name: namespaceName,
+        description: "updated description",
+      });
+      expect(ns2.description).toEqual("updated description");
+
+      // Cloudflare's namespace PUT is eventually consistent — poll briefly
+      // until the GET surfaces the new value before asserting.
+      const apiView2 = await poll({
+        description: "wait for namespace description update to propagate",
+        fn: () => getAiSearchNamespace(api, namespaceName),
+        predicate: (r) => r?.description === "updated description",
+        initialDelay: 500,
+        maxDelay: 2000,
+        timeout: 15_000,
+      });
+      expect(apiView2?.description).toEqual("updated description");
+
+      // (3) Clear by passing null explicitly.
+      const ns3 = await AiSearchNamespace("desc-ns", {
+        name: namespaceName,
+        description: null,
+      });
+      expect(ns3.description).toBeNull();
+
+      const apiView3 = await poll({
+        description: "wait for namespace description clear to propagate",
+        fn: () => getAiSearchNamespace(api, namespaceName),
+        // API surfaces cleared description as null or empty string — both OK.
+        predicate: (r) => !r?.description,
+        initialDelay: 500,
+        maxDelay: 2000,
+        timeout: 15_000,
+      });
+      expect(apiView3?.description ?? null).toBeFalsy();
+    } finally {
+      await destroy(scope);
+      await deleteAiSearchNamespace(api, namespaceName).catch(ignore404);
+    }
+  });
+
+  test("adopt on reserved default namespace binds without create", async (scope) => {
+    // The `default` namespace is reserved by Cloudflare — create/update/
+    // delete via the API all fail. Alchemy must bind to it via `adopt: true`
+    // without issuing any CREATE request, and destroy must NOT attempt to
+    // delete it.
+    const ns = await AiSearchNamespace("default-adoption", {
+      name: "default",
+      adopt: true,
+    });
+    expect(ns.namespace).toEqual("default");
+    expect(ns.type).toEqual("ai_search_namespace");
+
+    // Destroy must be a no-op for the default namespace (the helper
+    // skips it silently). If this throws, the implementation is attempting
+    // an illegal DELETE and we want the test to fail loudly.
+    await destroy(scope);
+  });
+
+  test("rejects names that violate Cloudflare's character rules", async (scope) => {
+    // Local validation catches bad names before any API call. This test
+    // locks in the documented regex: ^[a-z0-9]([a-z0-9-]{0,26}[a-z0-9])?$
+    try {
+      await expect(
+        AiSearchNamespace("bad-start", { name: "-leading-hyphen" }),
+      ).rejects.toThrow(/invalid/i);
+
+      await expect(
+        AiSearchNamespace("bad-end", { name: "trailing-hyphen-" }),
+      ).rejects.toThrow(/invalid/i);
+
+      await expect(
+        AiSearchNamespace("bad-upper", { name: "HasUppercase" }),
+      ).rejects.toThrow(/invalid/i);
+    } finally {
+      await destroy(scope);
+    }
+  });
+
+  test("delete=false preserves namespace on scope destroy", async (scope) => {
+    const namespaceName = `${testId}-nd`;
+
+    try {
+      await AiSearchNamespace("nodelete-ns", {
+        name: namespaceName,
+        delete: false,
+      });
+
+      // Destroy scope — namespace should still exist
+      await destroy(scope);
+
+      const stillExists = await getAiSearchNamespace(api, namespaceName);
+      expect(stillExists).toBeTruthy();
+      expect(stillExists!.name).toEqual(namespaceName);
+    } finally {
+      // Manual cleanup (delete: false means scope destroy didn't remove it)
+      await deleteAiSearchNamespace(api, namespaceName);
+    }
+  });
+});
+
+describe("AiSearch namespace + binding integration", () => {
+  const testId = `${BRANCH_PREFIX}-bnd`;
+
+  test("sourceless instance update changes maxNumResults without replacing the instance", async (scope) => {
+    const instanceName = `${testId}-srcupd`;
+
+    try {
+      // Create sourceless instance
+      let aiSearch = await AiSearch("srcless-upd", {
+        name: instanceName,
+        maxNumResults: 10,
+        adopt: true,
+      });
+      expect(aiSearch.maxNumResults).toEqual(10);
+      // Alchemy must not auto-create a service token for sourceless instances
+      // (the API may still surface an internal default token_id — that's fine).
+      expect(aiSearch.source).toBeFalsy();
+
+      const initialInternalId = aiSearch.internalId;
+
+      // Update maxNumResults — must not trigger a replace (internalId stable)
+      aiSearch = await AiSearch("srcless-upd", {
+        name: instanceName,
+        maxNumResults: 25,
+        adopt: true,
+      });
+      expect(aiSearch.maxNumResults).toEqual(25);
+      expect(aiSearch.source).toBeFalsy();
+      expect(aiSearch.internalId).toEqual(initialInternalId);
+
+      // Verify on the API
+      const instance = await getAiSearchInstance(api, "default", instanceName);
+      expect(instance.max_num_results).toEqual(25);
+      expect(instance.source).toBeFalsy();
+    } finally {
+      await destroy(scope);
+      // Verify gone. Cloudflare's delete endpoint is eventually consistent —
+      // poll briefly until the GET flips to 404 before failing the test.
+      const after = await poll({
+        description: "wait for instance deletion to propagate",
+        fn: () =>
+          api.get(
+            `/accounts/${api.accountId}/ai-search/namespaces/default/instances/${instanceName}`,
+          ),
+        predicate: (res) => res.status === 404,
+        initialDelay: 500,
+        maxDelay: 3000,
+        timeout: 30_000,
+      });
+      expect(after.status).toEqual(404);
+    }
+  });
+
+  test("changing namespace on an existing instance triggers replace", async (scope) => {
+    // Covers the critical path where a user moves an AI Search instance
+    // from one namespace to another. Because namespace is immutable on the
+    // CF side, Alchemy must delete the old instance and create a new one
+    // (rather than silently attempting an in-place PUT against the new
+    // namespace and leaking the old instance).
+    const namespaceName = `${testId}-mvns`;
+    const instanceName = `${testId}-mvinst`;
+
+    try {
+      await AiSearchNamespace("mv-ns", {
+        name: namespaceName,
+        adopt: true,
+      });
+
+      // Create in default namespace first
+      const first = await AiSearch("mv-inst", {
+        name: instanceName,
+        adopt: true,
+      });
+      expect(first.namespace).toEqual("default");
+      await scope.finalize();
+
+      const inDefault = await getAiSearchInstance(api, "default", instanceName);
+      expect(inDefault.id).toEqual(instanceName);
+
+      // Move to custom namespace — must trigger this.replace()
+      const second = await AiSearch("mv-inst", {
+        name: instanceName,
+        namespace: namespaceName,
+        adopt: true,
+      });
+      expect(second.namespace).toEqual(namespaceName);
+      await scope.finalize();
+
+      // Old (default) must be gone; new (custom ns) must exist. Delete is
+      // eventually consistent — poll for the old instance to vanish.
+      const oldGone = await poll({
+        description: "wait for old instance deletion to propagate",
+        fn: () =>
+          getAiSearchInstance(api, "default", instanceName).catch((e) =>
+            e?.status === 404 ? undefined : Promise.reject(e),
+          ),
+        predicate: (r) => r === undefined,
+        initialDelay: 500,
+        maxDelay: 3000,
+        timeout: 30_000,
+      });
+      expect(oldGone).toBeUndefined();
+
+      const newInstance = await getAiSearchInstance(
+        api,
+        namespaceName,
+        instanceName,
+      );
+      expect(newInstance.id).toEqual(instanceName);
+    } finally {
+      await deleteAiSearchInstance(api, "default", instanceName).catch(
+        ignore404,
+      );
+      await deleteAiSearchInstance(api, namespaceName, instanceName).catch(
+        ignore404,
+      );
+      await destroy(scope).catch(ignore404);
+      await deleteAiSearchNamespace(api, namespaceName).catch(ignore404);
+    }
+  });
+
+  test("namespace prop accepts a string (not just a Resource)", async (scope) => {
+    const namespaceName = `${testId}-sns`;
+    const instanceName = `${testId}-sinst`;
+
+    try {
+      // Pre-create the namespace since AiSearch doesn't create it for us
+      await AiSearchNamespace("str-ns", {
+        name: namespaceName,
+        adopt: true,
+      });
+
+      // Use the namespace as a plain string
+      const aiSearch = await AiSearch("str-inst", {
+        name: instanceName,
+        namespace: namespaceName, // string, not a Resource
+        adopt: true,
+      });
+
+      expect(aiSearch.namespace).toEqual(namespaceName);
+
+      // Verify on the API (namespace-scoped endpoint)
+      const instance = await getAiSearchInstance(
+        api,
+        namespaceName,
+        instanceName,
+      );
+      expect(instance.id).toEqual(instanceName);
+    } finally {
+      await destroy(scope);
+      await deleteAiSearchNamespace(api, namespaceName);
+    }
+  });
+
+  test("single-instance binding rejects non-default namespace at deploy time", async (scope) => {
+    const namespaceName = `${testId}-rjns`;
+    const instanceName = `${testId}-rjinst`;
+    const workerName = `${testId}-rjwkr`;
+
+    try {
+      const ns = await AiSearchNamespace("reject-ns", {
+        name: namespaceName,
+        adopt: true,
+      });
+
+      // Instance in a custom namespace
+      const aiSearch = await AiSearch("reject-inst", {
+        name: instanceName,
+        namespace: ns,
+        adopt: true,
+      });
+      expect(aiSearch.namespace).toEqual(namespaceName);
+
+      // Attempt to bind it as a single-instance binding — must fail
+      await expect(
+        Worker(workerName, {
+          name: workerName,
+          adopt: true,
+          script: "export default { fetch() { return new Response('hi'); } };",
+          format: "esm",
+          bindings: {
+            SEARCH: aiSearch, // ← single-instance binding, but namespace isn't "default"
+          },
+        }),
+      ).rejects.toThrow(/single-instance AiSearch binding/);
+    } finally {
+      await destroy(scope);
+      await deleteAiSearchNamespace(api, namespaceName);
+    }
+  });
 });

--- a/bun.lock
+++ b/bun.lock
@@ -834,7 +834,7 @@
     "@cloudflare/workers-types": "^4.20260420.1",
     "typescript": "^5.8.3",
     "vite": "^7.1.9",
-    "wrangler": "^4.70.0",
+    "wrangler": "^4.83.0",
   },
   "packages": {
     "@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.11.1", "", {}, "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ=="],
@@ -1189,7 +1189,7 @@
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260120.0", "", { "os": "win32", "cpu": "x64" }, "sha512-ASZIz1E8sqZQqQCgcfY1PJbBpUDrxPt8NZ+lqNil0qxnO4qX38hbCsdDF2/TDAuq0Txh7nu8ztgTelfNDlb4EA=="],
 
-    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260420.1", "", {}, "sha512-DHT9JnSn9cIiCSdL76OxW+Xvc1+ml1CWzWvgVwreoHQ+E604aeFxPPHp9X7nE+XRWm2NH4l0OgtxUI5T/nuI3g=="],
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260421.1", "", {}, "sha512-PJjuz1zwwa+/WP9dkf5ORMQWL7u2m1d8aFUhG3dx6ohweGd+zMppT1JG0zhc00LUg8gFXVaiZzZ5w/0Cp4HI+g=="],
 
     "@coinbase/cdp-sdk": ["@coinbase/cdp-sdk@1.38.4", "", { "dependencies": { "@solana-program/system": "^0.8.0", "@solana-program/token": "^0.6.0", "@solana/kit": "^3.0.3", "@solana/web3.js": "^1.98.1", "abitype": "1.0.6", "axios": "^1.12.2", "axios-retry": "^4.5.0", "jose": "^6.0.8", "md5": "^2.3.0", "uncrypto": "^0.1.3", "viem": "^2.21.26", "zod": "^3.24.4" } }, "sha512-xVvfluaGt0NxNmjElP3C1yI6KnsGwihabdXj+qNtjjsSmd/Ha2V3gAiCyNrrYOqIORn4mpC2jgu2fUFEDaMpaw=="],
 
@@ -5439,11 +5439,11 @@
 
     "@alchemy.run/rwsdk-template/@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
-    "@alchemy.run/rwsdk-template/miniflare": ["miniflare@4.20260420.0", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "^0.34.5", "undici": "7.24.8", "workerd": "1.20260420.1", "ws": "8.18.0", "youch": "4.1.0-beta.10" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-w8s3eh2W7EEsFh2uGdddZLkbTwiPI8MCSMXKtuLSA9btW8xmQsVVSkrFuLXFyTKcX0QkstS5dhcWjQPQRJ2WKg=="],
+    "@alchemy.run/rwsdk-template/miniflare": ["miniflare@4.20260415.0", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "^0.34.5", "undici": "7.24.8", "workerd": "1.20260415.1", "ws": "8.18.0", "youch": "4.1.0-beta.10" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-JoExRWN4YBI2luA5BoSMFEgi8rQWXUGzo3mtE+58VXCLV3jj/Xnk5Yeqs/IXWz8Es5GJIaq6BtsixDvAxXSIng=="],
 
-    "@alchemy.run/rwsdk-template/wrangler": ["wrangler@4.84.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.4.2", "@cloudflare/unenv-preset": "2.16.0", "blake3-wasm": "2.1.5", "esbuild": "0.27.3", "miniflare": "4.20260420.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260420.1" }, "optionalDependencies": { "fsevents": "~2.3.2" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260420.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-lYScYXeHZ385rDzbTF7QfP4FWu2vQuD7uDQRUjDZuutyq5fZVCR6ZxLLsySbqFiFjvKsF5RoxVPeJtI78blz4w=="],
+    "@alchemy.run/rwsdk-template/wrangler": ["wrangler@4.83.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.4.2", "@cloudflare/unenv-preset": "2.16.0", "blake3-wasm": "2.1.5", "esbuild": "0.27.3", "miniflare": "4.20260415.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260415.1" }, "optionalDependencies": { "fsevents": "~2.3.2" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260415.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-gw5g3LCiuAqVWxaoKY6+quE0HzAUEFb/FV3oAlNkE1ttd4XP3FiV91XDkkzUCcdqxS4WjhQvPhIDBNdhEi8P0A=="],
 
-    "@alchemy.run/sveltekit-template/miniflare": ["miniflare@4.20260420.0", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "^0.34.5", "undici": "7.24.8", "workerd": "1.20260420.1", "ws": "8.18.0", "youch": "4.1.0-beta.10" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-w8s3eh2W7EEsFh2uGdddZLkbTwiPI8MCSMXKtuLSA9btW8xmQsVVSkrFuLXFyTKcX0QkstS5dhcWjQPQRJ2WKg=="],
+    "@alchemy.run/sveltekit-template/miniflare": ["miniflare@4.20260415.0", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "^0.34.5", "undici": "7.24.8", "workerd": "1.20260415.1", "ws": "8.18.0", "youch": "4.1.0-beta.10" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-JoExRWN4YBI2luA5BoSMFEgi8rQWXUGzo3mtE+58VXCLV3jj/Xnk5Yeqs/IXWz8Es5GJIaq6BtsixDvAxXSIng=="],
 
     "@alchemy.run/tanstack-start-template/@cloudflare/vite-plugin": ["@cloudflare/vite-plugin@1.13.13", "", { "dependencies": { "@cloudflare/unenv-preset": "2.7.7", "@remix-run/node-fetch-server": "^0.8.0", "get-port": "^7.1.0", "miniflare": "4.20251008.0", "picocolors": "^1.1.1", "tinyglobby": "^0.2.12", "unenv": "2.0.0-rc.21", "wrangler": "4.43.0", "ws": "8.18.0" }, "peerDependencies": { "vite": "^6.1.0 || ^7.0.0" } }, "sha512-RgyoPy0fzqEETVmhzb2yhr2Jqz2N8dxwhL9+1bDiO0Bajdfb8cCURgBgppcRfmcYKlBTXYl9xvus+nnH5KRmRQ=="],
 
@@ -5865,7 +5865,7 @@
 
     "@redwoodjs/starter-drizzle/rwsdk": ["rwsdk@1.0.0-beta.51", "", { "dependencies": { "@ast-grep/napi": "~0.39.0", "@cloudflare/workers-types": "~4.20260124.0", "@mdx-js/mdx": "~3.1.1", "@puppeteer/browsers": "~2.10.0", "@types/decompress": "~4.2.7", "@types/fs-extra": "~11.0.4", "@types/glob": "^8.1.0", "@types/react": "~19.2.9", "@types/react-dom": "~19.2.3", "@types/react-is": "~19.0.0", "@vitejs/plugin-react": "~5.0.0", "chokidar": "~4.0.0", "debug": "~4.4.0", "decompress": "~4.2.1", "enhanced-resolve": "~5.18.1", "eventsource-parser": "~3.0.0", "execa": "~9.6.0", "find-up": "~8.0.0", "fs-extra": "~11.3.0", "get-port": "^7.1.0", "glob": "~11.1.0", "ignore": "~7.0.4", "jsonc-parser": "~3.3.1", "kysely": "~0.28.2", "kysely-do": "~0.0.1-rc.1", "lodash": "~4.17.23", "magic-string": "~0.30.17", "picocolors": "~1.1.1", "proper-lockfile": "~4.1.2", "puppeteer-core": "~24.22.0", "react-is": "~19.1.0", "rsc-html-stream": "~0.0.6", "server-only": "^0.0.1", "tmp-promise": "~3.0.3", "ts-morph": "~27.0.0", "unique-names-generator": "~4.7.1", "vibe-rules": "~0.3.0", "vite-tsconfig-paths": "~5.1.4" }, "peerDependencies": { "@cloudflare/vite-plugin": "^1.21.2", "capnweb": "~0.2.0", "react": ">=19.2.0-0 <19.3.0 || >=19.3.0-0 <20.0.0", "react-dom": ">=19.2.0-0 <19.3.0 || >=19.3.0-0 <20.0.0", "react-server-dom-webpack": ">=19.2.0-0 <19.3.0 || >=19.3.0-0 <20.0.0", "vite": "^6.2.6 || 7.x", "wrangler": "^4.60.0" }, "bin": { "rw-scripts": "bin/rw-scripts.mjs", "rwsdk": "bin/rw-scripts.mjs", "rwsync": "bin/rwsync" } }, "sha512-K5enSUQ67x5QfiOjo5k4t/OgUS+sIl1XhRhhxt6aQyVIKtb+2zpFNx7SVZqLFvadGhIzojCXNPPjgFbbJu5SsQ=="],
 
-    "@redwoodjs/starter-drizzle/wrangler": ["wrangler@4.84.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.4.2", "@cloudflare/unenv-preset": "2.16.0", "blake3-wasm": "2.1.5", "esbuild": "0.27.3", "miniflare": "4.20260420.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260420.1" }, "optionalDependencies": { "fsevents": "~2.3.2" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260420.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-lYScYXeHZ385rDzbTF7QfP4FWu2vQuD7uDQRUjDZuutyq5fZVCR6ZxLLsySbqFiFjvKsF5RoxVPeJtI78blz4w=="],
+    "@redwoodjs/starter-drizzle/wrangler": ["wrangler@4.83.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.4.2", "@cloudflare/unenv-preset": "2.16.0", "blake3-wasm": "2.1.5", "esbuild": "0.27.3", "miniflare": "4.20260415.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260415.1" }, "optionalDependencies": { "fsevents": "~2.3.2" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260415.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-gw5g3LCiuAqVWxaoKY6+quE0HzAUEFb/FV3oAlNkE1ttd4XP3FiV91XDkkzUCcdqxS4WjhQvPhIDBNdhEi8P0A=="],
 
     "@rollup/plugin-commonjs/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
@@ -5993,7 +5993,7 @@
 
     "alchemy/rwsdk": ["rwsdk@1.0.0-beta.51", "", { "dependencies": { "@ast-grep/napi": "~0.39.0", "@cloudflare/workers-types": "~4.20260124.0", "@mdx-js/mdx": "~3.1.1", "@puppeteer/browsers": "~2.10.0", "@types/decompress": "~4.2.7", "@types/fs-extra": "~11.0.4", "@types/glob": "^8.1.0", "@types/react": "~19.2.9", "@types/react-dom": "~19.2.3", "@types/react-is": "~19.0.0", "@vitejs/plugin-react": "~5.0.0", "chokidar": "~4.0.0", "debug": "~4.4.0", "decompress": "~4.2.1", "enhanced-resolve": "~5.18.1", "eventsource-parser": "~3.0.0", "execa": "~9.6.0", "find-up": "~8.0.0", "fs-extra": "~11.3.0", "get-port": "^7.1.0", "glob": "~11.1.0", "ignore": "~7.0.4", "jsonc-parser": "~3.3.1", "kysely": "~0.28.2", "kysely-do": "~0.0.1-rc.1", "lodash": "~4.17.23", "magic-string": "~0.30.17", "picocolors": "~1.1.1", "proper-lockfile": "~4.1.2", "puppeteer-core": "~24.22.0", "react-is": "~19.1.0", "rsc-html-stream": "~0.0.6", "server-only": "^0.0.1", "tmp-promise": "~3.0.3", "ts-morph": "~27.0.0", "unique-names-generator": "~4.7.1", "vibe-rules": "~0.3.0", "vite-tsconfig-paths": "~5.1.4" }, "peerDependencies": { "@cloudflare/vite-plugin": "^1.21.2", "capnweb": "~0.2.0", "react": ">=19.2.0-0 <19.3.0 || >=19.3.0-0 <20.0.0", "react-dom": ">=19.2.0-0 <19.3.0 || >=19.3.0-0 <20.0.0", "react-server-dom-webpack": ">=19.2.0-0 <19.3.0 || >=19.3.0-0 <20.0.0", "vite": "^6.2.6 || 7.x", "wrangler": "^4.60.0" }, "bin": { "rw-scripts": "bin/rw-scripts.mjs", "rwsdk": "bin/rw-scripts.mjs", "rwsync": "bin/rwsync" } }, "sha512-K5enSUQ67x5QfiOjo5k4t/OgUS+sIl1XhRhhxt6aQyVIKtb+2zpFNx7SVZqLFvadGhIzojCXNPPjgFbbJu5SsQ=="],
 
-    "alchemy/wrangler": ["wrangler@4.84.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.4.2", "@cloudflare/unenv-preset": "2.16.0", "blake3-wasm": "2.1.5", "esbuild": "0.27.3", "miniflare": "4.20260420.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260420.1" }, "optionalDependencies": { "fsevents": "~2.3.2" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260420.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-lYScYXeHZ385rDzbTF7QfP4FWu2vQuD7uDQRUjDZuutyq5fZVCR6ZxLLsySbqFiFjvKsF5RoxVPeJtI78blz4w=="],
+    "alchemy/wrangler": ["wrangler@4.84.1", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.4.2", "@cloudflare/unenv-preset": "2.16.0", "blake3-wasm": "2.1.5", "esbuild": "0.27.3", "miniflare": "4.20260421.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260421.1" }, "optionalDependencies": { "fsevents": "~2.3.2" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260421.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-Xe1S/Bik7pNdtdJ+asHsEZC2dX9k3WxYn2BbxFtOrrLVxN/LKi750zsrjX41jSAk00M/O1l7jzyQV4sQqw8ftg=="],
 
     "alchemy-web/@astrojs/cloudflare": ["@astrojs/cloudflare@12.6.0", "", { "dependencies": { "@astrojs/internal-helpers": "0.6.1", "@astrojs/underscore-redirects": "1.0.0", "@cloudflare/workers-types": "^4.20250507.0", "tinyglobby": "^0.2.13", "vite": "^6.3.5", "wrangler": "^4.14.1" }, "peerDependencies": { "astro": "^5.0.0" } }, "sha512-pQ8bokC59GEiXvyXpC4swBNoL7C/EknP+82KFzQwgR/Aeo5N1oPiAoPHgJbpPya/YF4E26WODdCQfBQDvLRfuw=="],
 
@@ -6123,7 +6123,7 @@
 
     "cloudflare-react-router/cloudflare": ["cloudflare@4.5.0", "", { "dependencies": { "@types/node": "^18.11.18", "@types/node-fetch": "^2.6.4", "abort-controller": "^3.0.0", "agentkeepalive": "^4.2.1", "form-data-encoder": "1.7.2", "formdata-node": "^4.3.2", "node-fetch": "^2.6.7" } }, "sha512-fPcbPKx4zF45jBvQ0z7PCdgejVAPBBCZxwqk1k7krQNfpM07Cfj97/Q6wBzvYqlWXx/zt1S9+m8vnfCe06umbQ=="],
 
-    "cloudflare-react-router/wrangler": ["wrangler@4.84.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.4.2", "@cloudflare/unenv-preset": "2.16.0", "blake3-wasm": "2.1.5", "esbuild": "0.27.3", "miniflare": "4.20260420.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260420.1" }, "optionalDependencies": { "fsevents": "~2.3.2" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260420.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-lYScYXeHZ385rDzbTF7QfP4FWu2vQuD7uDQRUjDZuutyq5fZVCR6ZxLLsySbqFiFjvKsF5RoxVPeJtI78blz4w=="],
+    "cloudflare-react-router/wrangler": ["wrangler@4.83.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.4.2", "@cloudflare/unenv-preset": "2.16.0", "blake3-wasm": "2.1.5", "esbuild": "0.27.3", "miniflare": "4.20260415.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260415.1" }, "optionalDependencies": { "fsevents": "~2.3.2" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260415.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-gw5g3LCiuAqVWxaoKY6+quE0HzAUEFb/FV3oAlNkE1ttd4XP3FiV91XDkkzUCcdqxS4WjhQvPhIDBNdhEi8P0A=="],
 
     "cloudflare-sveltekit/vite": ["vite@6.4.0", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-oLnWs9Hak/LOlKjeSpOwD6JMks8BeICEdYMJBf6P4Lac/pO9tKiv/XhXnAM7nNfSkZahjlCZu9sS50zL8fSnsw=="],
 
@@ -6597,7 +6597,7 @@
 
     "@alchemy.run/rwsdk-template/miniflare/sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
 
-    "@alchemy.run/rwsdk-template/miniflare/workerd": ["workerd@1.20260420.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260420.1", "@cloudflare/workerd-darwin-arm64": "1.20260420.1", "@cloudflare/workerd-linux-64": "1.20260420.1", "@cloudflare/workerd-linux-arm64": "1.20260420.1", "@cloudflare/workerd-windows-64": "1.20260420.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-1AOJgng169u4fiFrEd5WjrAGpdwd3A4ZJtP8PMvf+RF9NUKy+mdwrKdz4qPZ6Tt/Bya99vsLn6UX33fjAEVoaA=="],
+    "@alchemy.run/rwsdk-template/miniflare/workerd": ["workerd@1.20260415.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260415.1", "@cloudflare/workerd-darwin-arm64": "1.20260415.1", "@cloudflare/workerd-linux-64": "1.20260415.1", "@cloudflare/workerd-linux-arm64": "1.20260415.1", "@cloudflare/workerd-windows-64": "1.20260415.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-phyPjRnx+mQDfkhN9ENPioL1L0SdhYs4S0YmJK/xF9Oga+ykNfdSy1MHnsOj8yqnOV96zcVQMx32dJ0r3pq0jQ=="],
 
     "@alchemy.run/rwsdk-template/miniflare/ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
 
@@ -6609,11 +6609,11 @@
 
     "@alchemy.run/rwsdk-template/wrangler/unenv": ["unenv@2.0.0-rc.24", "", { "dependencies": { "pathe": "^2.0.3" } }, "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw=="],
 
-    "@alchemy.run/rwsdk-template/wrangler/workerd": ["workerd@1.20260420.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260420.1", "@cloudflare/workerd-darwin-arm64": "1.20260420.1", "@cloudflare/workerd-linux-64": "1.20260420.1", "@cloudflare/workerd-linux-arm64": "1.20260420.1", "@cloudflare/workerd-windows-64": "1.20260420.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-1AOJgng169u4fiFrEd5WjrAGpdwd3A4ZJtP8PMvf+RF9NUKy+mdwrKdz4qPZ6Tt/Bya99vsLn6UX33fjAEVoaA=="],
+    "@alchemy.run/rwsdk-template/wrangler/workerd": ["workerd@1.20260415.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260415.1", "@cloudflare/workerd-darwin-arm64": "1.20260415.1", "@cloudflare/workerd-linux-64": "1.20260415.1", "@cloudflare/workerd-linux-arm64": "1.20260415.1", "@cloudflare/workerd-windows-64": "1.20260415.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-phyPjRnx+mQDfkhN9ENPioL1L0SdhYs4S0YmJK/xF9Oga+ykNfdSy1MHnsOj8yqnOV96zcVQMx32dJ0r3pq0jQ=="],
 
     "@alchemy.run/sveltekit-template/miniflare/sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
 
-    "@alchemy.run/sveltekit-template/miniflare/workerd": ["workerd@1.20260420.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260420.1", "@cloudflare/workerd-darwin-arm64": "1.20260420.1", "@cloudflare/workerd-linux-64": "1.20260420.1", "@cloudflare/workerd-linux-arm64": "1.20260420.1", "@cloudflare/workerd-windows-64": "1.20260420.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-1AOJgng169u4fiFrEd5WjrAGpdwd3A4ZJtP8PMvf+RF9NUKy+mdwrKdz4qPZ6Tt/Bya99vsLn6UX33fjAEVoaA=="],
+    "@alchemy.run/sveltekit-template/miniflare/workerd": ["workerd@1.20260415.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260415.1", "@cloudflare/workerd-darwin-arm64": "1.20260415.1", "@cloudflare/workerd-linux-64": "1.20260415.1", "@cloudflare/workerd-linux-arm64": "1.20260415.1", "@cloudflare/workerd-windows-64": "1.20260415.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-phyPjRnx+mQDfkhN9ENPioL1L0SdhYs4S0YmJK/xF9Oga+ykNfdSy1MHnsOj8yqnOV96zcVQMx32dJ0r3pq0jQ=="],
 
     "@alchemy.run/sveltekit-template/miniflare/ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
 
@@ -7089,11 +7089,11 @@
 
     "@redwoodjs/starter-drizzle/wrangler/esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
 
-    "@redwoodjs/starter-drizzle/wrangler/miniflare": ["miniflare@4.20260420.0", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "^0.34.5", "undici": "7.24.8", "workerd": "1.20260420.1", "ws": "8.18.0", "youch": "4.1.0-beta.10" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-w8s3eh2W7EEsFh2uGdddZLkbTwiPI8MCSMXKtuLSA9btW8xmQsVVSkrFuLXFyTKcX0QkstS5dhcWjQPQRJ2WKg=="],
+    "@redwoodjs/starter-drizzle/wrangler/miniflare": ["miniflare@4.20260415.0", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "^0.34.5", "undici": "7.24.8", "workerd": "1.20260415.1", "ws": "8.18.0", "youch": "4.1.0-beta.10" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-JoExRWN4YBI2luA5BoSMFEgi8rQWXUGzo3mtE+58VXCLV3jj/Xnk5Yeqs/IXWz8Es5GJIaq6BtsixDvAxXSIng=="],
 
     "@redwoodjs/starter-drizzle/wrangler/unenv": ["unenv@2.0.0-rc.24", "", { "dependencies": { "pathe": "^2.0.3" } }, "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw=="],
 
-    "@redwoodjs/starter-drizzle/wrangler/workerd": ["workerd@1.20260420.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260420.1", "@cloudflare/workerd-darwin-arm64": "1.20260420.1", "@cloudflare/workerd-linux-64": "1.20260420.1", "@cloudflare/workerd-linux-arm64": "1.20260420.1", "@cloudflare/workerd-windows-64": "1.20260420.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-1AOJgng169u4fiFrEd5WjrAGpdwd3A4ZJtP8PMvf+RF9NUKy+mdwrKdz4qPZ6Tt/Bya99vsLn6UX33fjAEVoaA=="],
+    "@redwoodjs/starter-drizzle/wrangler/workerd": ["workerd@1.20260415.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260415.1", "@cloudflare/workerd-darwin-arm64": "1.20260415.1", "@cloudflare/workerd-linux-64": "1.20260415.1", "@cloudflare/workerd-linux-arm64": "1.20260415.1", "@cloudflare/workerd-windows-64": "1.20260415.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-phyPjRnx+mQDfkhN9ENPioL1L0SdhYs4S0YmJK/xF9Oga+ykNfdSy1MHnsOj8yqnOV96zcVQMx32dJ0r3pq0jQ=="],
 
     "@solana/codecs-numbers/@solana/errors/commander": ["commander@14.0.1", "", {}, "sha512-2JkV3gUZUVrbNA+1sjBOYLsMZ5cEEl8GTFP2a4AVz5hvasAMCQ1D2l2le/cX+pV4N6ZU17zjUahLpIXRrnWL8A=="],
 
@@ -7177,11 +7177,11 @@
 
     "alchemy/wrangler/esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
 
-    "alchemy/wrangler/miniflare": ["miniflare@4.20260420.0", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "^0.34.5", "undici": "7.24.8", "workerd": "1.20260420.1", "ws": "8.18.0", "youch": "4.1.0-beta.10" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-w8s3eh2W7EEsFh2uGdddZLkbTwiPI8MCSMXKtuLSA9btW8xmQsVVSkrFuLXFyTKcX0QkstS5dhcWjQPQRJ2WKg=="],
+    "alchemy/wrangler/miniflare": ["miniflare@4.20260421.0", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "^0.34.5", "undici": "7.24.8", "workerd": "1.20260421.1", "ws": "8.18.0", "youch": "4.1.0-beta.10" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-7ZkNQ7brgQ2hh5ha9iQCDUjxBkLvuiG2VdDns9esRL8O8lXg+MoP6E0dO1rtp+ZY2I+vV1tPWr6td5IojkewLw=="],
 
     "alchemy/wrangler/unenv": ["unenv@2.0.0-rc.24", "", { "dependencies": { "pathe": "^2.0.3" } }, "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw=="],
 
-    "alchemy/wrangler/workerd": ["workerd@1.20260420.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260420.1", "@cloudflare/workerd-darwin-arm64": "1.20260420.1", "@cloudflare/workerd-linux-64": "1.20260420.1", "@cloudflare/workerd-linux-arm64": "1.20260420.1", "@cloudflare/workerd-windows-64": "1.20260420.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-1AOJgng169u4fiFrEd5WjrAGpdwd3A4ZJtP8PMvf+RF9NUKy+mdwrKdz4qPZ6Tt/Bya99vsLn6UX33fjAEVoaA=="],
+    "alchemy/wrangler/workerd": ["workerd@1.20260421.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260421.1", "@cloudflare/workerd-darwin-arm64": "1.20260421.1", "@cloudflare/workerd-linux-64": "1.20260421.1", "@cloudflare/workerd-linux-arm64": "1.20260421.1", "@cloudflare/workerd-windows-64": "1.20260421.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-zTYD+xFR4d7TUCxsyl7FTPth9a8CDgk8pM7xUWbJxo0SGUx+2e5C7Q5LrramBZwmuAErtzXmOjlQ15PtkPAhZA=="],
 
     "archiver-utils/glob/jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
 
@@ -7385,11 +7385,11 @@
 
     "cloudflare-react-router/wrangler/esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
 
-    "cloudflare-react-router/wrangler/miniflare": ["miniflare@4.20260420.0", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "^0.34.5", "undici": "7.24.8", "workerd": "1.20260420.1", "ws": "8.18.0", "youch": "4.1.0-beta.10" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-w8s3eh2W7EEsFh2uGdddZLkbTwiPI8MCSMXKtuLSA9btW8xmQsVVSkrFuLXFyTKcX0QkstS5dhcWjQPQRJ2WKg=="],
+    "cloudflare-react-router/wrangler/miniflare": ["miniflare@4.20260415.0", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "^0.34.5", "undici": "7.24.8", "workerd": "1.20260415.1", "ws": "8.18.0", "youch": "4.1.0-beta.10" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-JoExRWN4YBI2luA5BoSMFEgi8rQWXUGzo3mtE+58VXCLV3jj/Xnk5Yeqs/IXWz8Es5GJIaq6BtsixDvAxXSIng=="],
 
     "cloudflare-react-router/wrangler/unenv": ["unenv@2.0.0-rc.24", "", { "dependencies": { "pathe": "^2.0.3" } }, "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw=="],
 
-    "cloudflare-react-router/wrangler/workerd": ["workerd@1.20260420.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260420.1", "@cloudflare/workerd-darwin-arm64": "1.20260420.1", "@cloudflare/workerd-linux-64": "1.20260420.1", "@cloudflare/workerd-linux-arm64": "1.20260420.1", "@cloudflare/workerd-windows-64": "1.20260420.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-1AOJgng169u4fiFrEd5WjrAGpdwd3A4ZJtP8PMvf+RF9NUKy+mdwrKdz4qPZ6Tt/Bya99vsLn6UX33fjAEVoaA=="],
+    "cloudflare-react-router/wrangler/workerd": ["workerd@1.20260415.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260415.1", "@cloudflare/workerd-darwin-arm64": "1.20260415.1", "@cloudflare/workerd-linux-64": "1.20260415.1", "@cloudflare/workerd-linux-arm64": "1.20260415.1", "@cloudflare/workerd-windows-64": "1.20260415.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-phyPjRnx+mQDfkhN9ENPioL1L0SdhYs4S0YmJK/xF9Oga+ykNfdSy1MHnsOj8yqnOV96zcVQMx32dJ0r3pq0jQ=="],
 
     "cloudflare-vite-container/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
@@ -7817,15 +7817,15 @@
 
     "@alchemy.run/rwsdk-template/miniflare/sharp/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
 
-    "@alchemy.run/rwsdk-template/miniflare/workerd/@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260420.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-Y6HtAY+pS5INiD9HyO1JvvujZO24mD3eqRwPZlLXBkcT+wW8bTOve/8mVKErEzEtZ5LkuT3tJqG9py8TxQEBgw=="],
+    "@alchemy.run/rwsdk-template/miniflare/workerd/@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260415.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-dsxaKsQm3LnPGNPEdsRv09QN3Y4DqCw7kX5j6noKqbAtro2jTr95sVlYM1jUxZ5FkOl1f7SXgaKKB9t5H5Nkbg=="],
 
-    "@alchemy.run/rwsdk-template/miniflare/workerd/@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260420.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-7aiRtZTc5S4aKcL6uIx+B3tCzb/bULjQmE67/03k0HtaDNzP20GnYmYpFCqleFqsdmIb4Tx8PkKPmsXI3AJLvQ=="],
+    "@alchemy.run/rwsdk-template/miniflare/workerd/@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260415.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-+JgSgVA49KyKteHRA1SnonE4Zn5Ei5zdAp5FQMxFmXI8qulZw4Hl7safXxRyK4i9sTO8gl7TFOKO5Q64VPvSDQ=="],
 
-    "@alchemy.run/rwsdk-template/miniflare/workerd/@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260420.1", "", { "os": "linux", "cpu": "x64" }, "sha512-J/DW149FPmug1wSM32zBF7My14xg+inIYwzS4bSAxyXR6tBiTxbhgFWQQz99nt08ZMstdKHRD6f6C/KQaleQcA=="],
+    "@alchemy.run/rwsdk-template/miniflare/workerd/@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260415.1", "", { "os": "linux", "cpu": "x64" }, "sha512-tU+9pwsqCy8afOVlGtiWrWQc/fedQK4SRm4KPIAt+zOiQWDxWASm6YGBUJis5c648WN80yz47qnmdDi8DQNOcA=="],
 
-    "@alchemy.run/rwsdk-template/miniflare/workerd/@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260420.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-a5I147McRM/L4YHu9EwOsoAyIExZndPRQoLx/33dbw/yUEnO825gvn5QZkCGXBVL2JwsPAyowB0Xliqrj+71Sw=="],
+    "@alchemy.run/rwsdk-template/miniflare/workerd/@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260415.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-bR9uITnV19r5NQ14xnypi2xHXu2iQvfYV8cVgx0JouFUmWwTEEAwFVojDdssGq93VHX9hr/pi2IRUZeegbYBog=="],
 
-    "@alchemy.run/rwsdk-template/miniflare/workerd/@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260420.1", "", { "os": "win32", "cpu": "x64" }, "sha512-ZrHqlHbJNU8P24EAOBaZ6B44G9P+po2z0DBwbAr8965aWR+vohy3cfmgE9uzNPAQfKNmvq7fmc4VwsRpERkg0w=="],
+    "@alchemy.run/rwsdk-template/miniflare/workerd/@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260415.1", "", { "os": "win32", "cpu": "x64" }, "sha512-4NuMLlerI0Ijua3Ir8HXQ+qyNvCUDEG5gDco5Om+sAiK6rnWiz+aGoSlbB8W16yW9QAgzCstbmXLiVknUBflfQ=="],
 
     "@alchemy.run/rwsdk-template/wrangler/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.3", "", { "os": "aix", "cpu": "ppc64" }, "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg=="],
 
@@ -7879,15 +7879,15 @@
 
     "@alchemy.run/rwsdk-template/wrangler/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.3", "", { "os": "win32", "cpu": "x64" }, "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA=="],
 
-    "@alchemy.run/rwsdk-template/wrangler/workerd/@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260420.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-Y6HtAY+pS5INiD9HyO1JvvujZO24mD3eqRwPZlLXBkcT+wW8bTOve/8mVKErEzEtZ5LkuT3tJqG9py8TxQEBgw=="],
+    "@alchemy.run/rwsdk-template/wrangler/workerd/@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260415.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-dsxaKsQm3LnPGNPEdsRv09QN3Y4DqCw7kX5j6noKqbAtro2jTr95sVlYM1jUxZ5FkOl1f7SXgaKKB9t5H5Nkbg=="],
 
-    "@alchemy.run/rwsdk-template/wrangler/workerd/@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260420.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-7aiRtZTc5S4aKcL6uIx+B3tCzb/bULjQmE67/03k0HtaDNzP20GnYmYpFCqleFqsdmIb4Tx8PkKPmsXI3AJLvQ=="],
+    "@alchemy.run/rwsdk-template/wrangler/workerd/@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260415.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-+JgSgVA49KyKteHRA1SnonE4Zn5Ei5zdAp5FQMxFmXI8qulZw4Hl7safXxRyK4i9sTO8gl7TFOKO5Q64VPvSDQ=="],
 
-    "@alchemy.run/rwsdk-template/wrangler/workerd/@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260420.1", "", { "os": "linux", "cpu": "x64" }, "sha512-J/DW149FPmug1wSM32zBF7My14xg+inIYwzS4bSAxyXR6tBiTxbhgFWQQz99nt08ZMstdKHRD6f6C/KQaleQcA=="],
+    "@alchemy.run/rwsdk-template/wrangler/workerd/@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260415.1", "", { "os": "linux", "cpu": "x64" }, "sha512-tU+9pwsqCy8afOVlGtiWrWQc/fedQK4SRm4KPIAt+zOiQWDxWASm6YGBUJis5c648WN80yz47qnmdDi8DQNOcA=="],
 
-    "@alchemy.run/rwsdk-template/wrangler/workerd/@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260420.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-a5I147McRM/L4YHu9EwOsoAyIExZndPRQoLx/33dbw/yUEnO825gvn5QZkCGXBVL2JwsPAyowB0Xliqrj+71Sw=="],
+    "@alchemy.run/rwsdk-template/wrangler/workerd/@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260415.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-bR9uITnV19r5NQ14xnypi2xHXu2iQvfYV8cVgx0JouFUmWwTEEAwFVojDdssGq93VHX9hr/pi2IRUZeegbYBog=="],
 
-    "@alchemy.run/rwsdk-template/wrangler/workerd/@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260420.1", "", { "os": "win32", "cpu": "x64" }, "sha512-ZrHqlHbJNU8P24EAOBaZ6B44G9P+po2z0DBwbAr8965aWR+vohy3cfmgE9uzNPAQfKNmvq7fmc4VwsRpERkg0w=="],
+    "@alchemy.run/rwsdk-template/wrangler/workerd/@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260415.1", "", { "os": "win32", "cpu": "x64" }, "sha512-4NuMLlerI0Ijua3Ir8HXQ+qyNvCUDEG5gDco5Om+sAiK6rnWiz+aGoSlbB8W16yW9QAgzCstbmXLiVknUBflfQ=="],
 
     "@alchemy.run/sveltekit-template/miniflare/sharp/@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
 
@@ -7935,15 +7935,15 @@
 
     "@alchemy.run/sveltekit-template/miniflare/sharp/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
 
-    "@alchemy.run/sveltekit-template/miniflare/workerd/@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260420.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-Y6HtAY+pS5INiD9HyO1JvvujZO24mD3eqRwPZlLXBkcT+wW8bTOve/8mVKErEzEtZ5LkuT3tJqG9py8TxQEBgw=="],
+    "@alchemy.run/sveltekit-template/miniflare/workerd/@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260415.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-dsxaKsQm3LnPGNPEdsRv09QN3Y4DqCw7kX5j6noKqbAtro2jTr95sVlYM1jUxZ5FkOl1f7SXgaKKB9t5H5Nkbg=="],
 
-    "@alchemy.run/sveltekit-template/miniflare/workerd/@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260420.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-7aiRtZTc5S4aKcL6uIx+B3tCzb/bULjQmE67/03k0HtaDNzP20GnYmYpFCqleFqsdmIb4Tx8PkKPmsXI3AJLvQ=="],
+    "@alchemy.run/sveltekit-template/miniflare/workerd/@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260415.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-+JgSgVA49KyKteHRA1SnonE4Zn5Ei5zdAp5FQMxFmXI8qulZw4Hl7safXxRyK4i9sTO8gl7TFOKO5Q64VPvSDQ=="],
 
-    "@alchemy.run/sveltekit-template/miniflare/workerd/@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260420.1", "", { "os": "linux", "cpu": "x64" }, "sha512-J/DW149FPmug1wSM32zBF7My14xg+inIYwzS4bSAxyXR6tBiTxbhgFWQQz99nt08ZMstdKHRD6f6C/KQaleQcA=="],
+    "@alchemy.run/sveltekit-template/miniflare/workerd/@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260415.1", "", { "os": "linux", "cpu": "x64" }, "sha512-tU+9pwsqCy8afOVlGtiWrWQc/fedQK4SRm4KPIAt+zOiQWDxWASm6YGBUJis5c648WN80yz47qnmdDi8DQNOcA=="],
 
-    "@alchemy.run/sveltekit-template/miniflare/workerd/@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260420.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-a5I147McRM/L4YHu9EwOsoAyIExZndPRQoLx/33dbw/yUEnO825gvn5QZkCGXBVL2JwsPAyowB0Xliqrj+71Sw=="],
+    "@alchemy.run/sveltekit-template/miniflare/workerd/@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260415.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-bR9uITnV19r5NQ14xnypi2xHXu2iQvfYV8cVgx0JouFUmWwTEEAwFVojDdssGq93VHX9hr/pi2IRUZeegbYBog=="],
 
-    "@alchemy.run/sveltekit-template/miniflare/workerd/@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260420.1", "", { "os": "win32", "cpu": "x64" }, "sha512-ZrHqlHbJNU8P24EAOBaZ6B44G9P+po2z0DBwbAr8965aWR+vohy3cfmgE9uzNPAQfKNmvq7fmc4VwsRpERkg0w=="],
+    "@alchemy.run/sveltekit-template/miniflare/workerd/@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260415.1", "", { "os": "win32", "cpu": "x64" }, "sha512-4NuMLlerI0Ijua3Ir8HXQ+qyNvCUDEG5gDco5Om+sAiK6rnWiz+aGoSlbB8W16yW9QAgzCstbmXLiVknUBflfQ=="],
 
     "@alchemy.run/tanstack-start-template/@cloudflare/vite-plugin/miniflare/acorn": ["acorn@8.14.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA=="],
 
@@ -8303,15 +8303,15 @@
 
     "@redwoodjs/starter-drizzle/wrangler/miniflare/ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
 
-    "@redwoodjs/starter-drizzle/wrangler/workerd/@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260420.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-Y6HtAY+pS5INiD9HyO1JvvujZO24mD3eqRwPZlLXBkcT+wW8bTOve/8mVKErEzEtZ5LkuT3tJqG9py8TxQEBgw=="],
+    "@redwoodjs/starter-drizzle/wrangler/workerd/@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260415.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-dsxaKsQm3LnPGNPEdsRv09QN3Y4DqCw7kX5j6noKqbAtro2jTr95sVlYM1jUxZ5FkOl1f7SXgaKKB9t5H5Nkbg=="],
 
-    "@redwoodjs/starter-drizzle/wrangler/workerd/@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260420.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-7aiRtZTc5S4aKcL6uIx+B3tCzb/bULjQmE67/03k0HtaDNzP20GnYmYpFCqleFqsdmIb4Tx8PkKPmsXI3AJLvQ=="],
+    "@redwoodjs/starter-drizzle/wrangler/workerd/@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260415.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-+JgSgVA49KyKteHRA1SnonE4Zn5Ei5zdAp5FQMxFmXI8qulZw4Hl7safXxRyK4i9sTO8gl7TFOKO5Q64VPvSDQ=="],
 
-    "@redwoodjs/starter-drizzle/wrangler/workerd/@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260420.1", "", { "os": "linux", "cpu": "x64" }, "sha512-J/DW149FPmug1wSM32zBF7My14xg+inIYwzS4bSAxyXR6tBiTxbhgFWQQz99nt08ZMstdKHRD6f6C/KQaleQcA=="],
+    "@redwoodjs/starter-drizzle/wrangler/workerd/@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260415.1", "", { "os": "linux", "cpu": "x64" }, "sha512-tU+9pwsqCy8afOVlGtiWrWQc/fedQK4SRm4KPIAt+zOiQWDxWASm6YGBUJis5c648WN80yz47qnmdDi8DQNOcA=="],
 
-    "@redwoodjs/starter-drizzle/wrangler/workerd/@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260420.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-a5I147McRM/L4YHu9EwOsoAyIExZndPRQoLx/33dbw/yUEnO825gvn5QZkCGXBVL2JwsPAyowB0Xliqrj+71Sw=="],
+    "@redwoodjs/starter-drizzle/wrangler/workerd/@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260415.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-bR9uITnV19r5NQ14xnypi2xHXu2iQvfYV8cVgx0JouFUmWwTEEAwFVojDdssGq93VHX9hr/pi2IRUZeegbYBog=="],
 
-    "@redwoodjs/starter-drizzle/wrangler/workerd/@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260420.1", "", { "os": "win32", "cpu": "x64" }, "sha512-ZrHqlHbJNU8P24EAOBaZ6B44G9P+po2z0DBwbAr8965aWR+vohy3cfmgE9uzNPAQfKNmvq7fmc4VwsRpERkg0w=="],
+    "@redwoodjs/starter-drizzle/wrangler/workerd/@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260415.1", "", { "os": "win32", "cpu": "x64" }, "sha512-4NuMLlerI0Ijua3Ir8HXQ+qyNvCUDEG5gDco5Om+sAiK6rnWiz+aGoSlbB8W16yW9QAgzCstbmXLiVknUBflfQ=="],
 
     "@tanstack/router-plugin/chokidar/readdirp/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
@@ -8477,15 +8477,15 @@
 
     "alchemy/wrangler/miniflare/ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
 
-    "alchemy/wrangler/workerd/@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260420.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-Y6HtAY+pS5INiD9HyO1JvvujZO24mD3eqRwPZlLXBkcT+wW8bTOve/8mVKErEzEtZ5LkuT3tJqG9py8TxQEBgw=="],
+    "alchemy/wrangler/workerd/@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260421.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-DLU5ZTZ1VHeZZnj0PuVJEMHKGisfLe2XShyImP5P/PPj/m/t7CLEJmPiI7FMxvT7ynArkckJl7m+Z5x7u4Kkdw=="],
 
-    "alchemy/wrangler/workerd/@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260420.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-7aiRtZTc5S4aKcL6uIx+B3tCzb/bULjQmE67/03k0HtaDNzP20GnYmYpFCqleFqsdmIb4Tx8PkKPmsXI3AJLvQ=="],
+    "alchemy/wrangler/workerd/@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260421.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Trotq3xRAkIcpC505WoxM8+kIH4JIvOJCNuRatyHcz9uF5S+ukgiVUFUlM+GIjw1uCM/Bda2St+vSniX1RZdpw=="],
 
-    "alchemy/wrangler/workerd/@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260420.1", "", { "os": "linux", "cpu": "x64" }, "sha512-J/DW149FPmug1wSM32zBF7My14xg+inIYwzS4bSAxyXR6tBiTxbhgFWQQz99nt08ZMstdKHRD6f6C/KQaleQcA=="],
+    "alchemy/wrangler/workerd/@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260421.1", "", { "os": "linux", "cpu": "x64" }, "sha512-938QjUv0z+QqK6BAvgwX/lCIZ2b224ZXoXtGTbhyNVMhB+mt4Dj24cj9qca4ekNXjVM7uTKp1yOHZO97fVSacw=="],
 
-    "alchemy/wrangler/workerd/@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260420.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-a5I147McRM/L4YHu9EwOsoAyIExZndPRQoLx/33dbw/yUEnO825gvn5QZkCGXBVL2JwsPAyowB0Xliqrj+71Sw=="],
+    "alchemy/wrangler/workerd/@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260421.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-YI4+mLfwnJcKJ+iPyxzx+tp2Jy4o29BxBPSQGZxl/AZyvZ9eTKsmNZmtjEiT4i3O/M0tdO/B/d9ESDHbRCs2rQ=="],
 
-    "alchemy/wrangler/workerd/@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260420.1", "", { "os": "win32", "cpu": "x64" }, "sha512-ZrHqlHbJNU8P24EAOBaZ6B44G9P+po2z0DBwbAr8965aWR+vohy3cfmgE9uzNPAQfKNmvq7fmc4VwsRpERkg0w=="],
+    "alchemy/wrangler/workerd/@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260421.1", "", { "os": "win32", "cpu": "x64" }, "sha512-q1SFgwlNH9lFmw74vh7EJbJtduo92Nx51mNOfd3/u6pux6AldcwRviYzKEEv3FEbtv6OBB7J8D5f8vtZj7Z6Sg=="],
 
     "archiver-utils/glob/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
@@ -8641,15 +8641,15 @@
 
     "cloudflare-react-router/wrangler/miniflare/ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
 
-    "cloudflare-react-router/wrangler/workerd/@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260420.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-Y6HtAY+pS5INiD9HyO1JvvujZO24mD3eqRwPZlLXBkcT+wW8bTOve/8mVKErEzEtZ5LkuT3tJqG9py8TxQEBgw=="],
+    "cloudflare-react-router/wrangler/workerd/@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260415.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-dsxaKsQm3LnPGNPEdsRv09QN3Y4DqCw7kX5j6noKqbAtro2jTr95sVlYM1jUxZ5FkOl1f7SXgaKKB9t5H5Nkbg=="],
 
-    "cloudflare-react-router/wrangler/workerd/@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260420.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-7aiRtZTc5S4aKcL6uIx+B3tCzb/bULjQmE67/03k0HtaDNzP20GnYmYpFCqleFqsdmIb4Tx8PkKPmsXI3AJLvQ=="],
+    "cloudflare-react-router/wrangler/workerd/@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260415.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-+JgSgVA49KyKteHRA1SnonE4Zn5Ei5zdAp5FQMxFmXI8qulZw4Hl7safXxRyK4i9sTO8gl7TFOKO5Q64VPvSDQ=="],
 
-    "cloudflare-react-router/wrangler/workerd/@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260420.1", "", { "os": "linux", "cpu": "x64" }, "sha512-J/DW149FPmug1wSM32zBF7My14xg+inIYwzS4bSAxyXR6tBiTxbhgFWQQz99nt08ZMstdKHRD6f6C/KQaleQcA=="],
+    "cloudflare-react-router/wrangler/workerd/@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260415.1", "", { "os": "linux", "cpu": "x64" }, "sha512-tU+9pwsqCy8afOVlGtiWrWQc/fedQK4SRm4KPIAt+zOiQWDxWASm6YGBUJis5c648WN80yz47qnmdDi8DQNOcA=="],
 
-    "cloudflare-react-router/wrangler/workerd/@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260420.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-a5I147McRM/L4YHu9EwOsoAyIExZndPRQoLx/33dbw/yUEnO825gvn5QZkCGXBVL2JwsPAyowB0Xliqrj+71Sw=="],
+    "cloudflare-react-router/wrangler/workerd/@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260415.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-bR9uITnV19r5NQ14xnypi2xHXu2iQvfYV8cVgx0JouFUmWwTEEAwFVojDdssGq93VHX9hr/pi2IRUZeegbYBog=="],
 
-    "cloudflare-react-router/wrangler/workerd/@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260420.1", "", { "os": "win32", "cpu": "x64" }, "sha512-ZrHqlHbJNU8P24EAOBaZ6B44G9P+po2z0DBwbAr8965aWR+vohy3cfmgE9uzNPAQfKNmvq7fmc4VwsRpERkg0w=="],
+    "cloudflare-react-router/wrangler/workerd/@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260415.1", "", { "os": "win32", "cpu": "x64" }, "sha512-4NuMLlerI0Ijua3Ir8HXQ+qyNvCUDEG5gDco5Om+sAiK6rnWiz+aGoSlbB8W16yW9QAgzCstbmXLiVknUBflfQ=="],
 
     "cloudflare-vite-container/cloudflare/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
 

--- a/examples/cloudflare-ai-search/README.md
+++ b/examples/cloudflare-ai-search/README.md
@@ -1,0 +1,52 @@
+# cloudflare-ai-search
+
+Example project demonstrating Cloudflare AI Search (formerly AutoRAG) with Alchemy.
+
+Covers:
+
+- Creating an AI Search instance backed by an R2 bucket
+- Seeding the bucket with text documents
+- Creating an AI Search namespace
+- Binding the AI Search instance to a Worker as both a direct binding (`ai_search`) and a namespace binding (`ai_search_namespaces`)
+- Using the legacy `env.AI.autorag()` path for comparison
+
+## Prerequisites
+
+Set your Cloudflare API token in `.env` at the repo root:
+
+```sh
+CLOUDFLARE_API_TOKEN=your-api-token
+```
+
+## Deploy
+
+```sh
+bun run deploy
+```
+
+The script logs the Worker URL when done.
+
+## Endpoints
+
+- `GET /search?q=<query>` — AI Search single-instance binding
+- `GET /ns-search?q=<query>&instance=<name>` — AI Search namespace binding
+- `GET /list` — List instances in the namespace
+- `POST /upload` (multipart form with a `file` field) — upload a document to the single-instance binding
+- `GET /legacy/query?q=<query>` — Legacy `env.AI.autorag()` path
+
+## Tear Down
+
+```sh
+bun run destroy
+```
+
+## Local Dev
+
+> Note: AI Search bindings are not natively supported by Miniflare. In
+> `alchemy dev` they are proxied to the deployed instance via the
+> remote-binding-proxy worker, so the bindings only work after you've run
+> `alchemy deploy` at least once.
+
+```sh
+bun run dev
+```

--- a/examples/cloudflare-ai-search/alchemy.run.ts
+++ b/examples/cloudflare-ai-search/alchemy.run.ts
@@ -1,5 +1,11 @@
 import alchemy from "alchemy";
-import { Ai, AiSearch, R2Bucket, Worker } from "alchemy/cloudflare";
+import {
+  Ai,
+  AiSearch,
+  AiSearchNamespace,
+  R2Bucket,
+  Worker,
+} from "alchemy/cloudflare";
 
 export const app = await alchemy("cloudflare-ai-search");
 
@@ -35,13 +41,23 @@ const search = await AiSearch("search", {
   adopt: true,
 });
 
-await bucket.list().then((list) => {
-  console.log(list.objects.map((o) => o.key));
+// Create a namespace for dynamic instance access. Omitting `name` lets
+// Alchemy derive a stage-scoped physical name (`${app}-${stage}-docs`) so
+// concurrent stage/branch deploys don't collide on a single global name.
+const ns = await AiSearchNamespace("docs", {
+  adopt: true,
 });
+
+const list = await bucket.list();
+console.log(list.objects.map((o) => o.key));
 
 export const worker = await Worker("worker", {
   entrypoint: "src/worker.ts",
   bindings: {
+    // New: AI Search bindings (recommended)
+    SEARCH: search, // Single instance binding (ai_search)
+    DOCS: ns, // Namespace binding (ai_search_namespaces)
+    // Legacy: AI binding with autorag() (still works)
     AI: Ai(),
     RAG_ID: search.id,
   },

--- a/examples/cloudflare-ai-search/e2e.test.ts
+++ b/examples/cloudflare-ai-search/e2e.test.ts
@@ -8,6 +8,7 @@ export async function test(props: { url: string }) {
     description: "wait for worker to be ready",
     fn: () => fetch(props.url),
     predicate: (res) => res.ok,
+    timeout: 90_000,
   });
   console.log("worker ready");
   await poll({
@@ -16,27 +17,67 @@ export async function test(props: { url: string }) {
       const url = new URL(props.url);
       url.pathname = "/search";
       url.searchParams.set("q", "What is the capital of France?");
-      console.log(url.href);
       return fetch(url);
     },
-    predicate: (res) => {
-      console.log(res);
-      return res.ok;
-    },
+    predicate: (res) => res.ok,
     initialDelay: 5000,
     maxDelay: 10_000,
+    timeout: 8 * 60_000,
   });
   console.log("index ready");
-  const url = new URL(props.url);
-  url.pathname = "/query";
-  url.searchParams.set("q", "What is the capital of France?");
-  const response = await fetch(url);
-  const result = (await response.json()) as AutoRagAiSearchResponse;
-  assert(
-    result.response.includes("Paris"),
-    `Paris is not in the response: ${result.response}`,
-  );
-  assert(result.data.length > 0, "No data returned");
-  assert.equal(result.data[0].filename, "france.txt");
+
+  // 1. /legacy/query — legacy AI.autorag() path
+  {
+    const url = new URL(props.url);
+    url.pathname = "/legacy/query";
+    url.searchParams.set("q", "What is the capital of France?");
+    const response = await fetch(url);
+    const result = (await response.json()) as AutoRagAiSearchResponse;
+    assert(
+      result.response.includes("Paris"),
+      `Paris is not in the response: ${result.response}`,
+    );
+    assert(result.data.length > 0, "No data returned");
+    assert.equal(result.data[0].filename, "france.txt");
+    console.log("legacy/query: success");
+  }
+
+  // 2. /search — ai_search binding
+  {
+    const url = new URL(props.url);
+    url.pathname = "/search";
+    url.searchParams.set("q", "What is the capital of France?");
+    const response = await fetch(url);
+    assert(response.ok, `/search failed: ${response.status}`);
+    const result = (await response.json()) as {
+      chunks?: Array<{ text?: string }>;
+    };
+    assert((result.chunks?.length ?? 0) > 0, "/search returned no chunks");
+    // Parity with the legacy path: verify the retrieved chunks actually
+    // surface "Paris" from the seeded `france.txt` document. Without this,
+    // the assertion was only checking that *some* chunk came back, which
+    // could succeed even if the ranking was completely broken.
+    assert(
+      result.chunks!.some((c) => c.text?.toLowerCase().includes("paris")),
+      `/search did not surface "Paris" in any chunk: ${JSON.stringify(result.chunks)}`,
+    );
+    console.log("/search: success");
+  }
+
+  // 3. /list — ai_search_namespaces binding
+  {
+    const url = new URL(props.url);
+    url.pathname = "/list";
+    const response = await fetch(url);
+    assert(response.ok, `/list failed: ${response.status}`);
+    const result = (await response.json()) as {
+      result?: Array<{ id: string }>;
+    };
+    // result.result may be empty if the namespace has no instances yet,
+    // but the call must succeed.
+    assert(Array.isArray(result.result), "/list did not return an array");
+    console.log("/list: success");
+  }
+
   console.log("success");
 }

--- a/examples/cloudflare-ai-search/src/worker.ts
+++ b/examples/cloudflare-ai-search/src/worker.ts
@@ -3,26 +3,62 @@ import type { worker } from "../alchemy.run.ts";
 export default {
   async fetch(request: Request, env: typeof worker.Env) {
     const url = new URL(request.url);
-    if (url.pathname === "/list") {
-      const result = await env.AI.autorag(env.RAG_ID).list();
+    const query = url.searchParams.get("q");
+
+    // ── New AI Search Binding (recommended) ──────────────────────
+    // Direct access via the ai_search binding — no AI binding needed
+    if (url.pathname === "/search" && query) {
+      const result = await env.SEARCH.search({
+        query,
+      });
       return Response.json(result);
     }
-    const query = url.searchParams.get("q");
-    if (url.pathname === "/query" && query) {
+
+    // ── Namespace binding — dynamic instance access ──────────────
+    // Access any instance in the namespace at runtime
+    if (url.pathname === "/ns-search" && query) {
+      const instanceName = url.searchParams.get("instance") || "search";
+      const result = await env.DOCS.get(instanceName).search({
+        query,
+      });
+      return Response.json(result);
+    }
+
+    // ── List instances in the namespace ──────────────────────────
+    if (url.pathname === "/list") {
+      const instances = await env.DOCS.list();
+      return Response.json(instances);
+    }
+
+    // ── Upload a file into the ai_search binding ─────────────────
+    // POST a multipart form with a `file` field.
+    if (url.pathname === "/upload" && request.method === "POST") {
+      const form = await request.formData();
+      const file = form.get("file");
+      if (!(file instanceof File)) {
+        return new Response("No `file` field in form data", { status: 400 });
+      }
+      const item = await env.SEARCH.items.upload(file.name, file);
+      return Response.json({ uploaded: file.name, status: item.status });
+    }
+
+    // ── Legacy: AI binding with autorag() (still works) ─────────
+    if (url.pathname === "/legacy/query" && query) {
       const result = await env.AI.autorag(env.RAG_ID).aiSearch({
         query,
       });
-      return Response.json(result, {
-        status: result.data.length > 0 ? 200 : 400,
-      });
-    } else if (url.pathname === "/search" && query) {
-      const result = await env.AI.autorag(env.RAG_ID).search({
-        query,
-      });
-      return Response.json(result, {
-        status: result.data.length > 0 ? 200 : 400,
-      });
+      // Empty results are a "no-match" response, not a client error —
+      // return 200 with the payload so callers can inspect `result.data`.
+      return Response.json(result);
     }
-    return new Response("Usage: /query?q=... or /search?q=...");
+
+    return new Response(
+      "Usage:\n" +
+        "  /search?q=...           — AI Search binding\n" +
+        "  /ns-search?q=...&instance=... — Namespace binding\n" +
+        "  /list                   — List instances in namespace\n" +
+        "  /upload (POST form data with `file`) — Upload a file\n" +
+        "  /legacy/query?q=...     — Legacy AI.autorag()\n",
+    );
   },
 };

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
       "@cloudflare/vite-plugin": "^1.21.2",
       "vite": "^7.1.9",
       "typescript": "^5.8.3",
-      "wrangler": "^4.70.0"
+      "wrangler": "^4.83.0"
     },
     "packages": [
       "alchemy-web",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     { "path": "./alchemy/tsconfig.test.json" },
     { "path": "./stacks/tsconfig.json" },
     { "path": "./examples/aws-app/tsconfig.json" },
+    { "path": "./examples/cloudflare-ai-search/tsconfig.json" },
     { "path": "./examples/cloudflare-astro/tsconfig.json" },
     { "path": "./examples/cloudflare-container/tsconfig.json" },
     { "path": "./examples/cloudflare-durable-object-websocket/tsconfig.json" },


### PR DESCRIPTION
## Summary

Adds `AiSearchNamespace` resource and the two official Cloudflare AI Search worker bindings (`ai_search` and `ai_search_namespace`), replacing the legacy `env.AI.autorag()` path.

## New resources & bindings

- **`AiSearchNamespace` resource** — CRUD lifecycle for AI Search namespaces, with support for:
  - `adopt: true` (pre-flight existence check, not status-code matching — no false positives on unrelated 400s)
  - Rename triggers replace (delete old + create new at scope finalize)
  - `delete: false` opt-out
  - The reserved `"default"` namespace (adopt-only; delete is silently skipped since it cannot be deleted via the API)
  - Three-way semantics on `description`: absent = leave untouched, `string` = set, `null` = explicit clear
- **`ai_search` Worker binding** — binds directly to a single AI Search instance. `Bound<AiSearch>` maps to the runtime `AiSearchInstance` class from `@cloudflare/workers-types`.
- **`ai_search_namespace` Worker binding** — scoped to a namespace for dynamic multi-instance access. `get(id) / list() / create() / delete() / search() / chatCompletions()` at runtime. `Bound<AiSearchNamespace>` maps to the runtime `AiSearchNamespace` class (name-collision handled via `_`-prefixed import aliases).

## `AiSearch` updates

- **Source is now optional** — omit `source` for a built-in-storage instance that accepts manual uploads via the items API.
- **`namespace: string | AiSearchNamespace`** prop (defaults to `"default"`); changing it on an existing instance triggers a replace.
- **Service tokens are only auto-created for R2 sources** — web-crawler and sourceless instances don't need them.
- **All API endpoints migrated** to the namespace-scoped URL shape (`/ai-search/namespaces/{ns}/instances/...`).

## Validation

- Single-instance `ai_search` bindings validate at deploy time that the bound instance is in the `default` namespace; error message points at the `AiSearchNamespace` binding alternative.
- Namespace names validated locally against CF's documented regex before any API call.

## Lifecycle hardening

- `deleteAiSearchInstance` and `deleteAiSearchNamespace` actively wait for `GET` to return 404 before returning, presenting a strongly-consistent "resource is gone" contract to callers (child token delete, user-facing teardown assertions, downstream resources).
- `deleteAiSearchToken` briefly retries on 7076 `token_in_use_by_instances` to cover residual cross-colo lag. A persistent 409 throws an actionable error — a post-retry 409 means the token is genuinely shared by another instance and should not be silently leaked.
- Child `AiSearchToken` honors the parent `AiSearch`'s `delete: false` so preserving an instance also preserves its referencing token.

## Usage

```ts
import { AiSearch, AiSearchNamespace, Worker } from "alchemy/cloudflare";

// Namespace binding — dynamic multi-instance access
const ns = await AiSearchNamespace("docs", { name: "docs" });

// Single instance (built-in storage, no R2 or token needed)
const search = await AiSearch("kb", { name: "knowledge-base" });

// Instance in a custom namespace
const search2 = await AiSearch("blog", {
  name: "blog",
  namespace: ns,
});

const worker = await Worker("api", {
  entrypoint: "./src/worker.ts",
  bindings: {
    SEARCH: search,  // ai_search binding
    DOCS: ns,         // ai_search_namespace binding
  },
});
```

```ts
// Worker runtime
// Single instance binding — simple query shape
const results = await env.SEARCH.search({ query: "How does caching work?" });
await env.SEARCH.items.upload("faq.md", "# FAQ\n\n...");

// Namespace binding — access instances dynamically
const blog = env.DOCS.get("blog");
const stream = await blog.chatCompletions({
  messages: [{ role: "user", content: "explain caching" }],
  stream: true,
});

// Namespace-level operations
const instances = await env.DOCS.list();
await env.DOCS.create({ id: "tenant-123" });
await env.DOCS.delete("old-docs");
```

## Test coverage

24 tests against the real Cloudflare API. Highlights:

| Test | Coverage |
|---|---|
| `adopt preserves underlying AiSearch instance (createdAt + internalId stable)` | Catches silent-recreate regressions on adopt |
| `adopt preserves underlying namespace resource (createdAt match)` | Same, for namespaces |
| `rename triggers replace (old deleted, new created)` | Verifies delete-old-then-create-new semantics |
| `description round-trips through the API (set → update → clear with null)` | Three-way `description` semantics including `null` clear, round-tripped to the API |
| `adopt on reserved default namespace binds without create` | Reserved `default` namespace adopt + destroy no-op |
| `rejects names that violate Cloudflare's character rules` | Local regex validation (offline) |
| `delete=false preserves namespace on scope destroy` | Opt-out deletion pattern |
| `sourceless instance update changes maxNumResults without replacing the instance` | Sourceless = no token auto-created; updatable without replace |
| `changing namespace on an existing instance triggers replace` | Namespace immutability + replace correctness |
| `namespace prop accepts a string (not just a Resource)` | Both input shapes |
| `single-instance binding rejects non-default namespace at deploy time` | Deploy-time validation with actionable error |
| `AI Search with RAG response generation via Worker` | Full E2E of the (legacy) `env.AI.autorag()` path via deployed Worker |

Full suite runs in ~2 min against a live Cloudflare account.

## Files changed

| Category | Files |
|---|---|
| New resource | `alchemy/src/cloudflare/ai-search-namespace.ts` |
| Updated resource | `alchemy/src/cloudflare/ai-search.ts`, `ai-search-token.ts` |
| Binding integration | `bindings.ts`, `bound.ts`, `worker-metadata.ts`, `miniflare/build-worker-options.ts`, `wrangler.json.ts` |
| Exports | `index.ts` |
| Tests | `alchemy/test/cloudflare/ai-search.test.ts` (24 tests total) |
| Docs | new `ai-search-namespace.md`, updated `ai-search.md`, new `cloudflare-ai-search.mdx` guide |
| Example | `examples/cloudflare-ai-search/` (updated `alchemy.run.ts` + `worker.ts`, new `README.md`, registered in root tsconfig) |
| Deps | `@cloudflare/workers-types: ^4.20260420.1`, `wrangler: ^4.83.0` (for native miniflare AI Search support) |

## Notes

- Local dev: `miniflare@4.20260415.0+` (via `wrangler@^4.83.0`) natively proxies AI Search bindings to the deployed instance via `remote: true` — same mechanism as `ai`, `vectorize`, `browser`, etc.
- Binding resolution uses `isAiSearch()` / `isAiSearchNamespace()` type guards (via `ResourceKind`) since `AiSearch.type` is the *source* type (`"r2" | "web-crawler"`), not a binding discriminant.
- `bound.ts` places AI Search arms FIRST in the `Bound<T>` conditional chain (required for the same reason — `AiSearch.type` would otherwise false-match structural discriminators later in the chain).
- `AiSearchItems.upload()` accepts `ReadableStream | Blob | string` — docs and examples updated accordingly.