### PR TITLE
fix(cloudflare): repair AI Search binding support in `alchemy dev`

### DIFF
--- a/alchemy/package.json
+++ b/alchemy/package.json
@@ -195,7 +195,7 @@
     "glob": "^10.0.0",
     "jszip": "^3.0.0",
     "libsodium-wrappers": "^0.8.0",
-    "miniflare": "4.20260310.0",
+    "miniflare": "4.20260329.0",
     "neverthrow": "^8.2.0",
     "open": "^10.1.2",
     "openapi-types": "^12.1.3",

--- a/alchemy/src/cloudflare/ai-search-namespace.ts
+++ b/alchemy/src/cloudflare/ai-search-namespace.ts
@@ -194,17 +194,13 @@ export const AiSearchNamespace = Resource(
       );
     }
 
-    if (this.scope.local) {
-      // Local development mode — return mock output
-      return {
-        type: "ai_search_namespace",
-        id: namespace,
-        namespace,
-        description: props.description ?? null,
-        createdAt: new Date().toISOString(),
-      };
-    }
-
+    // NOTE: AI Search is an always-remote binding (no Miniflare-native
+    // implementation). `alchemy dev` wires the worker binding via
+    // `remote-binding-proxy`, which requires the namespace to actually exist
+    // on Cloudflare at preview-token creation time — a locally mocked
+    // resource would cause the Worker deploy to fail with error 10359
+    // ("namespace … does not exist"). Follow the same pattern as Vectorize
+    // and skip the `scope.local` mock branch entirely.
     const api = await createCloudflareApi(props);
 
     if (this.phase === "delete") {

--- a/alchemy/src/cloudflare/ai-search.ts
+++ b/alchemy/src/cloudflare/ai-search.ts
@@ -373,32 +373,13 @@ export const AiSearch = Resource(
     // Resolve namespace: AiSearchNamespace resource → string, default to "default"
     const namespace = resolveNamespace(props.namespace);
 
-    if (this.scope.local) {
-      // Local development mode — return a mock shape so `alchemy dev` does
-      // not hit the real Cloudflare API. Matches the AiSearchNamespace
-      // local-mode pattern and satisfies AGENTS.md requirements.
-      const name =
-        props.name ??
-        this.output?.name ??
-        this.scope.createPhysicalName(id, "-", 32);
-      const now = new Date().toISOString();
-      // `AiSearch` is `SnakeToCamel<ApiResponse>` intersected with extras —
-      // all non-required fields are optional, so we only populate what's
-      // needed. No `as unknown as` escape hatch required.
-      const mock: AiSearch = {
-        id: name,
-        name,
-        namespace,
-        accountId: "local",
-        accountTag: "local",
-        createdAt: now,
-        internalId: name,
-        modifiedAt: now,
-        vectorizeName: "",
-      };
-      return mock;
-    }
-
+    // NOTE: AI Search is an always-remote binding (no Miniflare-native
+    // implementation). `alchemy dev` wires the worker binding via
+    // `remote-binding-proxy`, which requires the instance to actually exist
+    // on Cloudflare at preview-token creation time — a locally mocked
+    // resource would cause the Worker deploy to fail with error 10360
+    // ("instance … not found"). Follow the same pattern as Vectorize and
+    // skip the `scope.local` mock branch entirely.
     const api = await createCloudflareApi(props);
 
     const validateBucketSource = async (

--- a/alchemy/src/cloudflare/miniflare/build-worker-options.ts
+++ b/alchemy/src/cloudflare/miniflare/build-worker-options.ts
@@ -40,8 +40,6 @@ type RemoteBinding =
       {
         type:
           | "ai"
-          | "ai_search"
-          | "ai_search_namespace"
           | "browser"
           | "dispatch_namespace"
           | "mtls_certificate"
@@ -57,7 +55,13 @@ type RemoteBinding =
   | Extract<
       WorkerBindingSpec,
       { type: "send_email" | "service" | "vpc_service" }
-    >;
+    >
+  // AI Search bindings reject the `raw` flag at the Cloudflare API
+  // validation layer (10333). Wrangler's upload form deliberately omits
+  // `raw` for these two binding types in
+  // packages/wrangler/src/deployment-bundle/create-worker-upload-form.ts,
+  // so we mirror that here for the remote-binding-proxy upload.
+  | Extract<WorkerBindingSpec, { type: "ai_search" | "ai_search_namespace" }>;
 
 type BaseWorkerOptions = {
   [K in keyof miniflare.WorkerOptions]: K extends
@@ -96,24 +100,30 @@ export const buildWorkerOptions = async (
     }
     if (isAiSearch(binding)) {
       // AI Search instance bindings are not supported natively by Miniflare;
-      // proxy them to the deployed instance (same mechanism used by `ai`,
-      // `vectorize`, etc.). Instance bindings are always scoped to the
-      // default namespace on the CF side, so the namespace need not be
-      // surfaced in the remote-proxy metadata.
+      // proxy them to the deployed instance via the `remote-binding-proxy`
+      // worker (same mechanism used by `ai`, `vectorize`, etc.). Instance
+      // bindings are always scoped to the default namespace on the CF side,
+      // so the namespace need not be surfaced in the remote-proxy metadata.
+      //
+      // Note: unlike `ai`/`browser`/`vectorize`, AI Search bindings must NOT
+      // carry `raw: true` — CF's API rejects that field on `ai_search` and
+      // `ai_search_namespace` bindings (error 10333). This mirrors wrangler's
+      // create-worker-upload-form.ts which also omits `raw` for these two
+      // binding types.
       remoteBindings.push({
         type: "ai_search",
         name: key,
         instance_name: binding.name,
-        raw: true,
       });
       continue;
     }
     if (isAiSearchNamespace(binding)) {
+      // See comment above on `ai_search`: `raw: true` is rejected by CF for
+      // this binding type, so we push without it.
       remoteBindings.push({
         type: "ai_search_namespace",
         name: key,
         namespace: binding.namespace,
-        raw: true,
       });
       continue;
     }

--- a/alchemy/src/cloudflare/miniflare/remote-binding-proxy.ts
+++ b/alchemy/src/cloudflare/miniflare/remote-binding-proxy.ts
@@ -39,7 +39,12 @@ export async function createRemoteProxyWorker(input: {
   bindings: WorkerBindingSpec[];
 }): Promise<RemoteBindingProxy> {
   const script = await getInternalWorkerBundle("remote-binding-proxy");
-  const [token, { host, accessToken }] = await Promise.all([
+  // We must create the preview token BEFORE probing for Cloudflare Access:
+  // a preview worker URL only returns the Access 302 when the request carries
+  // the preview token (otherwise CF responds with 404 regardless of Access
+  // configuration). Probing without the token would incorrectly report
+  // "no Access" for accounts that do gate workers.dev behind Access.
+  const [token, subdomain] = await Promise.all([
     createWorkersPreviewToken(input.api, {
       name: input.name,
       metadata: {
@@ -54,14 +59,10 @@ export async function createRemoteProxyWorker(input: {
         minimal_mode: true,
       },
     }),
-    getAccountSubdomain(input.api).then(async (subdomain) => {
-      const host = `${input.name}.${subdomain}.workers.dev`;
-      return {
-        host,
-        accessToken: await getAccessToken(host),
-      };
-    }),
+    getAccountSubdomain(input.api),
   ]);
+  const host = `${input.name}.${subdomain}.workers.dev`;
+  const accessToken = await getAccessToken(host, token);
 
   const baseHeaders: Record<string, string> = {
     "cf-workers-preview-token": token,
@@ -158,7 +159,13 @@ async function createWorkersPreviewToken(
 
 async function prewarm(url: string, previewToken: string) {
   try {
-    const accessToken = await getAccessToken(new URL(url).hostname);
+    // Pass the preview token to the Access probe — prewarm targets a preview
+    // worker URL, which only surfaces an Access 302 when the request carries
+    // the preview token.
+    const accessToken = await getAccessToken(
+      new URL(url).hostname,
+      previewToken,
+    );
     await fetch(url, {
       method: "POST",
       headers: {
@@ -197,42 +204,59 @@ async function createWorkersPreviewSession(api: CloudflareApi) {
 /**
  * If the given domain uses Cloudflare Access, fetches the access token for the domain.
  * Otherwise, returns undefined.
+ *
+ * For workers.dev preview URLs, pass the `cf-workers-preview-token` alongside
+ * the HEAD probe: the preview worker only surfaces its Access 302 when the
+ * request carries the preview token (a bare HEAD returns 404 regardless of
+ * Access configuration).
+ *
  * @see https://github.com/cloudflare/workers-sdk/blob/a5eb5134f73d3983655d325a4de71c6370c57faa/packages/wrangler/src/user/access.ts#L10
  */
-const getAccessToken = memoize(async (hostname: string) => {
-  if (!(await domainUsesAccess(hostname))) {
-    return undefined;
-  }
-  const result = await Scope.current
-    .exec(`access-${hostname}`, `cloudflared access login ${hostname}`)
-    .catch(() => {
-      throw new Error(
-        [
-          `The \`cloudflared\` CLI is not installed, but is required to access the domain "${hostname}".`,
-          `Please install it from https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/install-and-setup/installation and run \`cloudflare access login ${hostname}\`.`,
-        ].join("\n"),
-      );
-    });
-  const matches = result.stdout.match(/fetched your token:\n\n(.*)/m);
-  if (matches?.[1]) {
-    return matches[1];
-  }
-  const error = new Error(
-    `Failed to get access token for domain "${hostname}".`,
-  );
-  Object.assign(error, result);
-  throw error;
-});
+const getAccessToken = memoize(
+  async (hostname: string, previewToken?: string) => {
+    if (!(await domainUsesAccess(hostname, previewToken))) {
+      return undefined;
+    }
+    const result = await Scope.current
+      .exec(`access-${hostname}`, `cloudflared access login ${hostname}`)
+      .catch(() => {
+        throw new Error(
+          [
+            `The \`cloudflared\` CLI is not installed, but is required to access the domain "${hostname}".`,
+            `Please install it from https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/install-and-setup/installation and run \`cloudflare access login ${hostname}\`.`,
+          ].join("\n"),
+        );
+      });
+    const matches = result.stdout.match(/fetched your token:\n\n(.*)/m);
+    if (matches?.[1]) {
+      return matches[1];
+    }
+    const error = new Error(
+      `Failed to get access token for domain "${hostname}".`,
+    );
+    Object.assign(error, result);
+    throw error;
+  },
+  (hostname) => hostname,
+);
 
 /**
  * Returns true if the domain uses Cloudflare Access.
+ *
+ * @param hostname  the workers.dev preview host
+ * @param previewToken  optional preview token; required when probing a
+ *   preview-worker URL because CF only serves the Access 302 to requests
+ *   that carry the token.
  */
-async function domainUsesAccess(hostname: string) {
+async function domainUsesAccess(hostname: string, previewToken?: string) {
   try {
     const response = await fetch(`https://${hostname}`, {
       method: "HEAD",
       redirect: "manual",
       signal: AbortSignal.timeout(1000),
+      headers: previewToken
+        ? { "cf-workers-preview-token": previewToken }
+        : undefined,
     });
     return !!(
       response.status === 302 &&

--- a/bun.lock
+++ b/bun.lock
@@ -52,7 +52,7 @@
         "glob": "^10.0.0",
         "jszip": "^3.0.0",
         "libsodium-wrappers": "^0.8.0",
-        "miniflare": "4.20260310.0",
+        "miniflare": "4.20260329.0",
         "neverthrow": "^8.2.0",
         "open": "^10.1.2",
         "openapi-types": "^12.1.3",
@@ -5989,7 +5989,7 @@
 
     "alchemy/glob": ["glob@10.4.5", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg=="],
 
-    "alchemy/miniflare": ["miniflare@4.20260310.0", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "^0.34.5", "undici": "7.18.2", "workerd": "1.20260310.1", "ws": "8.18.0", "youch": "4.1.0-beta.10" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-uC5vNPenFpDSj5aUU3wGSABG6UUqMr+Xs1m4AkCrTHo37F4Z6xcQw5BXqViTfPDVT/zcYH1UgTVoXhr1l6ZMXw=="],
+    "alchemy/miniflare": ["miniflare@4.20260329.0", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "^0.34.5", "undici": "7.24.4", "workerd": "1.20260329.1", "ws": "8.18.0", "youch": "4.1.0-beta.10" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-+G+1YFVeuEpw/gZZmUHQR7IfzJV+DDGvnSl0yXzhgvHh8Nbr8Go5uiWIwl17EyZ1Uors3FKUMDUyU6+ejeKZOw=="],
 
     "alchemy/rwsdk": ["rwsdk@1.0.0-beta.51", "", { "dependencies": { "@ast-grep/napi": "~0.39.0", "@cloudflare/workers-types": "~4.20260124.0", "@mdx-js/mdx": "~3.1.1", "@puppeteer/browsers": "~2.10.0", "@types/decompress": "~4.2.7", "@types/fs-extra": "~11.0.4", "@types/glob": "^8.1.0", "@types/react": "~19.2.9", "@types/react-dom": "~19.2.3", "@types/react-is": "~19.0.0", "@vitejs/plugin-react": "~5.0.0", "chokidar": "~4.0.0", "debug": "~4.4.0", "decompress": "~4.2.1", "enhanced-resolve": "~5.18.1", "eventsource-parser": "~3.0.0", "execa": "~9.6.0", "find-up": "~8.0.0", "fs-extra": "~11.3.0", "get-port": "^7.1.0", "glob": "~11.1.0", "ignore": "~7.0.4", "jsonc-parser": "~3.3.1", "kysely": "~0.28.2", "kysely-do": "~0.0.1-rc.1", "lodash": "~4.17.23", "magic-string": "~0.30.17", "picocolors": "~1.1.1", "proper-lockfile": "~4.1.2", "puppeteer-core": "~24.22.0", "react-is": "~19.1.0", "rsc-html-stream": "~0.0.6", "server-only": "^0.0.1", "tmp-promise": "~3.0.3", "ts-morph": "~27.0.0", "unique-names-generator": "~4.7.1", "vibe-rules": "~0.3.0", "vite-tsconfig-paths": "~5.1.4" }, "peerDependencies": { "@cloudflare/vite-plugin": "^1.21.2", "capnweb": "~0.2.0", "react": ">=19.2.0-0 <19.3.0 || >=19.3.0-0 <20.0.0", "react-dom": ">=19.2.0-0 <19.3.0 || >=19.3.0-0 <20.0.0", "react-server-dom-webpack": ">=19.2.0-0 <19.3.0 || >=19.3.0-0 <20.0.0", "vite": "^6.2.6 || 7.x", "wrangler": "^4.60.0" }, "bin": { "rw-scripts": "bin/rw-scripts.mjs", "rwsdk": "bin/rw-scripts.mjs", "rwsync": "bin/rwsync" } }, "sha512-K5enSUQ67x5QfiOjo5k4t/OgUS+sIl1XhRhhxt6aQyVIKtb+2zpFNx7SVZqLFvadGhIzojCXNPPjgFbbJu5SsQ=="],
 
@@ -7137,9 +7137,9 @@
 
     "alchemy/miniflare/sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
 
-    "alchemy/miniflare/undici": ["undici@7.18.2", "", {}, "sha512-y+8YjDFzWdQlSE9N5nzKMT3g4a5UBX1HKowfdXh0uvAnTaqqwqB92Jt4UXBAeKekDs5IaDKyJFR4X1gYVCgXcw=="],
+    "alchemy/miniflare/undici": ["undici@7.24.4", "", {}, "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w=="],
 
-    "alchemy/miniflare/workerd": ["workerd@1.20260310.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260310.1", "@cloudflare/workerd-darwin-arm64": "1.20260310.1", "@cloudflare/workerd-linux-64": "1.20260310.1", "@cloudflare/workerd-linux-arm64": "1.20260310.1", "@cloudflare/workerd-windows-64": "1.20260310.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-yawXhypXXHtArikJj15HOMknNGikpBbSg2ZDe6lddUbqZnJXuCVSkgc/0ArUeVMG1jbbGvpst+REFtKwILvRTQ=="],
+    "alchemy/miniflare/workerd": ["workerd@1.20260329.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260329.1", "@cloudflare/workerd-darwin-arm64": "1.20260329.1", "@cloudflare/workerd-linux-64": "1.20260329.1", "@cloudflare/workerd-linux-arm64": "1.20260329.1", "@cloudflare/workerd-windows-64": "1.20260329.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-+ifMv3uBuD33ee7pan5n8+sgVxm2u5HnbgfXzHKwMNTKw86znqBJSnJoBqtP88+2T5U2Lu11xXUt+khPYioXwQ=="],
 
     "alchemy/miniflare/ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
 
@@ -8369,15 +8369,15 @@
 
     "alchemy/miniflare/sharp/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
 
-    "alchemy/miniflare/workerd/@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260310.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-hF2VpoWaMb1fiGCQJqCY6M8I+2QQqjkyY4LiDYdTL5D/w6C1l5v1zhc0/jrjdD1DXfpJtpcSMSmEPjHse4p9Ig=="],
+    "alchemy/miniflare/workerd/@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260329.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-oyDXYlPBuGXKkZ85+M3jFz0/qYmvA4AEURN8USIGPDCR5q+HFSRwywSd9neTx3Wi7jhey2wuYaEpD3fEFWyWUA=="],
 
-    "alchemy/miniflare/workerd/@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260310.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-h/Vl3XrYYPI6yFDE27XO1QPq/1G1lKIM8tzZGIWYpntK3IN5XtH3Ee/sLaegpJ49aIJoqhF2mVAZ6Yw+Vk2gJw=="],
+    "alchemy/miniflare/workerd/@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260329.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-++ZxVa3ovzYeDLEG6zMqql9gzZAG8vak6ZSBQgprGKZp7akr+GKTpw9f3RrMP552NSi3gTisroLobrrkPBtYLQ=="],
 
-    "alchemy/miniflare/workerd/@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260310.1", "", { "os": "linux", "cpu": "x64" }, "sha512-XzQ0GZ8G5P4d74bQYOIP2Su4CLdNPpYidrInaSOuSxMw+HamsHaFrjVsrV2mPy/yk2hi6SY2yMbgKFK9YjA7vw=="],
+    "alchemy/miniflare/workerd/@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260329.1", "", { "os": "linux", "cpu": "x64" }, "sha512-kkeywAgIHwbqHkVILqbj/YkfbrA6ARbmutjiYzZA2MwMSfNXlw6/kedAKOY8YwcymZIgepx3YTIPnBP50pOotw=="],
 
-    "alchemy/miniflare/workerd/@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260310.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-sxv4CxnN4ZR0uQGTFVGa0V4KTqwdej/czpIc5tYS86G8FQQoGIBiAIs2VvU7b8EROPcandxYHDBPTb+D9HIMPw=="],
+    "alchemy/miniflare/workerd/@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260329.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-eYBN20+B7XOUSWEe0mlqkMUbfLoIKjKZnpqQiSxnLbL72JKY0D/KlfN/b7RVGLpewB7i8rTrwTNr0szCKnZzSQ=="],
 
-    "alchemy/miniflare/workerd/@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260310.1", "", { "os": "win32", "cpu": "x64" }, "sha512-+1ZTViWKJypLfgH/luAHCqkent0DEBjAjvO40iAhOMHRLYP/SPphLvr4Jpi6lb+sIocS8Q1QZL4uM5Etg1Wskg=="],
+    "alchemy/miniflare/workerd/@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260329.1", "", { "os": "win32", "cpu": "x64" }, "sha512-5R+/oxrDhS9nL3oA3ZWtD6ndMOqm7RfKknDNxLcmYW5DkUu7UH3J/s1t/Dz66iFePzr5BJmE7/8gbmve6TjtZQ=="],
 
     "alchemy/rwsdk/@ast-grep/napi/@ast-grep/napi-darwin-arm64": ["@ast-grep/napi-darwin-arm64@0.39.9", "", { "os": "darwin", "cpu": "arm64" }, "sha512-0gdBC2oPBkIBsh89yUXxJeK37QYRbp1qNZVuRGizT666ljgCw+2NIxHeQGNjwWuI0+g3exrd8FyqD3gMixRx3w=="],
 


### PR DESCRIPTION
## Summary

Follow-up to #1386. Four bug fixes that together make AI Search bindings (`ai_search`, `ai_search_namespace`) actually work in `alchemy dev`. Before this change, running a Worker with either binding type in dev mode failed with a mix of CF API rejections and runtime `TypeError`s on `env.SEARCH` / `env.DOCS`.

Opened as a draft because fix #4 (Access probe) can't be end-to-end verified locally on my test account (unrelated ZT config issue) — the code change itself is correct and mirrors what wrangler's equivalent path does, but the specific runtime interaction needs a reviewer with a workers.dev subdomain not gated behind Access / WARP.

## The bugs

### 1. `raw: true` on `ai_search` / `ai_search_namespace` remote bindings — CF API rejects with 10333

Cloudflare's `/edge-preview` API rejects the `raw` property on these two binding types:

```
[10333] Binding 'DOCS' of type 'ai_search_namespace' does not support
        being configure with the 'raw' property.
```

Wrangler's [`create-worker-upload-form.ts`](https://github.com/cloudflare/workers-sdk/blob/main/packages/wrangler/src/deployment-bundle/create-worker-upload-form.ts) deliberately omits `raw` for these two binding types (while keeping it for `ai`, `browser`, `vectorize`, etc.). This PR mirrors that shape when assembling `remoteBindings` for the `remote-binding-proxy` worker upload.

### 2. `scope.local` mock branches break the remote-binding-proxy flow — 10359 / 10360

`AiSearch` and `AiSearchNamespace` both had `if (this.scope.local) return mock;` short-circuits. But AI Search is an always-remote binding: the `remote-binding-proxy` worker needs the namespace/instance to **actually exist** on Cloudflare at preview-token creation time, or the binding validation fails with:

```
[10359] AI Search binding 'DOCS' references namespace 'foo' which does not exist.
[10360] AI Search binding 'SEARCH' references instance 'bar' … not found.
```

Removed the mock branches. Matches the existing pattern used by Vectorize, D1, R2, etc. (none of which mock in `scope.local`). Left the separate R2-bucket-needs-`dev: { remote: true }` guard in `ai-search.ts` in place — that's a distinct developer-UX check.

### 3. miniflare pinned too old — no `ai-search` plugin, so bindings are undefined at runtime

Alchemy pinned `miniflare: 4.20260310.0`. The `ai-search` plugin was added in [workers-sdk#13027](https://github.com/cloudflare/workers-sdk/pull/13027), merged 2026-03-27. Without it, miniflare has no idea what `aiSearchNamespaces` / `aiSearchInstances` options mean — `env.SEARCH` / `env.DOCS` are simply never populated in the Worker runtime and you get `TypeError: Cannot read properties of undefined`.

Bumped to `4.20260329.0` (first release containing the plugin).

### 4. Access detection can't see Access 302 on preview workers without the preview token

`domainUsesAccess(host)` does a bare HEAD probe to detect Access. For a workers.dev preview-worker URL, CF only surfaces the Access 302 when the request carries `cf-workers-preview-token`; a bare HEAD returns 404 regardless of Access configuration. So on accounts that gate workers.dev behind Access, alchemy would silently report "no Access", skip `cloudflared access login`, and every subsequent proxy request would 302-redirect to Access login and fail.

Also had to restructure `createRemoteProxyWorker` to obtain the preview token *before* the Access probe (they were running in `Promise.all` previously, so the probe never had the token available).

## Verification

- `bunx tsc --noEmit --project alchemy/tsconfig.json` — clean
- `bunx tsc --noEmit --project alchemy/tsconfig.test.json` — clean
- `bun format` — clean
- Ran 5 AI Search tests against real CF (adopt / name validation / namespace prop / binding integration) — all green
- Manually reproduced each bug path against a live CF account with the pkg.pr.new tarball of #1386, confirmed fix resolves it

Specifically for (1) and (2) I traced the failing `/edge-preview` POSTs via curl to confirm CF's exact error codes, and for (4) I captured the preview token from the running proxy and verified HEAD-with-token returns 302→cloudflareaccess.com while bare HEAD returns 404.

## Test snippet

```ts
import alchemy from "alchemy";
import { AiSearch, AiSearchNamespace, Worker } from "alchemy/cloudflare";

const app = await alchemy("ai-search-dev-test");

const ns = await AiSearchNamespace("docs", {
  name: "my-docs",
  adopt: true,
});

// Instance in a custom namespace — exercised via env.DOCS.get(name)
const nsInstance = await AiSearch("ns-kb", {
  name: "my-ns-kb",
  namespace: ns,
  adopt: true,
});

// Instance in the default namespace — bound via single-instance ai_search
const defaultInstance = await AiSearch("default-kb", {
  name: "my-default-kb",
  adopt: true,
});

const worker = await Worker("api", {
  entrypoint: "src/worker.ts",
  url: true,
  bindings: {
    SEARCH: defaultInstance,  // ai_search binding
    DOCS: ns,                  // ai_search_namespace binding
  },
});

await app.finalize();
```

Worker implementation:

```ts
export default {
  async fetch(request, env) {
    const url = new URL(request.url);
    if (url.pathname === "/search") {
      return Response.json(await env.SEARCH.search({ query: "hello" }));
    }
    if (url.pathname === "/ns/list") {
      return Response.json(await env.DOCS.list());
    }
    return new Response("ok");
  },
};
```

Before this PR: `alchemy dev` fails with 10333 (and even after bypassing that, 10359 / 10360 / undefined-binding).

After this PR: `alchemy dev` creates both namespace + instance on CF, uploads the remote-binding-proxy worker with valid binding metadata, miniflare wires `env.SEARCH` / `env.DOCS` through the proxy, and the Worker serves `/search` + `/ns/list`.