### PR TITLE
fix(cloudflare): wire dev.tunnel through Vite/Website spawn path

### DIFF
--- a/alchemy/src/cloudflare/website.ts
+++ b/alchemy/src/cloudflare/website.ts
@@ -8,6 +8,7 @@ import { logger } from "../util/logger.ts";
 import { createCloudflareApi } from "./api.ts";
 import { Assets } from "./assets.ts";
 import type { Bindings } from "./bindings.ts";
+import { quickTunnel } from "./quick-tunnel.ts";
 import { DEFAULT_COMPATIBILITY_DATE } from "./compatibility-date.ts";
 import { unionCompatibilityFlags } from "./compatibility-presets.ts";
 import {
@@ -367,6 +368,10 @@ export async function Website<
         ALCHEMY_ROOT: Scope.current.rootDir,
       },
     });
+    if (url && typeof dev === "object" && dev.tunnel) {
+      const { tunnelUrl } = await quickTunnel(scope, url);
+      url = tunnelUrl;
+    }
   }
 
   return (await Worker(id, {

--- a/alchemy/src/cloudflare/website.ts
+++ b/alchemy/src/cloudflare/website.ts
@@ -8,9 +8,9 @@ import { logger } from "../util/logger.ts";
 import { createCloudflareApi } from "./api.ts";
 import { Assets } from "./assets.ts";
 import type { Bindings } from "./bindings.ts";
-import { quickTunnel } from "./quick-tunnel.ts";
 import { DEFAULT_COMPATIBILITY_DATE } from "./compatibility-date.ts";
 import { unionCompatibilityFlags } from "./compatibility-presets.ts";
+import { quickTunnel } from "./quick-tunnel.ts";
 import {
   extractStringAndSecretBindings,
   unencryptSecrets,
@@ -368,7 +368,7 @@ export async function Website<
         ALCHEMY_ROOT: Scope.current.rootDir,
       },
     });
-    if (url && typeof dev === "object" && dev.tunnel) {
+    if (url && ((typeof dev === "object" && dev.tunnel) || scope.tunnel)) {
       const { tunnelUrl } = await quickTunnel(scope, url);
       url = tunnelUrl;
     }

--- a/alchemy/src/cloudflare/website.ts
+++ b/alchemy/src/cloudflare/website.ts
@@ -79,6 +79,10 @@ export interface WebsiteProps<
          */
         domain?: string;
         /**
+         * Whether to use a Cloudflare Tunnel for the dev server
+         */
+        tunnel?: boolean;
+        /**
          * Additional environment variables to set when running the dev command
          */
         env?: Record<string, string>;
@@ -377,7 +381,16 @@ export async function Website<
           }
         : {}),
     },
-    dev: url ? { url } : undefined,
+    dev: worker.dev
+      ? {
+          url: url as never,
+          port: worker.dev.port,
+          remote: worker.dev.remote,
+          tunnel: worker.dev.tunnel,
+        }
+      : url
+        ? { url }
+        : undefined,
   })) as Website<B, RPC>;
 }
 


### PR DESCRIPTION
Supersedes #1393. Adds the `dev.tunnel` property surface from that PR, plus the missing wiring so the flag actually takes effect on Vite/TanStackStart/Website resources.

## Diagnosis

For Vite-based resources, `website.ts` spawns the framework dev server and sets the resulting localhost URL as `worker.dev.url`. In `worker.ts:1156`, the `if (props.dev?.url)` branch short-circuits the `MiniflareController.add({ tunnel, ... })` path — which is the only place `dev.tunnel` is consumed. Net effect on the current PR head (`2e7ca5e`): `dev.tunnel: true` is silently ignored, no cloudflared spawns, `web.url` resolves to localhost.

## Fix

After the `scope.spawn(...)` block in `website.ts` that produces the local URL, wrap with `quickTunnel(scope, url)` when `dev.tunnel` is set. Five lines, reuses the existing helper. The trycloudflare URL flows into `Worker` as `dev.url` so the resource output is the public URL.

## Tested

Verified locally on a TanStackStart app: cloudflared spawns alongside vite, public URL appears in resource output (`web.url` resolves to `https://<random>.trycloudflare.com`), vite HMR works through the tunnel.

## Caveat / follow-up

Quick-tunnel only — random hostname per restart, not a replacement for named tunnels (OAuth callbacks, webhooks, etc.). Happy to follow up with a design issue for unifying `dev.tunnel: true | { hostname }` so named tunnels become declarative on framework resources too.