### PR TITLE
fix(cloudflare): auto-allow trycloudflare hosts in vite when dev.tunnel is set

### DIFF
--- a/alchemy/src/cloudflare/vite/plugin.ts
+++ b/alchemy/src/cloudflare/vite/plugin.ts
@@ -28,13 +28,19 @@ const alchemy = (config?: PluginConfig): PluginOption => {
       persistState,
     }),
     {
-      name: "alchemy-supress-watch",
+      name: "alchemy:dev",
       config() {
+        const allowedHosts: string[] = [];
+        if (process.env.ALCHEMY_DEV_TUNNEL === "quick") {
+          // leading dot = match all subdomains
+          allowedHosts.push(".trycloudflare.com");
+        }
         return {
           server: {
             watch: {
               ignored: ["**/.alchemy/**"],
             },
+            ...(allowedHosts.length ? { allowedHosts } : {}),
           },
         };
       },

--- a/alchemy/src/cloudflare/website.ts
+++ b/alchemy/src/cloudflare/website.ts
@@ -344,6 +344,8 @@ export async function Website<
   let url: string | undefined;
   const devCommand = typeof dev === "string" ? dev : dev?.command;
   if (devCommand && scope.local) {
+    const tunnelEnabled =
+      (typeof dev === "object" && dev.tunnel) || scope.tunnel;
     url = await scope.spawn(name, {
       cmd: devCommand,
       cwd: paths.cwd,
@@ -366,9 +368,10 @@ export async function Website<
         // which breaks `vite dev` (it won't, for example, re-write `process.env.TSS_APP_BASE` in the `.js` client side bundle)
         NODE_ENV: "development",
         ALCHEMY_ROOT: Scope.current.rootDir,
+        ...(tunnelEnabled ? { ALCHEMY_DEV_TUNNEL: "quick" } : {}),
       },
     });
-    if (url && ((typeof dev === "object" && dev.tunnel) || scope.tunnel)) {
+    if (url && tunnelEnabled) {
       const { tunnelUrl } = await quickTunnel(scope, url);
       url = tunnelUrl;
     }


### PR DESCRIPTION
## Problem

With `dev: { tunnel: true }` on a Vite-based resource (TanStackStart/Vite/Website), alchemy spawns vite + a quick tunnel and reports the public `*.trycloudflare.com` URL. Visiting it fails:

![Blocked request screenshot](https://github.com/yan-vikng-dev/alchemy/raw/assets/assets/vite-tunnel-blocked.png)

The user has to reconcile two pieces of alchemy-managed state (the tunnel hostname and vite's allowlist) in their own config — and the hostname rotates per restart, so they end up wildcarding `.trycloudflare.com` themselves.

## Fix

Alchemy already owns both seams. `website.ts` sets `ALCHEMY_DEV_TUNNEL=quick` on the spawned vite process when `dev.tunnel` (or `scope.tunnel`) is on; the `alchemy()` vite plugin reads it in its `config()` hook and pushes `.trycloudflare.com` into `server.allowedHosts` (leading dot = subdomain wildcard, merged into user's config via vite's array-concat semantics).

Small change across two files. Wildcard rather than exact hostname because quick tunnels rotate per restart and the hostname isn't known at vite spawn time. For a future named-tunnel surface (`dev: { tunnel: <Tunnel> }`), the same plugin can read an exact host instead — same mechanism.

Drive-by: renamed the (mis-spelled, now-broader) `alchemy-supress-watch` plugin to `alchemy:dev` since it now handles more than watch suppression.

## Tested

Verified locally on a TanStackStart app with `dev: { tunnel: true }`:
- Without patch: `HTTP 403`, "Blocked request" body.
- With patch: `HTTP 200`, app HTML, vite HMR works through the tunnel.

## Caveat

Only takes effect for users who use the `alchemy()` vite plugin — which is the recommended path for cloudflare bindings via vite anyway, so this is a non-case in practice.