### PR TITLE
feat(cloudflare): add Zero Trust Access resources

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -547,18 +547,27 @@ if (this.phase === "delete") {
 
 #### Internal API Types Convention
 
-Mark internal types used only for API serialization with JSDoc `@internal`:
+Mark **exported** types and functions that are not part of the user-facing API
+with JSDoc `@internal` — for example, helpers exported only so siblings inside
+the same provider can `import` them. Do not add `@internal` to file-private
+declarations: TypeScript's `export` keyword already conveys their visibility,
+so the tag is redundant noise.
 
 ```ts
 /**
- * Raw provider API response for resource creation
+ * Serialise the resource's wire shape. Exported only so sibling resources
+ * in this provider can call it.
  * @internal
  */
+export function serializeResource(resource: Resource): Record<string, unknown> {
+  // ...
+}
+
+// File-private — no `@internal` needed.
 interface ResourceApiResponse {
   id: string;
   name: string;
   created_at: number;
-  // API field names may differ from output
 }
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -326,18 +326,27 @@ if (this.phase === "delete") {
 
 ##### Internal API Types Convention
 
-Mark internal types used only for API serialization with JSDoc `@internal`:
+Mark **exported** types and functions that are not part of the user-facing API
+with JSDoc `@internal` — for example, helpers exported only so siblings inside
+the same provider can `import` them. Do not add `@internal` to file-private
+declarations: TypeScript's `export` keyword already conveys their visibility,
+so the tag is redundant noise.
 
 ```typescript
 /**
- * Raw provider API response for resource creation
+ * Serialise the resource's wire shape. Exported only so sibling resources
+ * in this provider can call it.
  * @internal
  */
+export function serializeResource(resource: Resource): Record<string, unknown> {
+  // ...
+}
+
+// File-private — no `@internal` needed.
 interface ResourceApiResponse {
   id: string;
   name: string;
   created_at: number;
-  // API field names may differ from output
 }
 ```
 

--- a/alchemy-web/src/content/docs/providers/cloudflare/access-application.md
+++ b/alchemy-web/src/content/docs/providers/cloudflare/access-application.md
@@ -1,0 +1,70 @@
+---
+title: AccessApplication
+description: Protect an application with Cloudflare Zero Trust Access.
+---
+
+A [Cloudflare Access application](https://developers.cloudflare.com/cloudflare-one/applications/) is the protected resource — a self-hosted domain, a SaaS integration, or a launcher bookmark. Three variants are strictly typed (`self_hosted`, `saas`, `bookmark`); the rest fall back to a permissive shape.
+
+## Self-Hosted Application
+
+Protect a hostname with one or more reusable [AccessPolicy](./access-policy) resources.
+
+```ts
+import { AccessApplication, AccessPolicy } from "alchemy/cloudflare";
+
+const employees = await AccessPolicy("employees", {
+  name: "Employees",
+  decision: "allow",
+  include: [{ email_domain: { domain: "acme.com" } }],
+});
+
+const admin = await AccessApplication("admin", {
+  type: "self_hosted",
+  name: "Internal Admin",
+  domain: "admin.acme.com",
+  policies: [employees],
+  sessionDuration: "8h",
+});
+
+// Validate `cf-access-jwt-assertion` against `admin.aud` at your origin.
+```
+
+## Bookmark Application
+
+A vanity link in the Access launcher — no policy enforcement, just a tile.
+
+```ts
+const wiki = await AccessApplication("wiki", {
+  type: "bookmark",
+  name: "Internal Wiki",
+  domain: "https://wiki.acme.com",
+  appLauncherVisible: true,
+});
+```
+
+## SaaS OIDC Integration
+
+Cloudflare brokers SSO between your IdP and a SaaS vendor over OIDC (or SAML).
+
+```ts
+const slack = await AccessApplication("slack-saas", {
+  type: "saas",
+  name: "Slack",
+  saas: {
+    authType: "oidc",
+    redirectUris: ["https://acme.slack.com/oidc/callback"],
+    scopes: ["openid", "email", "profile"],
+  },
+  policies: [employees],
+});
+
+// slack.clientId / slack.clientSecret.unencrypted are returned only on
+// creation — register them in Slack's SSO settings.
+```
+
+## Notes
+
+- `type` and `zone` are **immutable** — changing either forces replacement.
+- `domain` is required for `self_hosted`, and is the link target for `bookmark`.
+- For SaaS OIDC apps, `clientSecret` is only returned on creation; subsequent updates retain the original.
+- Set `zone: someZone` to scope the application to a specific zone instead of the account; only `self_hosted`, `bookmark`, and a few others support this.

--- a/alchemy-web/src/content/docs/providers/cloudflare/access-group.md
+++ b/alchemy-web/src/content/docs/providers/cloudflare/access-group.md
@@ -1,0 +1,52 @@
+---
+title: AccessGroup
+description: Define reusable rule sets for Cloudflare Zero Trust Access policies.
+---
+
+A [Cloudflare Access group](https://developers.cloudflare.com/cloudflare-one/identity/users/groups/) is a reusable bundle of `include` / `exclude` / `require` rules that can be referenced by [AccessPolicy](./access-policy) resources.
+
+## Email Domain Allowlist
+
+```ts
+import { AccessGroup } from "alchemy/cloudflare";
+
+const engineering = await AccessGroup("engineering", {
+  name: "Engineering",
+  include: [{ email_domain: { domain: "acme.com" } }],
+});
+```
+
+## Nested Groups via the `group` Rule
+
+Groups can reference other groups, and the lifted `string | AccessGroup` type lets you pass the resource directly.
+
+```ts
+const admins = await AccessGroup("admins", {
+  name: "Admins",
+  include: [{ email: { email: "alice@acme.com" } }],
+});
+
+const engineeringPlusAdmins = await AccessGroup("eng-plus-admins", {
+  name: "Engineering + Admins",
+  include: [
+    { email_domain: { domain: "acme.com" } },
+    { group: { id: admins } },
+  ],
+});
+```
+
+## Default Group
+
+Mark a group as the account default — it applies to every Access application unless overridden.
+
+```ts
+const defaultEmployees = await AccessGroup("default-employees", {
+  name: "All Employees",
+  include: [{ email_domain: { domain: "acme.com" } }],
+  isDefault: true,
+});
+```
+
+## Rule Reference
+
+The `include`, `exclude`, and `require` arrays accept any [AccessRule](./access-policy#rule-reference) — see the AccessPolicy page for the full catalog.

--- a/alchemy-web/src/content/docs/providers/cloudflare/access-identity-provider.md
+++ b/alchemy-web/src/content/docs/providers/cloudflare/access-identity-provider.md
@@ -1,0 +1,56 @@
+---
+title: AccessIdentityProvider
+description: Configure Cloudflare Zero Trust Access identity providers (Google, Okta, OIDC, SAML, OneTimePin and more).
+---
+
+A [Cloudflare Access identity provider](https://developers.cloudflare.com/cloudflare-one/identity/idp-integration/) allows users to sign in to Access-protected applications. The five most common types (`onetimepin`, `google`, `okta`, `oidc`, `saml`) are strictly typed; everything else falls back to a permissive `config` object.
+
+## OneTimePin (Email Code)
+
+The simplest provider — Cloudflare emails a one-time code to the user. No external setup required.
+
+```ts
+import { AccessIdentityProvider } from "alchemy/cloudflare";
+
+const otp = await AccessIdentityProvider("otp", {
+  type: "onetimepin",
+  name: "Email OTP",
+});
+```
+
+## Google OAuth
+
+```ts
+const google = await AccessIdentityProvider("google", {
+  type: "google",
+  name: "Google",
+  config: {
+    clientId: alchemy.secret.env.GOOGLE_CLIENT_ID.unencrypted,
+    clientSecret: alchemy.secret.env.GOOGLE_CLIENT_SECRET,
+  },
+});
+```
+
+## Generic OIDC
+
+```ts
+const oidc = await AccessIdentityProvider("idp", {
+  type: "oidc",
+  name: "Corporate IdP",
+  config: {
+    authUrl: "https://idp.example.com/oauth2/authorize",
+    tokenUrl: "https://idp.example.com/oauth2/token",
+    certsUrl: "https://idp.example.com/oauth2/certs",
+    clientId: "my-app",
+    clientSecret: alchemy.secret.env.IDP_CLIENT_SECRET,
+    scopes: ["openid", "email", "profile"],
+    pkceEnabled: true,
+  },
+});
+```
+
+## Notes
+
+- The `type` field is **immutable** — changing it forces replacement of the underlying Cloudflare resource.
+- The provider's `config.clientSecret` is re-sent on every update; Cloudflare clears it if the field is omitted.
+- Deleting an identity provider fails if any [AccessApplication](./access-application) references it via `allowedIdps`.

--- a/alchemy-web/src/content/docs/providers/cloudflare/access-identity-provider.md
+++ b/alchemy-web/src/content/docs/providers/cloudflare/access-identity-provider.md
@@ -24,10 +24,8 @@ const otp = await AccessIdentityProvider("otp", {
 const google = await AccessIdentityProvider("google", {
   type: "google",
   name: "Google",
-  config: {
-    clientId: alchemy.secret.env.GOOGLE_CLIENT_ID.unencrypted,
-    clientSecret: alchemy.secret.env.GOOGLE_CLIENT_SECRET,
-  },
+  clientId: alchemy.secret.env.GOOGLE_CLIENT_ID.unencrypted,
+  clientSecret: alchemy.secret.env.GOOGLE_CLIENT_SECRET,
 });
 ```
 
@@ -37,20 +35,18 @@ const google = await AccessIdentityProvider("google", {
 const oidc = await AccessIdentityProvider("idp", {
   type: "oidc",
   name: "Corporate IdP",
-  config: {
-    authUrl: "https://idp.example.com/oauth2/authorize",
-    tokenUrl: "https://idp.example.com/oauth2/token",
-    certsUrl: "https://idp.example.com/oauth2/certs",
-    clientId: "my-app",
-    clientSecret: alchemy.secret.env.IDP_CLIENT_SECRET,
-    scopes: ["openid", "email", "profile"],
-    pkceEnabled: true,
-  },
+  authUrl: "https://idp.example.com/oauth2/authorize",
+  tokenUrl: "https://idp.example.com/oauth2/token",
+  certsUrl: "https://idp.example.com/oauth2/certs",
+  clientId: "my-app",
+  clientSecret: alchemy.secret.env.IDP_CLIENT_SECRET,
+  scopes: ["openid", "email", "profile"],
+  pkceEnabled: true,
 });
 ```
 
 ## Notes
 
 - The `type` field is **immutable** — changing it forces replacement of the underlying Cloudflare resource.
-- The provider's `config.clientSecret` is re-sent on every update; Cloudflare clears it if the field is omitted.
+- `clientSecret` is re-sent on every update; Cloudflare clears it if the field is omitted.
 - Deleting an identity provider fails if any [AccessApplication](./access-application) references it via `allowedIdps`.

--- a/alchemy-web/src/content/docs/providers/cloudflare/access-policy.md
+++ b/alchemy-web/src/content/docs/providers/cloudflare/access-policy.md
@@ -1,0 +1,69 @@
+---
+title: AccessPolicy
+description: Reusable allow / deny / bypass rules attached to Cloudflare Zero Trust Access applications.
+---
+
+A reusable [Cloudflare Access policy](https://developers.cloudflare.com/cloudflare-one/policies/access/) defines who can reach an [AccessApplication](./access-application). Attach the same policy to multiple applications via their `policies` array.
+
+## Simple Allow Policy
+
+```ts
+import { AccessPolicy } from "alchemy/cloudflare";
+
+const employees = await AccessPolicy("employees", {
+  name: "Employees",
+  decision: "allow",
+  include: [{ email_domain: { domain: "acme.com" } }],
+});
+```
+
+## Bypass Policy for Office IPs
+
+```ts
+const officeBypass = await AccessPolicy("office-bypass", {
+  name: "Office Bypass",
+  decision: "bypass",
+  include: [{ ip: { ip: "203.0.113.0/24" } }],
+});
+```
+
+## Reference an AccessGroup with Approval Required
+
+```ts
+const sensitive = await AccessPolicy("sensitive", {
+  name: "Sensitive admin access",
+  decision: "allow",
+  include: [{ group: { id: adminGroup } }],
+  approvalRequired: true,
+  approvalGroups: [
+    { approvalsNeeded: 2, emailAddresses: ["security@acme.com"] },
+  ],
+  isolationRequired: true,
+});
+```
+
+## Decision Is Immutable
+
+Changing `decision` (e.g. `allow` → `deny`) forces replacement of the underlying Cloudflare resource. Other fields (`name`, rules, approval settings) update in place.
+
+## Rule Reference
+
+The `include`, `exclude`, and `require` arrays accept any of these rule shapes:
+
+| Rule | Shape |
+|---|---|
+| `email` | `{ email: { email: "user@acme.com" } }` |
+| `email_domain` | `{ email_domain: { domain: "acme.com" } }` |
+| `ip` | `{ ip: { ip: "203.0.113.0/24" } }` |
+| `ip_list` | `{ ip_list: { id: "<list-uuid>" } }` |
+| `geo` / `country` | `{ geo: { country_code: "US" } }` |
+| `everyone` | `{ everyone: {} }` |
+| `group` | `{ group: { id: groupResource } }` |
+| `service_token` | `{ service_token: { token_id: tokenResource } }` |
+| `any_valid_service_token` | `{ any_valid_service_token: {} }` |
+| `azure` / `okta` / `gsuite` / `github_organization` / `saml` | `{ <key>: { …, identity_provider_id: idpResource } }` |
+| `certificate` / `common_name` | `{ certificate: {} }` / `{ common_name: { common_name: "..." } }` |
+| `device_posture` | `{ device_posture: { integration_uid: "..." } }` |
+| `auth_method` / `login_method` / `oidc_claim` / `authentication_context` | per Cloudflare docs |
+
+Resource-typed fields (`group.id`, `service_token.token_id`, `*.identity_provider_id`, `login_method.id`) accept either a string ID or the corresponding Alchemy resource — references are normalised at the API boundary. See the [Cloudflare rules-language docs](https://developers.cloudflare.com/cloudflare-one/policies/access/#rule-types) for the full list.

--- a/alchemy-web/src/content/docs/providers/cloudflare/access-service-token.md
+++ b/alchemy-web/src/content/docs/providers/cloudflare/access-service-token.md
@@ -1,0 +1,50 @@
+---
+title: AccessServiceToken
+description: Create Cloudflare Zero Trust Access service tokens for machine-to-machine authentication against Access-protected applications.
+---
+
+A [Cloudflare Access service token](https://developers.cloudflare.com/cloudflare-one/identity/service-tokens/) authenticates non-human callers (CI runners, scripts, services) against Access-protected applications. The `clientSecret` is only returned on creation — store it immediately.
+
+## Minimal Example
+
+```ts
+import { AccessServiceToken } from "alchemy/cloudflare";
+
+const token = await AccessServiceToken("ci-runner", {
+  name: "ci-runner",
+});
+
+// token.clientId / token.clientSecret.unencrypted go into the
+// CF-Access-Client-Id / CF-Access-Client-Secret request headers.
+```
+
+## Custom Duration
+
+By default tokens are valid for 1 year. Override with a Cloudflare duration string.
+
+```ts
+const previewToken = await AccessServiceToken("preview-deploy", {
+  name: "preview-deploy",
+  duration: "720h", // 30 days
+});
+```
+
+## Use With a Worker
+
+Bind the secret into a Worker so it can authenticate against another Access-protected app.
+
+```ts
+import { Worker, AccessServiceToken } from "alchemy/cloudflare";
+
+const token = await AccessServiceToken("worker-to-admin", {
+  name: "worker-to-admin",
+});
+
+await Worker("admin-client", {
+  entrypoint: "./src/worker.ts",
+  bindings: {
+    CF_ACCESS_CLIENT_ID: token.clientId,
+    CF_ACCESS_CLIENT_SECRET: token.clientSecret!,
+  },
+});
+```

--- a/alchemy/src/cloudflare/access-application.ts
+++ b/alchemy/src/cloudflare/access-application.ts
@@ -15,7 +15,7 @@ import {
   type CloudflareApi,
   type CloudflareApiOptions,
 } from "./api.ts";
-import type { Zone } from "./zone.ts";
+import { findZoneForHostname, type Zone } from "./zone.ts";
 
 /**
  * Cloudflare Access application types. Three are strictly typed below;
@@ -226,10 +226,6 @@ export function isAccessApplication(
   return resource?.[ResourceKind] === "cloudflare::AccessApplication";
 }
 
-/**
- * Cloudflare wire shape.
- * @internal
- */
 interface CloudflareAccessApplication {
   id: string;
   name: string;
@@ -288,11 +284,10 @@ export const AccessApplication = Resource(
     const api = await createCloudflareApi(props);
     const name = props.name ?? this.scope.createPhysicalName(id);
 
-    // Resolve zone ID if the variant supports zone scoping.
     const zoneId =
       "zone" in props && props.zone
         ? typeof props.zone === "string"
-          ? props.zone
+          ? (await findZoneForHostname(api, props.zone)).zoneId
           : props.zone.id
         : undefined;
 
@@ -443,7 +438,6 @@ export const AccessApplication = Resource(
   },
 );
 
-/** @internal */
 function isAccessDuplicateNameError(err: unknown): boolean {
   if (
     isCloudflareApiError(err, { status: 409 }) ||
@@ -460,7 +454,6 @@ function isAccessDuplicateNameError(err: unknown): boolean {
   return false;
 }
 
-/** @internal */
 async function findAccessApplicationByName(
   api: CloudflareApi,
   basePath: string,
@@ -483,7 +476,6 @@ async function findAccessApplicationByName(
   }
 }
 
-/** @internal */
 async function deleteAccessApplication(
   api: CloudflareApi,
   path: string,

--- a/alchemy/src/cloudflare/access-application.ts
+++ b/alchemy/src/cloudflare/access-application.ts
@@ -1,0 +1,497 @@
+import { alchemy } from "../alchemy.ts";
+import type { Context } from "../context.ts";
+import { Resource, ResourceKind } from "../resource.ts";
+import type { Secret } from "../secret.ts";
+import { logger } from "../util/logger.ts";
+import type { AccessIdentityProvider } from "./access-identity-provider.ts";
+import type { AccessPolicy } from "./access-policy.ts";
+import { isCloudflareApiError } from "./api-error.ts";
+import {
+  extractCloudflareResult,
+  type CloudflareApiListResponse,
+} from "./api-response.ts";
+import {
+  createCloudflareApi,
+  type CloudflareApi,
+  type CloudflareApiOptions,
+} from "./api.ts";
+import type { Zone } from "./zone.ts";
+
+/**
+ * Cloudflare Access application types. Three are strictly typed below;
+ * everything else falls back to {@link OtherAccessApplicationProps}.
+ *
+ * @see https://developers.cloudflare.com/cloudflare-one/applications/
+ */
+export type AccessApplicationType =
+  | "self_hosted"
+  | "saas"
+  | "bookmark"
+  | "ssh"
+  | "vnc"
+  | "rdp"
+  | "app_launcher"
+  | "warp"
+  | "biso"
+  | "dash_sso"
+  | "infrastructure"
+  | "mcp"
+  | "mcp_portal"
+  | "proxy_endpoint"
+  | (string & {});
+
+interface BaseAccessApplicationProps extends CloudflareApiOptions {
+  /**
+   * Display name shown in the Access dashboard.
+   *
+   * @default ${app}-${stage}-${id}
+   */
+  name?: string;
+
+  /**
+   * Identity providers permitted to authenticate to this application.
+   * If unset, all account IdPs are allowed.
+   */
+  allowedIdps?: (string | AccessIdentityProvider)[];
+
+  /**
+   * Reusable Access policies attached to this application, in priority order.
+   */
+  policies?: (string | AccessPolicy)[];
+
+  /** Cloudflare duration string, e.g. `"24h"`. */
+  sessionDuration?: string;
+
+  /** Show this app in the user-facing App Launcher. */
+  appLauncherVisible?: boolean;
+
+  /** Skip the IdP-selection screen when only one IdP applies. */
+  autoRedirectToIdentity?: boolean;
+
+  /** Custom message shown to denied users. */
+  customDenyMessage?: string;
+
+  /** URL users are redirected to when denied. */
+  customDenyUrl?: string;
+
+  /** URL non-identity users (e.g. service tokens) are redirected to when denied. */
+  customNonIdentityDenyUrl?: string;
+
+  /** Free-form labels for grouping applications. */
+  tags?: string[];
+
+  /** Skip the Access interstitial page on first load. */
+  skipInterstitial?: boolean;
+
+  /**
+   * For service-token authenticated requests, return 401 on failure
+   * (instead of redirecting).
+   */
+  serviceAuth401Redirect?: boolean;
+
+  /**
+   * Adopt an existing application with the same name instead of failing.
+   *
+   * @default false
+   */
+  adopt?: boolean;
+
+  /**
+   * Whether to delete the application when removed from Alchemy.
+   *
+   * @default true
+   */
+  delete?: boolean;
+}
+
+/**
+ * A self-hosted application protected by Access at a specific domain.
+ */
+export interface SelfHostedAccessApplicationProps extends BaseAccessApplicationProps {
+  type: "self_hosted";
+  /** Hostname (or hostname/path prefix) the application lives at. */
+  domain: string;
+  /**
+   * Bind the application to a specific zone. If omitted, the application
+   * is account-scoped. Moving between scopes triggers replacement.
+   */
+  zone?: string | Zone;
+}
+
+/**
+ * SaaS OIDC integration configuration.
+ */
+export interface SaasOidcConfig {
+  authType: "oidc";
+  redirectUris: string[];
+  scopes?: ("openid" | "groups" | "email" | "profile")[];
+  groupFilterRegex?: string;
+}
+
+/**
+ * SaaS SAML 2.0 integration configuration.
+ */
+export interface SaasSamlConfig {
+  authType: "saml";
+  spEntityId: string;
+  consumerServiceUrl: string;
+  nameIdFormat?: string;
+  defaultRelayState?: string;
+}
+
+/**
+ * A SaaS application — Cloudflare brokers SSO between your IdP and the SaaS
+ * vendor over either OIDC or SAML.
+ */
+export interface SaasAccessApplicationProps extends BaseAccessApplicationProps {
+  type: "saas";
+  saas: SaasOidcConfig | SaasSamlConfig;
+}
+
+/**
+ * A bookmark — a vanity link in the Access launcher with no policy
+ * enforcement.
+ */
+export interface BookmarkAccessApplicationProps extends BaseAccessApplicationProps {
+  type: "bookmark";
+  /** URL the bookmark points to. */
+  domain: string;
+  /**
+   * Bind the bookmark to a zone. If omitted, the bookmark is account-scoped.
+   */
+  zone?: string | Zone;
+}
+
+/**
+ * Catch-all variant for application types not covered by a strict variant
+ * (`ssh`, `vnc`, `rdp`, `app_launcher`, `warp`, `biso`, `dash_sso`,
+ * `infrastructure`, `mcp`, `mcp_portal`, `proxy_endpoint`, or future types).
+ */
+export interface OtherAccessApplicationProps extends BaseAccessApplicationProps {
+  type: Exclude<AccessApplicationType, "self_hosted" | "saas" | "bookmark">;
+  /** Required for `ssh`, `vnc`, `rdp`, `proxy_endpoint`. */
+  domain?: string;
+  /** Zone-scope the application where supported by the type. */
+  zone?: string | Zone;
+}
+
+/**
+ * Properties for creating or updating an {@link AccessApplication}.
+ */
+export type AccessApplicationProps =
+  | SelfHostedAccessApplicationProps
+  | SaasAccessApplicationProps
+  | BookmarkAccessApplicationProps
+  | OtherAccessApplicationProps;
+
+/**
+ * Output for an {@link AccessApplication}.
+ */
+export type AccessApplication = Omit<
+  AccessApplicationProps,
+  "adopt" | "delete" | "zone"
+> & {
+  /** Cloudflare-assigned application UUID. */
+  id: string;
+  /** Display name. */
+  name: string;
+  /**
+   * Audience tag (used to validate Access JWTs at your origin).
+   */
+  aud: string;
+  /**
+   * Resolved zone ID, if the application is zone-scoped.
+   */
+  zoneId?: string;
+  /**
+   * SaaS OIDC client identifier (only set for SaaS OIDC apps).
+   */
+  clientId?: string;
+  /**
+   * SaaS OIDC client secret (only returned on creation; retained on update).
+   */
+  clientSecret?: Secret;
+  /** ISO 8601 creation timestamp. */
+  createdAt: string;
+  /** ISO 8601 last-update timestamp. */
+  updatedAt: string;
+};
+
+/**
+ * Type guard for {@link AccessApplication}.
+ */
+export function isAccessApplication(
+  resource: any,
+): resource is AccessApplication {
+  return resource?.[ResourceKind] === "cloudflare::AccessApplication";
+}
+
+/**
+ * Cloudflare wire shape.
+ * @internal
+ */
+interface CloudflareAccessApplication {
+  id: string;
+  name: string;
+  type: string;
+  domain?: string;
+  aud: string;
+  client_id?: string;
+  client_secret?: string;
+  created_at: string;
+  updated_at: string;
+}
+
+/**
+ * Creates a Cloudflare Zero Trust [Access application](https://developers.cloudflare.com/cloudflare-one/applications/)
+ * — a protected resource users authenticate to via Access.
+ *
+ * @example
+ * // Self-hosted application protected by an Access policy.
+ * const app = await AccessApplication("admin", {
+ *   type: "self_hosted",
+ *   name: "Internal Admin",
+ *   domain: "admin.acme.com",
+ *   policies: [employeesPolicy],
+ *   sessionDuration: "8h",
+ * });
+ *
+ * @example
+ * // Bookmark in the Access launcher.
+ * const wiki = await AccessApplication("wiki", {
+ *   type: "bookmark",
+ *   name: "Internal Wiki",
+ *   domain: "https://wiki.acme.com",
+ *   appLauncherVisible: true,
+ * });
+ *
+ * @example
+ * // SaaS OIDC integration.
+ * const slack = await AccessApplication("slack-saas", {
+ *   type: "saas",
+ *   name: "Slack",
+ *   saas: {
+ *     authType: "oidc",
+ *     redirectUris: ["https://acme.slack.com/oidc/callback"],
+ *     scopes: ["openid", "email", "profile"],
+ *   },
+ *   policies: [employeesPolicy],
+ * });
+ */
+export const AccessApplication = Resource(
+  "cloudflare::AccessApplication",
+  async function (
+    this: Context<AccessApplication>,
+    id: string,
+    props: AccessApplicationProps,
+  ): Promise<AccessApplication> {
+    const api = await createCloudflareApi(props);
+    const name = props.name ?? this.scope.createPhysicalName(id);
+
+    // Resolve zone ID if the variant supports zone scoping.
+    const zoneId =
+      "zone" in props && props.zone
+        ? typeof props.zone === "string"
+          ? props.zone
+          : props.zone.id
+        : undefined;
+
+    const basePath = zoneId
+      ? `/zones/${zoneId}/access/apps`
+      : `/accounts/${api.accountId}/access/apps`;
+
+    if (this.phase === "delete") {
+      if (this.output?.id && props.delete !== false) {
+        const deletePath = this.output.zoneId
+          ? `/zones/${this.output.zoneId}/access/apps/${this.output.id}`
+          : `/accounts/${api.accountId}/access/apps/${this.output.id}`;
+        await deleteAccessApplication(api, deletePath);
+      }
+      return this.destroy();
+    }
+
+    // type and zone are immutable — recreate if either changed.
+    if (this.phase === "update" && this.output) {
+      if (
+        this.output.type !== props.type ||
+        (this.output.zoneId ?? undefined) !== (zoneId ?? undefined)
+      ) {
+        this.replace(true);
+      }
+    }
+
+    if (
+      props.type === "self_hosted" &&
+      !(props as SelfHostedAccessApplicationProps).domain
+    ) {
+      throw new Error(
+        `AccessApplication "${name}": 'domain' is required for self_hosted applications.`,
+      );
+    }
+
+    const body: Record<string, unknown> = {
+      name,
+      type: props.type,
+    };
+    if ("domain" in props && props.domain) body.domain = props.domain;
+    if (props.allowedIdps)
+      body.allowed_idps = props.allowedIdps.map((idp) =>
+        typeof idp === "string" ? idp : idp.id,
+      );
+    if (props.policies)
+      body.policies = props.policies.map((p) =>
+        typeof p === "string" ? p : p.id,
+      );
+    if (props.sessionDuration !== undefined)
+      body.session_duration = props.sessionDuration;
+    if (props.appLauncherVisible !== undefined)
+      body.app_launcher_visible = props.appLauncherVisible;
+    if (props.autoRedirectToIdentity !== undefined)
+      body.auto_redirect_to_identity = props.autoRedirectToIdentity;
+    if (props.customDenyMessage !== undefined)
+      body.custom_deny_message = props.customDenyMessage;
+    if (props.customDenyUrl !== undefined)
+      body.custom_deny_url = props.customDenyUrl;
+    if (props.customNonIdentityDenyUrl !== undefined)
+      body.custom_non_identity_deny_url = props.customNonIdentityDenyUrl;
+    if (props.tags) body.tags = props.tags;
+    if (props.skipInterstitial !== undefined)
+      body.skip_interstitial = props.skipInterstitial;
+    if (props.serviceAuth401Redirect !== undefined)
+      body.service_auth_401_redirect = props.serviceAuth401Redirect;
+    if (props.type === "saas" && (props as SaasAccessApplicationProps).saas) {
+      const saas = (props as SaasAccessApplicationProps).saas;
+      body.saas =
+        saas.authType === "oidc"
+          ? {
+              auth_type: "oidc",
+              redirect_uris: saas.redirectUris,
+              scopes: saas.scopes,
+              group_filter_regex: saas.groupFilterRegex,
+            }
+          : {
+              auth_type: "saml",
+              sp_entity_id: saas.spEntityId,
+              consumer_service_url: saas.consumerServiceUrl,
+              name_id_format: saas.nameIdFormat,
+              default_relay_state: saas.defaultRelayState,
+            };
+    }
+
+    let app: CloudflareAccessApplication;
+    if (this.phase === "update" && this.output?.id) {
+      const updatePath = this.output.zoneId
+        ? `/zones/${this.output.zoneId}/access/apps/${this.output.id}`
+        : `/accounts/${api.accountId}/access/apps/${this.output.id}`;
+      app = await extractCloudflareResult<CloudflareAccessApplication>(
+        `update access application "${name}"`,
+        api.put(updatePath, body),
+      );
+    } else {
+      const adopt = props.adopt ?? this.scope.adopt;
+      try {
+        app = await extractCloudflareResult<CloudflareAccessApplication>(
+          `create access application "${name}"`,
+          api.post(basePath, body),
+        );
+      } catch (err) {
+        if (adopt && isAccessDuplicateNameError(err)) {
+          const existing = await findAccessApplicationByName(
+            api,
+            basePath,
+            name,
+          );
+          if (!existing) {
+            throw new Error(
+              `Access application "${name}" already exists but could not be found for adoption.`,
+              { cause: err },
+            );
+          }
+          logger.log(
+            `Adopting existing access application "${name}" (${existing.id})`,
+          );
+          app = await extractCloudflareResult<CloudflareAccessApplication>(
+            `adopt access application "${name}"`,
+            api.put(`${basePath}/${existing.id}`, body),
+          );
+        } else {
+          throw err;
+        }
+      }
+    }
+
+    // SaaS OIDC client_secret is only returned on POST — retain on update.
+    const clientSecret = app.client_secret
+      ? alchemy.secret(app.client_secret)
+      : this.output?.clientSecret;
+
+    const rest: Record<string, unknown> = { ...props };
+    delete rest.adopt;
+    delete rest.delete;
+    delete rest.zone;
+    return {
+      ...rest,
+      id: app.id,
+      name: app.name,
+      aud: app.aud,
+      zoneId,
+      clientId: app.client_id,
+      clientSecret,
+      createdAt: app.created_at,
+      updatedAt: app.updated_at,
+    } as AccessApplication;
+  },
+);
+
+/** @internal */
+function isAccessDuplicateNameError(err: unknown): boolean {
+  if (
+    isCloudflareApiError(err, { status: 409 }) ||
+    isCloudflareApiError(err, { status: 400 })
+  ) {
+    const data = err.errorData;
+    return (
+      Array.isArray(data) &&
+      data.some(
+        (e) => "message" in e && /already exists/i.test(String(e.message)),
+      )
+    );
+  }
+  return false;
+}
+
+/** @internal */
+async function findAccessApplicationByName(
+  api: CloudflareApi,
+  basePath: string,
+  name: string,
+): Promise<CloudflareAccessApplication | null> {
+  let page = 1;
+  const perPage = 50;
+  while (true) {
+    const response = await api.get(
+      `${basePath}?page=${page}&per_page=${perPage}`,
+    );
+    if (!response.ok) return null;
+    const data =
+      (await response.json()) as CloudflareApiListResponse<CloudflareAccessApplication>;
+    const match = data.result.find((a) => a.name === name);
+    if (match) return match;
+    const info = data.result_info;
+    if (!info || info.page * info.per_page >= info.total_count) return null;
+    page++;
+  }
+}
+
+/** @internal */
+async function deleteAccessApplication(
+  api: CloudflareApi,
+  path: string,
+): Promise<void> {
+  const response = await api.delete(path);
+  if (!response.ok && response.status !== 404) {
+    logger.error(
+      `Error deleting access application at ${path}: ${response.status} ${response.statusText}`,
+    );
+  }
+}

--- a/alchemy/src/cloudflare/access-group.ts
+++ b/alchemy/src/cloudflare/access-group.ts
@@ -1,0 +1,246 @@
+import type { Context } from "../context.ts";
+import { Resource, ResourceKind } from "../resource.ts";
+import { logger } from "../util/logger.ts";
+import { serializeAccessRule, type AccessRule } from "./access-rule.ts";
+import { isCloudflareApiError } from "./api-error.ts";
+import {
+  extractCloudflareResult,
+  type CloudflareApiListResponse,
+} from "./api-response.ts";
+import {
+  createCloudflareApi,
+  type CloudflareApi,
+  type CloudflareApiOptions,
+} from "./api.ts";
+
+/**
+ * Properties for creating or updating an {@link AccessGroup}.
+ */
+export interface AccessGroupProps extends CloudflareApiOptions {
+  /**
+   * Display name of the group.
+   *
+   * @default ${app}-${stage}-${id}
+   */
+  name?: string;
+
+  /**
+   * Rules that grant membership (OR logic — any match includes the user).
+   */
+  include?: AccessRule[];
+
+  /**
+   * Rules that revoke membership when matched.
+   */
+  exclude?: AccessRule[];
+
+  /**
+   * Rules that must additionally match for membership (AND logic).
+   */
+  require?: AccessRule[];
+
+  /**
+   * Mark this group as the account default. Default groups apply to every
+   * Access application unless explicitly overridden.
+   *
+   * @default false
+   */
+  isDefault?: boolean;
+
+  /**
+   * Adopt an existing group with the same name instead of failing.
+   *
+   * @default false
+   */
+  adopt?: boolean;
+
+  /**
+   * Whether to delete the group when removed from Alchemy.
+   *
+   * @default true
+   */
+  delete?: boolean;
+}
+
+/**
+ * Output for an {@link AccessGroup}.
+ */
+export type AccessGroup = Omit<AccessGroupProps, "adopt" | "delete"> & {
+  /** Cloudflare-assigned group UUID. */
+  id: string;
+  /** Display name. */
+  name: string;
+  /** ISO 8601 creation timestamp. */
+  createdAt: string;
+  /** ISO 8601 last-update timestamp. */
+  updatedAt: string;
+};
+
+/**
+ * Type guard for {@link AccessGroup}.
+ */
+export function isAccessGroup(resource: any): resource is AccessGroup {
+  return resource?.[ResourceKind] === "cloudflare::AccessGroup";
+}
+
+/**
+ * Cloudflare wire shape.
+ * @internal
+ */
+interface CloudflareAccessGroup {
+  id: string;
+  name: string;
+  include?: Record<string, unknown>[];
+  exclude?: Record<string, unknown>[];
+  require?: Record<string, unknown>[];
+  is_default?: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+/**
+ * Creates a Cloudflare Zero Trust [Access group](https://developers.cloudflare.com/cloudflare-one/identity/users/groups/),
+ * a reusable bundle of rules that can be referenced by Access policies.
+ *
+ * @example
+ * // Engineering team by email domain.
+ * const engineering = await AccessGroup("engineering", {
+ *   name: "Engineering",
+ *   include: [{ email_domain: { domain: "acme.com" } }],
+ * });
+ *
+ * @example
+ * // Allow a managed IP list, exclude one specific IP.
+ * const officeIps = await AccessGroup("office", {
+ *   name: "Office IPs",
+ *   include: [{ ip_list: { id: "<list-uuid>" } }],
+ *   exclude: [{ ip: { ip: "203.0.113.99/32" } }],
+ * });
+ */
+export const AccessGroup = Resource(
+  "cloudflare::AccessGroup",
+  async function (
+    this: Context<AccessGroup>,
+    id: string,
+    props: AccessGroupProps,
+  ): Promise<AccessGroup> {
+    const api = await createCloudflareApi(props);
+    const name = props.name ?? this.scope.createPhysicalName(id);
+    const basePath = `/accounts/${api.accountId}/access/groups`;
+
+    if (this.phase === "delete") {
+      if (this.output?.id && props.delete !== false) {
+        await deleteAccessGroup(api, this.output.id);
+      }
+      return this.destroy();
+    }
+
+    const body: Record<string, unknown> = {
+      name,
+      include: (props.include ?? []).map(serializeAccessRule),
+      exclude: (props.exclude ?? []).map(serializeAccessRule),
+      require: (props.require ?? []).map(serializeAccessRule),
+      is_default: props.isDefault ?? false,
+    };
+
+    let group: CloudflareAccessGroup;
+    if (this.phase === "update" && this.output?.id) {
+      group = await extractCloudflareResult<CloudflareAccessGroup>(
+        `update access group "${name}"`,
+        api.put(`${basePath}/${this.output.id}`, body),
+      );
+    } else {
+      const adopt = props.adopt ?? this.scope.adopt;
+      try {
+        group = await extractCloudflareResult<CloudflareAccessGroup>(
+          `create access group "${name}"`,
+          api.post(basePath, body),
+        );
+      } catch (err) {
+        if (adopt && isAccessDuplicateNameError(err)) {
+          const existing = await findAccessGroupByName(api, name);
+          if (!existing) {
+            throw new Error(
+              `Access group "${name}" already exists but could not be found for adoption.`,
+              { cause: err },
+            );
+          }
+          logger.log(
+            `Adopting existing access group "${name}" (${existing.id})`,
+          );
+          group = await extractCloudflareResult<CloudflareAccessGroup>(
+            `adopt access group "${name}"`,
+            api.put(`${basePath}/${existing.id}`, body),
+          );
+        } else {
+          throw err;
+        }
+      }
+    }
+
+    return {
+      id: group.id,
+      name: group.name,
+      include: props.include,
+      exclude: props.exclude,
+      require: props.require,
+      isDefault: group.is_default,
+      createdAt: group.created_at,
+      updatedAt: group.updated_at,
+    };
+  },
+);
+
+/** @internal */
+function isAccessDuplicateNameError(err: unknown): boolean {
+  if (
+    isCloudflareApiError(err, { status: 409 }) ||
+    isCloudflareApiError(err, { status: 400 })
+  ) {
+    const data = err.errorData;
+    return (
+      Array.isArray(data) &&
+      data.some(
+        (e) => "message" in e && /already exists/i.test(String(e.message)),
+      )
+    );
+  }
+  return false;
+}
+
+/** @internal */
+async function findAccessGroupByName(
+  api: CloudflareApi,
+  name: string,
+): Promise<CloudflareAccessGroup | null> {
+  let page = 1;
+  const perPage = 50;
+  while (true) {
+    const response = await api.get(
+      `/accounts/${api.accountId}/access/groups?page=${page}&per_page=${perPage}`,
+    );
+    if (!response.ok) return null;
+    const data =
+      (await response.json()) as CloudflareApiListResponse<CloudflareAccessGroup>;
+    const match = data.result.find((g) => g.name === name);
+    if (match) return match;
+    const info = data.result_info;
+    if (!info || info.page * info.per_page >= info.total_count) return null;
+    page++;
+  }
+}
+
+/** @internal */
+async function deleteAccessGroup(
+  api: CloudflareApi,
+  groupId: string,
+): Promise<void> {
+  const response = await api.delete(
+    `/accounts/${api.accountId}/access/groups/${groupId}`,
+  );
+  if (!response.ok && response.status !== 404) {
+    logger.error(
+      `Error deleting access group ${groupId}: ${response.status} ${response.statusText}`,
+    );
+  }
+}

--- a/alchemy/src/cloudflare/access-group.ts
+++ b/alchemy/src/cloudflare/access-group.ts
@@ -83,10 +83,6 @@ export function isAccessGroup(resource: any): resource is AccessGroup {
   return resource?.[ResourceKind] === "cloudflare::AccessGroup";
 }
 
-/**
- * Cloudflare wire shape.
- * @internal
- */
 interface CloudflareAccessGroup {
   id: string;
   name: string;
@@ -115,6 +111,38 @@ interface CloudflareAccessGroup {
  *   name: "Office IPs",
  *   include: [{ ip_list: { id: "<list-uuid>" } }],
  *   exclude: [{ ip: { ip: "203.0.113.99/32" } }],
+ * });
+ *
+ * @example
+ * // Compose groups: admins are engineers who are also on-call. Resources
+ * // can be passed directly — Alchemy lifts `.id` at the wire boundary.
+ * const onCall = await AccessGroup("on-call", {
+ *   include: [{ email_domain: { domain: "acme.com" } }],
+ * });
+ * const admins = await AccessGroup("admins", {
+ *   include: [{ group: { id: engineering } }],
+ *   require: [{ group: { id: onCall } }],
+ * });
+ *
+ * @example
+ * // IdP-bound rules — match Okta groups via an AccessIdentityProvider.
+ * const okta = await AccessIdentityProvider("okta", {
+ *   type: "okta",
+ *   name: "Acme Okta",
+ *   oktaAccount: "acme.okta.com",
+ *   clientId: "...",
+ *   clientSecret: alchemy.secret.env.OKTA_SECRET,
+ * });
+ * const sre = await AccessGroup("sre", {
+ *   include: [{ okta: { name: "sre", identity_provider_id: okta } }],
+ * });
+ *
+ * @example
+ * // Account default — applied implicitly to every Access application.
+ * await AccessGroup("default-deny", {
+ *   isDefault: true,
+ *   include: [{ everyone: {} }],
+ *   exclude: [{ email_domain: { domain: "acme.com" } }],
  * });
  */
 export const AccessGroup = Resource(
@@ -191,7 +219,6 @@ export const AccessGroup = Resource(
   },
 );
 
-/** @internal */
 function isAccessDuplicateNameError(err: unknown): boolean {
   if (
     isCloudflareApiError(err, { status: 409 }) ||
@@ -208,7 +235,6 @@ function isAccessDuplicateNameError(err: unknown): boolean {
   return false;
 }
 
-/** @internal */
 async function findAccessGroupByName(
   api: CloudflareApi,
   name: string,
@@ -230,7 +256,6 @@ async function findAccessGroupByName(
   }
 }
 
-/** @internal */
 async function deleteAccessGroup(
   api: CloudflareApi,
   groupId: string,

--- a/alchemy/src/cloudflare/access-identity-provider.ts
+++ b/alchemy/src/cloudflare/access-identity-provider.ts
@@ -72,12 +72,29 @@ export interface OneTimePinIdentityProviderProps extends BaseAccessIdpProps {
  */
 export interface GoogleIdentityProviderProps extends BaseAccessIdpProps {
   type: "google";
-  config: {
-    clientId: string;
-    clientSecret: string | Secret;
-    claims?: string[];
-    emailClaimName?: string;
-  };
+
+  /**
+   * OAuth 2.0 client ID issued by Google for your application.
+   * This is a public identifier (not a secret).
+   */
+  clientId: string;
+
+  /**
+   * OAuth 2.0 client secret issued by Google. Use {@link alchemy.secret} so
+   * the value is encrypted at rest in the Alchemy state file.
+   */
+  clientSecret: string | Secret;
+
+  /**
+   * Custom claims to request from the IdP and forward into the Access JWT.
+   */
+  claims?: string[];
+
+  /**
+   * Override the OIDC claim Cloudflare reads as the user's email
+   * (defaults to `email`).
+   */
+  emailClaimName?: string;
 }
 
 /**
@@ -85,15 +102,39 @@ export interface GoogleIdentityProviderProps extends BaseAccessIdpProps {
  */
 export interface OktaIdentityProviderProps extends BaseAccessIdpProps {
   type: "okta";
-  config: {
-    /** Your Okta tenant subdomain, e.g. `acme` for `acme.okta.com`. */
-    oktaAccount: string;
-    authorizationServerId?: string;
-    clientId: string;
-    clientSecret: string | Secret;
-    claims?: string[];
-    emailClaimName?: string;
-  };
+
+  /**
+   * Your Okta tenant subdomain, e.g. `acme` for `acme.okta.com`.
+   */
+  oktaAccount: string;
+
+  /**
+   * Custom Okta authorization server ID. Omit to use Okta's default
+   * authorization server.
+   */
+  authorizationServerId?: string;
+
+  /**
+   * OAuth 2.0 client ID of the Okta app integration.
+   */
+  clientId: string;
+
+  /**
+   * OAuth 2.0 client secret of the Okta app integration. Use
+   * {@link alchemy.secret} for at-rest encryption.
+   */
+  clientSecret: string | Secret;
+
+  /**
+   * Custom claims to request from Okta and forward into the Access JWT.
+   */
+  claims?: string[];
+
+  /**
+   * Override the OIDC claim Cloudflare reads as the user's email
+   * (defaults to `email`).
+   */
+  emailClaimName?: string;
 }
 
 /**
@@ -101,17 +142,58 @@ export interface OktaIdentityProviderProps extends BaseAccessIdpProps {
  */
 export interface OidcIdentityProviderProps extends BaseAccessIdpProps {
   type: "oidc";
-  config: {
-    authUrl: string;
-    tokenUrl: string;
-    certsUrl: string;
-    clientId: string;
-    clientSecret: string | Secret;
-    scopes?: string[];
-    claims?: string[];
-    emailClaimName?: string;
-    pkceEnabled?: boolean;
-  };
+
+  /**
+   * IdP authorization endpoint URL (the page users are redirected to to
+   * sign in).
+   */
+  authUrl: string;
+
+  /**
+   * IdP token endpoint URL (used by Cloudflare to exchange the auth code
+   * for tokens).
+   */
+  tokenUrl: string;
+
+  /**
+   * JWKS endpoint URL — public keys Cloudflare uses to verify ID-token
+   * signatures.
+   */
+  certsUrl: string;
+
+  /**
+   * OAuth 2.0 client ID registered with the IdP.
+   */
+  clientId: string;
+
+  /**
+   * OAuth 2.0 client secret registered with the IdP. Use
+   * {@link alchemy.secret} for at-rest encryption.
+   */
+  clientSecret: string | Secret;
+
+  /**
+   * OIDC scopes to request. Defaults to `["openid", "email", "profile"]`
+   * server-side if omitted.
+   */
+  scopes?: string[];
+
+  /**
+   * Custom claims to request from the IdP and forward into the Access JWT.
+   */
+  claims?: string[];
+
+  /**
+   * Override the OIDC claim Cloudflare reads as the user's email
+   * (defaults to `email`).
+   */
+  emailClaimName?: string;
+
+  /**
+   * Enable PKCE on the authorization code flow. Recommended for public
+   * clients and required by some IdPs.
+   */
+  pkceEnabled?: boolean;
 }
 
 /**
@@ -119,16 +201,46 @@ export interface OidcIdentityProviderProps extends BaseAccessIdpProps {
  */
 export interface SamlIdentityProviderProps extends BaseAccessIdpProps {
   type: "saml";
-  config: {
-    issuerUrl: string;
-    ssoTargetUrl: string;
-    /** PEM-encoded x509 certificates the IdP will use to sign assertions. */
-    idpPublicCerts: string[];
-    attributes?: string[];
-    emailAttributeName?: string;
-    headerAttributes?: { headerName: string; attributeName: string }[];
-    signRequest?: boolean;
-  };
+
+  /**
+   * SAML issuer (entity ID) of the IdP, used to validate the `Issuer`
+   * element of incoming assertions.
+   */
+  issuerUrl: string;
+
+  /**
+   * IdP single sign-on URL — Cloudflare redirects users here to start
+   * the SAML flow.
+   */
+  ssoTargetUrl: string;
+
+  /**
+   * PEM-encoded x509 certificates the IdP will use to sign assertions.
+   * Multiple entries support certificate rotation.
+   */
+  idpPublicCerts: string[];
+
+  /**
+   * SAML attributes to forward from the assertion into the Access JWT.
+   */
+  attributes?: string[];
+
+  /**
+   * Override the SAML attribute Cloudflare reads as the user's email
+   * (defaults to `email`).
+   */
+  emailAttributeName?: string;
+
+  /**
+   * Map SAML attributes to HTTP headers Cloudflare will inject when
+   * forwarding requests to the origin.
+   */
+  headerAttributes?: { headerName: string; attributeName: string }[];
+
+  /**
+   * Sign outgoing AuthnRequests with Cloudflare's signing key.
+   */
+  signRequest?: boolean;
 }
 
 /**
@@ -137,13 +249,20 @@ export interface SamlIdentityProviderProps extends BaseAccessIdpProps {
  * `onelogin`, `pingone`, `yandex`, or future providers).
  *
  * Pass a free-form camelCase `config` object — keys are converted to
- * snake_case at the API boundary.
+ * snake_case at the API boundary. This nested escape hatch is an
+ * intentional exception to the flat-props convention used by the strict
+ * variants above.
  */
 export interface OtherIdentityProviderProps extends BaseAccessIdpProps {
   type: Exclude<
     AccessIdentityProviderType,
     "onetimepin" | "google" | "okta" | "oidc" | "saml"
   >;
+
+  /**
+   * Free-form provider configuration. Use {@link alchemy.secret} for any
+   * sensitive values; they are unwrapped before sending to Cloudflare.
+   */
   config: { clientId?: string; clientSecret?: string | Secret } & Record<
     string,
     unknown
@@ -183,10 +302,6 @@ export function isAccessIdentityProvider(
   return resource?.[ResourceKind] === "cloudflare::AccessIdentityProvider";
 }
 
-/**
- * Cloudflare wire shape.
- * @internal
- */
 interface CloudflareAccessIdentityProvider {
   id: string;
   name: string;
@@ -210,10 +325,8 @@ interface CloudflareAccessIdentityProvider {
  * const google = await AccessIdentityProvider("google", {
  *   type: "google",
  *   name: "Google",
- *   config: {
- *     clientId: process.env.GOOGLE_CLIENT_ID!,
- *     clientSecret: alchemy.secret.env.GOOGLE_CLIENT_SECRET,
- *   },
+ *   clientId: process.env.GOOGLE_CLIENT_ID!,
+ *   clientSecret: alchemy.secret.env.GOOGLE_CLIENT_SECRET,
  * });
  *
  * @example
@@ -221,15 +334,13 @@ interface CloudflareAccessIdentityProvider {
  * const oidc = await AccessIdentityProvider("idp", {
  *   type: "oidc",
  *   name: "Corporate IdP",
- *   config: {
- *     authUrl: "https://idp.example.com/oauth2/authorize",
- *     tokenUrl: "https://idp.example.com/oauth2/token",
- *     certsUrl: "https://idp.example.com/oauth2/certs",
- *     clientId: "my-app",
- *     clientSecret: alchemy.secret.env.IDP_CLIENT_SECRET,
- *     scopes: ["openid", "email", "profile"],
- *     pkceEnabled: true,
- *   },
+ *   authUrl: "https://idp.example.com/oauth2/authorize",
+ *   tokenUrl: "https://idp.example.com/oauth2/token",
+ *   certsUrl: "https://idp.example.com/oauth2/certs",
+ *   clientId: "my-app",
+ *   clientSecret: alchemy.secret.env.IDP_CLIENT_SECRET,
+ *   scopes: ["openid", "email", "profile"],
+ *   pkceEnabled: true,
  * });
  */
 export const AccessIdentityProvider = Resource(
@@ -265,10 +376,7 @@ export const AccessIdentityProvider = Resource(
     const body: Record<string, unknown> = {
       name,
       type: props.type,
-      config:
-        "config" in props && props.config
-          ? camelToSnakeWithSecrets(props.config as Record<string, unknown>)
-          : {},
+      config: extractIdpConfig(props),
     };
 
     let result: CloudflareAccessIdentityProvider;
@@ -312,8 +420,12 @@ export const AccessIdentityProvider = Resource(
     delete rest.adopt;
     delete rest.delete;
 
-    // Output convention (CLAUDE.md): secrets are always wrapped. If the user
-    // passed a raw string for clientSecret, normalize it before returning.
+    // Output convention (CLAUDE.md): secrets are always wrapped. Strict
+    // variants carry `clientSecret` at the top level; the `Other` variant
+    // tucks it inside `config`.
+    if (typeof rest.clientSecret === "string") {
+      rest.clientSecret = Secret.wrap(rest.clientSecret);
+    }
     const config = rest.config as Record<string, unknown> | undefined;
     if (config && typeof config.clientSecret === "string") {
       rest.config = {
@@ -331,11 +443,51 @@ export const AccessIdentityProvider = Resource(
 );
 
 /**
+ * Top-level prop keys that are *not* part of the IdP-specific configuration
+ * (the wire `config` blob) — Alchemy/Cloudflare metadata, the type
+ * discriminator, and the explicit `config` escape hatch on the `Other`
+ * variant.
+ */
+const IDP_METADATA_KEYS = new Set<string>([
+  "name",
+  "type",
+  "adopt",
+  "delete",
+  "baseUrl",
+  "profile",
+  "apiKey",
+  "apiToken",
+  "accountId",
+  "email",
+  "config",
+]);
+
+/**
+ * Build the wire-format `config` blob from props. Strict variants store
+ * config fields flat at the top level; the `Other` variant uses an explicit
+ * nested `config` object as an escape hatch.
+ */
+function extractIdpConfig(
+  props: AccessIdentityProviderProps,
+): Record<string, unknown> {
+  if ("config" in props && props.config) {
+    return camelToSnakeWithSecrets(props.config as Record<string, unknown>);
+  }
+  const flat: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(
+    props as unknown as Record<string, unknown>,
+  )) {
+    if (!IDP_METADATA_KEYS.has(key) && value !== undefined) {
+      flat[key] = value;
+    }
+  }
+  return camelToSnakeWithSecrets(flat);
+}
+
+/**
  * Convert a camelCase config object to snake_case for the wire, unwrapping
  * any {@link Secret} values along the way. Recurses into arrays of objects
  * (e.g. SAML `headerAttributes`).
- *
- * @internal
  */
 function camelToSnakeWithSecrets(
   input: Record<string, unknown>,
@@ -364,7 +516,6 @@ function transformValue(value: unknown): unknown {
 /**
  * Cloudflare returns 409/400 with an "already exists" message for duplicate
  * IdP names.
- * @internal
  */
 function isAccessDuplicateNameError(err: unknown): boolean {
   if (
@@ -384,7 +535,6 @@ function isAccessDuplicateNameError(err: unknown): boolean {
 
 /**
  * Look up an existing IdP by name across paginated results.
- * @internal
  */
 async function findAccessIdentityProviderByName(
   api: CloudflareApi,
@@ -409,7 +559,6 @@ async function findAccessIdentityProviderByName(
 
 /**
  * Delete an IdP. Cloudflare returns 400 if any Application references it.
- * @internal
  */
 async function deleteAccessIdentityProvider(
   api: CloudflareApi,

--- a/alchemy/src/cloudflare/access-identity-provider.ts
+++ b/alchemy/src/cloudflare/access-identity-provider.ts
@@ -259,15 +259,17 @@ export const AccessIdentityProvider = Resource(
       this.replace(true);
     }
 
+    // Cloudflare requires `config` to always be present, even for variants
+    // that don't take any (e.g. `onetimepin`). Omitting it returns
+    // [12130] "unexpected end of JSON input".
     const body: Record<string, unknown> = {
       name,
       type: props.type,
+      config:
+        "config" in props && props.config
+          ? camelToSnakeWithSecrets(props.config as Record<string, unknown>)
+          : {},
     };
-    if ("config" in props && props.config) {
-      body.config = camelToSnakeWithSecrets(
-        props.config as Record<string, unknown>,
-      );
-    }
 
     let result: CloudflareAccessIdentityProvider;
     if (this.phase === "update" && this.output?.id) {

--- a/alchemy/src/cloudflare/access-identity-provider.ts
+++ b/alchemy/src/cloudflare/access-identity-provider.ts
@@ -1,0 +1,422 @@
+import type { Context } from "../context.ts";
+import { Resource, ResourceKind } from "../resource.ts";
+import { Secret } from "../secret.ts";
+import { logger } from "../util/logger.ts";
+import { isCloudflareApiError } from "./api-error.ts";
+import {
+  extractCloudflareResult,
+  type CloudflareApiListResponse,
+} from "./api-response.ts";
+import {
+  createCloudflareApi,
+  type CloudflareApi,
+  type CloudflareApiOptions,
+} from "./api.ts";
+
+/**
+ * Supported Access identity provider types. The five most common providers
+ * have strict {@link AccessIdentityProviderProps} variants below; everything
+ * else falls back to {@link OtherIdentityProviderProps} with a permissive
+ * `config` shape.
+ */
+export type AccessIdentityProviderType =
+  | "onetimepin"
+  | "google"
+  | "google-apps"
+  | "github"
+  | "okta"
+  | "azureAD"
+  | "oidc"
+  | "saml"
+  | "centrify"
+  | "facebook"
+  | "linkedin"
+  | "onelogin"
+  | "pingone"
+  | "yandex"
+  | (string & {});
+
+interface BaseAccessIdpProps extends CloudflareApiOptions {
+  /**
+   * Display name shown on the Access login page.
+   *
+   * @default ${app}-${stage}-${id}
+   */
+  name?: string;
+
+  /**
+   * Adopt an existing IdP with the same name instead of failing.
+   *
+   * @default false
+   */
+  adopt?: boolean;
+
+  /**
+   * Whether to delete the IdP when removed from Alchemy.
+   *
+   * @default true
+   */
+  delete?: boolean;
+}
+
+/**
+ * One-Time PIN — Cloudflare emails a code to the user. No external IdP
+ * configuration required.
+ */
+export interface OneTimePinIdentityProviderProps extends BaseAccessIdpProps {
+  type: "onetimepin";
+}
+
+/**
+ * Google OAuth identity provider.
+ */
+export interface GoogleIdentityProviderProps extends BaseAccessIdpProps {
+  type: "google";
+  config: {
+    clientId: string;
+    clientSecret: string | Secret;
+    claims?: string[];
+    emailClaimName?: string;
+  };
+}
+
+/**
+ * Okta identity provider (OIDC under the hood).
+ */
+export interface OktaIdentityProviderProps extends BaseAccessIdpProps {
+  type: "okta";
+  config: {
+    /** Your Okta tenant subdomain, e.g. `acme` for `acme.okta.com`. */
+    oktaAccount: string;
+    authorizationServerId?: string;
+    clientId: string;
+    clientSecret: string | Secret;
+    claims?: string[];
+    emailClaimName?: string;
+  };
+}
+
+/**
+ * Generic OpenID Connect identity provider.
+ */
+export interface OidcIdentityProviderProps extends BaseAccessIdpProps {
+  type: "oidc";
+  config: {
+    authUrl: string;
+    tokenUrl: string;
+    certsUrl: string;
+    clientId: string;
+    clientSecret: string | Secret;
+    scopes?: string[];
+    claims?: string[];
+    emailClaimName?: string;
+    pkceEnabled?: boolean;
+  };
+}
+
+/**
+ * Generic SAML 2.0 identity provider.
+ */
+export interface SamlIdentityProviderProps extends BaseAccessIdpProps {
+  type: "saml";
+  config: {
+    issuerUrl: string;
+    ssoTargetUrl: string;
+    /** PEM-encoded x509 certificates the IdP will use to sign assertions. */
+    idpPublicCerts: string[];
+    attributes?: string[];
+    emailAttributeName?: string;
+    headerAttributes?: { headerName: string; attributeName: string }[];
+    signRequest?: boolean;
+  };
+}
+
+/**
+ * Catch-all for IdP types not covered by a strict variant
+ * (`azureAD`, `github`, `google-apps`, `centrify`, `facebook`, `linkedin`,
+ * `onelogin`, `pingone`, `yandex`, or future providers).
+ *
+ * Pass a free-form camelCase `config` object — keys are converted to
+ * snake_case at the API boundary.
+ */
+export interface OtherIdentityProviderProps extends BaseAccessIdpProps {
+  type: Exclude<
+    AccessIdentityProviderType,
+    "onetimepin" | "google" | "okta" | "oidc" | "saml"
+  >;
+  config: { clientId?: string; clientSecret?: string | Secret } & Record<
+    string,
+    unknown
+  >;
+}
+
+/**
+ * Properties for creating or updating an {@link AccessIdentityProvider}.
+ */
+export type AccessIdentityProviderProps =
+  | OneTimePinIdentityProviderProps
+  | GoogleIdentityProviderProps
+  | OktaIdentityProviderProps
+  | OidcIdentityProviderProps
+  | SamlIdentityProviderProps
+  | OtherIdentityProviderProps;
+
+/**
+ * Output for an {@link AccessIdentityProvider}.
+ */
+export type AccessIdentityProvider = Omit<
+  AccessIdentityProviderProps,
+  "adopt" | "delete"
+> & {
+  /** Cloudflare-assigned IdP UUID. */
+  id: string;
+  /** Display name. */
+  name: string;
+};
+
+/**
+ * Type guard for {@link AccessIdentityProvider}.
+ */
+export function isAccessIdentityProvider(
+  resource: any,
+): resource is AccessIdentityProvider {
+  return resource?.[ResourceKind] === "cloudflare::AccessIdentityProvider";
+}
+
+/**
+ * Cloudflare wire shape.
+ * @internal
+ */
+interface CloudflareAccessIdentityProvider {
+  id: string;
+  name: string;
+  type: string;
+  config?: Record<string, unknown>;
+}
+
+/**
+ * Creates a Cloudflare Zero Trust [Access identity provider](https://developers.cloudflare.com/cloudflare-one/identity/idp-integration/)
+ * which lets users sign in to Access-protected applications.
+ *
+ * @example
+ * // Built-in One-Time PIN (no IdP setup required).
+ * const otp = await AccessIdentityProvider("otp", {
+ *   type: "onetimepin",
+ *   name: "Email OTP",
+ * });
+ *
+ * @example
+ * // Google OAuth.
+ * const google = await AccessIdentityProvider("google", {
+ *   type: "google",
+ *   name: "Google",
+ *   config: {
+ *     clientId: alchemy.secret.env.GOOGLE_CLIENT_ID.unencrypted,
+ *     clientSecret: alchemy.secret.env.GOOGLE_CLIENT_SECRET,
+ *   },
+ * });
+ *
+ * @example
+ * // Generic OIDC provider.
+ * const oidc = await AccessIdentityProvider("idp", {
+ *   type: "oidc",
+ *   name: "Corporate IdP",
+ *   config: {
+ *     authUrl: "https://idp.example.com/oauth2/authorize",
+ *     tokenUrl: "https://idp.example.com/oauth2/token",
+ *     certsUrl: "https://idp.example.com/oauth2/certs",
+ *     clientId: "my-app",
+ *     clientSecret: alchemy.secret.env.IDP_CLIENT_SECRET,
+ *     scopes: ["openid", "email", "profile"],
+ *     pkceEnabled: true,
+ *   },
+ * });
+ */
+export const AccessIdentityProvider = Resource(
+  "cloudflare::AccessIdentityProvider",
+  async function (
+    this: Context<AccessIdentityProvider>,
+    id: string,
+    props: AccessIdentityProviderProps,
+  ): Promise<AccessIdentityProvider> {
+    const api = await createCloudflareApi(props);
+    const name = props.name ?? this.scope.createPhysicalName(id);
+    const basePath = `/accounts/${api.accountId}/access/identity_providers`;
+
+    if (this.phase === "delete") {
+      if (this.output?.id && props.delete !== false) {
+        await deleteAccessIdentityProvider(api, this.output.id);
+      }
+      return this.destroy();
+    }
+
+    // type is immutable — recreate if it changed.
+    if (
+      this.phase === "update" &&
+      this.output &&
+      this.output.type !== props.type
+    ) {
+      this.replace(true);
+    }
+
+    const body: Record<string, unknown> = {
+      name,
+      type: props.type,
+    };
+    if ("config" in props && props.config) {
+      body.config = camelToSnakeWithSecrets(
+        props.config as Record<string, unknown>,
+      );
+    }
+
+    let result: CloudflareAccessIdentityProvider;
+    if (this.phase === "update" && this.output?.id) {
+      result = await extractCloudflareResult<CloudflareAccessIdentityProvider>(
+        `update access identity provider "${name}"`,
+        api.put(`${basePath}/${this.output.id}`, body),
+      );
+    } else {
+      const adopt = props.adopt ?? this.scope.adopt;
+      try {
+        result =
+          await extractCloudflareResult<CloudflareAccessIdentityProvider>(
+            `create access identity provider "${name}"`,
+            api.post(basePath, body),
+          );
+      } catch (err) {
+        if (adopt && isAccessDuplicateNameError(err)) {
+          const existing = await findAccessIdentityProviderByName(api, name);
+          if (!existing) {
+            throw new Error(
+              `Identity provider "${name}" already exists but could not be found for adoption.`,
+              { cause: err },
+            );
+          }
+          logger.log(
+            `Adopting existing access identity provider "${name}" (${existing.id})`,
+          );
+          result =
+            await extractCloudflareResult<CloudflareAccessIdentityProvider>(
+              `adopt access identity provider "${name}"`,
+              api.put(`${basePath}/${existing.id}`, body),
+            );
+        } else {
+          throw err;
+        }
+      }
+    }
+
+    const { adopt: _adopt, delete: _delete, ...rest } = props;
+    void _adopt;
+    void _delete;
+    return {
+      ...rest,
+      id: result.id,
+      name: result.name,
+    } as AccessIdentityProvider;
+  },
+);
+
+/**
+ * Convert a camelCase config object to snake_case for the wire, unwrapping
+ * any {@link Secret} values along the way. Recurses into arrays of objects
+ * (e.g. SAML `headerAttributes`).
+ *
+ * @internal
+ */
+function camelToSnakeWithSecrets(
+  input: Record<string, unknown>,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(input)) {
+    if (value === undefined) continue;
+    const snakeKey = key.replace(/[A-Z]/g, (c) => `_${c.toLowerCase()}`);
+    out[snakeKey] = transformValue(value);
+  }
+  return out;
+}
+
+function transformValue(value: unknown): unknown {
+  if (value instanceof Secret) return value.unencrypted;
+  if (Array.isArray(value)) {
+    return value.map((item) =>
+      item && typeof item === "object" && !Array.isArray(item)
+        ? camelToSnakeWithSecrets(item as Record<string, unknown>)
+        : transformValue(item),
+    );
+  }
+  return value;
+}
+
+/**
+ * Cloudflare returns 409/400 with an "already exists" message for duplicate
+ * IdP names.
+ * @internal
+ */
+function isAccessDuplicateNameError(err: unknown): boolean {
+  if (
+    isCloudflareApiError(err, { status: 409 }) ||
+    isCloudflareApiError(err, { status: 400 })
+  ) {
+    const data = err.errorData;
+    return (
+      Array.isArray(data) &&
+      data.some(
+        (e) => "message" in e && /already exists/i.test(String(e.message)),
+      )
+    );
+  }
+  return false;
+}
+
+/**
+ * Look up an existing IdP by name across paginated results.
+ * @internal
+ */
+async function findAccessIdentityProviderByName(
+  api: CloudflareApi,
+  name: string,
+): Promise<CloudflareAccessIdentityProvider | null> {
+  let page = 1;
+  const perPage = 50;
+  while (true) {
+    const response = await api.get(
+      `/accounts/${api.accountId}/access/identity_providers?page=${page}&per_page=${perPage}`,
+    );
+    if (!response.ok) return null;
+    const data =
+      (await response.json()) as CloudflareApiListResponse<CloudflareAccessIdentityProvider>;
+    const match = data.result.find((p) => p.name === name);
+    if (match) return match;
+    const info = data.result_info;
+    if (!info || info.page * info.per_page >= info.total_count) return null;
+    page++;
+  }
+}
+
+/**
+ * Delete an IdP. Cloudflare returns 400 if any Application references it.
+ * @internal
+ */
+async function deleteAccessIdentityProvider(
+  api: CloudflareApi,
+  idpId: string,
+): Promise<void> {
+  const response = await api.delete(
+    `/accounts/${api.accountId}/access/identity_providers/${idpId}`,
+  );
+  if (!response.ok && response.status !== 404) {
+    let body = "";
+    try {
+      body = await response.text();
+    } catch {}
+    if (/in use|reference|associated/i.test(body)) {
+      throw new Error(
+        `Cannot delete identity provider ${idpId}: it is referenced by one or more Access applications. Remove those references first.\n${body}`,
+      );
+    }
+    logger.error(
+      `Error deleting access identity provider ${idpId}: ${response.status} ${response.statusText}\n${body}`,
+    );
+  }
+}

--- a/alchemy/src/cloudflare/access-identity-provider.ts
+++ b/alchemy/src/cloudflare/access-identity-provider.ts
@@ -206,12 +206,12 @@ interface CloudflareAccessIdentityProvider {
  * });
  *
  * @example
- * // Google OAuth.
+ * // Google OAuth. clientId is a public OAuth identifier (not a secret).
  * const google = await AccessIdentityProvider("google", {
  *   type: "google",
  *   name: "Google",
  *   config: {
- *     clientId: alchemy.secret.env.GOOGLE_CLIENT_ID.unencrypted,
+ *     clientId: process.env.GOOGLE_CLIENT_ID!,
  *     clientSecret: alchemy.secret.env.GOOGLE_CLIENT_SECRET,
  *   },
  * });
@@ -306,9 +306,20 @@ export const AccessIdentityProvider = Resource(
       }
     }
 
-    const { adopt: _adopt, delete: _delete, ...rest } = props;
-    void _adopt;
-    void _delete;
+    const rest: Record<string, unknown> = { ...props };
+    delete rest.adopt;
+    delete rest.delete;
+
+    // Output convention (CLAUDE.md): secrets are always wrapped. If the user
+    // passed a raw string for clientSecret, normalize it before returning.
+    const config = rest.config as Record<string, unknown> | undefined;
+    if (config && typeof config.clientSecret === "string") {
+      rest.config = {
+        ...config,
+        clientSecret: Secret.wrap(config.clientSecret),
+      };
+    }
+
     return {
       ...rest,
       id: result.id,

--- a/alchemy/src/cloudflare/access-policy.ts
+++ b/alchemy/src/cloudflare/access-policy.ts
@@ -73,8 +73,8 @@ export interface AccessPolicyProps extends CloudflareApiOptions {
   decision: AccessPolicyDecision;
 
   /**
-   * Rules a request must match to be considered (OR logic). At least one
-   * rule is required.
+   * Rules a request must match to be considered (OR logic). Must be
+   * non-empty — Cloudflare rejects policies with no include rules.
    */
   include: AccessRule[];
 

--- a/alchemy/src/cloudflare/access-policy.ts
+++ b/alchemy/src/cloudflare/access-policy.ts
@@ -1,0 +1,399 @@
+import type { Context } from "../context.ts";
+import { Resource, ResourceKind } from "../resource.ts";
+import { logger } from "../util/logger.ts";
+import { serializeAccessRule, type AccessRule } from "./access-rule.ts";
+import { isCloudflareApiError } from "./api-error.ts";
+import {
+  extractCloudflareResult,
+  type CloudflareApiListResponse,
+} from "./api-response.ts";
+import {
+  createCloudflareApi,
+  type CloudflareApi,
+  type CloudflareApiOptions,
+} from "./api.ts";
+
+/**
+ * Access decision a policy applies when its rules match.
+ * - `allow`: grant access when an authenticated user matches `include`.
+ * - `deny`: deny access when matched.
+ * - `non_identity`: allow without identity (e.g. service tokens, IP allowlists).
+ * - `bypass`: skip Access entirely (no auth required).
+ */
+export type AccessPolicyDecision = "allow" | "deny" | "non_identity" | "bypass";
+
+/**
+ * An approval group authorising an access request when
+ * `approvalRequired: true`.
+ */
+export interface AccessPolicyApprovalGroup {
+  /** Number of approvals required from this group. */
+  approvalsNeeded: number;
+  /** Email addresses of approvers. */
+  emailAddresses?: string[];
+  /** UUID of an Access email list. */
+  emailListUuid?: string;
+}
+
+/**
+ * Optional MFA enforcement on top of the IdP's authentication.
+ */
+export interface AccessPolicyMfaConfig {
+  allowedAuthenticators?: string[];
+  mfaDisabled?: boolean;
+  /** Cloudflare duration string, e.g. `"30m"`. */
+  sessionDuration?: string;
+}
+
+/**
+ * Connection-protocol-specific options (currently only RDP clipboard
+ * formats are supported by Cloudflare).
+ */
+export interface AccessPolicyConnectionRules {
+  rdp?: {
+    allowedClipboardFormats?: ("text" | "image" | "files")[];
+  };
+}
+
+/**
+ * Properties for creating or updating an {@link AccessPolicy}.
+ */
+export interface AccessPolicyProps extends CloudflareApiOptions {
+  /**
+   * Display name of the policy.
+   *
+   * @default ${app}-${stage}-${id}
+   */
+  name?: string;
+
+  /**
+   * Decision the policy applies. **Immutable** — changing the decision will
+   * trigger replacement of the underlying Cloudflare resource.
+   */
+  decision: AccessPolicyDecision;
+
+  /**
+   * Rules a request must match to be considered (OR logic). At least one
+   * rule is required.
+   */
+  include: AccessRule[];
+
+  /**
+   * Rules that, when matched, exclude the request from this policy.
+   */
+  exclude?: AccessRule[];
+
+  /**
+   * Rules that must additionally match (AND logic).
+   */
+  require?: AccessRule[];
+
+  /**
+   * Require explicit approval before granting access.
+   */
+  approvalRequired?: boolean;
+
+  /**
+   * Approver groups consulted when `approvalRequired: true`.
+   */
+  approvalGroups?: AccessPolicyApprovalGroup[];
+
+  /**
+   * Prompt the user for a purpose justification on each access.
+   */
+  purposeJustificationRequired?: boolean;
+
+  /**
+   * Prompt text shown when `purposeJustificationRequired` is true.
+   */
+  purposeJustificationPrompt?: string;
+
+  /**
+   * Force isolated browser rendering for this policy.
+   */
+  isolationRequired?: boolean;
+
+  /**
+   * Optional MFA enforcement.
+   */
+  mfaConfig?: AccessPolicyMfaConfig;
+
+  /**
+   * Override the default Access session duration (Cloudflare duration string).
+   */
+  sessionDuration?: string;
+
+  /**
+   * Per-protocol connection rules (e.g. RDP clipboard restrictions).
+   */
+  connectionRules?: AccessPolicyConnectionRules;
+
+  /**
+   * Adopt an existing policy with the same name instead of failing.
+   *
+   * @default false
+   */
+  adopt?: boolean;
+
+  /**
+   * Whether to delete the policy when removed from Alchemy.
+   *
+   * @default true
+   */
+  delete?: boolean;
+}
+
+/**
+ * Output for an {@link AccessPolicy}.
+ */
+export type AccessPolicy = Omit<AccessPolicyProps, "adopt" | "delete"> & {
+  /** Cloudflare-assigned policy UUID. */
+  id: string;
+  /** Display name. */
+  name: string;
+  /** Number of applications currently referencing this policy. */
+  appCount: number;
+  /** ISO 8601 creation timestamp. */
+  createdAt: string;
+  /** ISO 8601 last-update timestamp. */
+  updatedAt: string;
+};
+
+/**
+ * Type guard for {@link AccessPolicy}.
+ */
+export function isAccessPolicy(resource: any): resource is AccessPolicy {
+  return resource?.[ResourceKind] === "cloudflare::AccessPolicy";
+}
+
+/**
+ * Cloudflare wire shape.
+ * @internal
+ */
+interface CloudflareAccessPolicy {
+  id: string;
+  name: string;
+  decision: AccessPolicyDecision;
+  include: Record<string, unknown>[];
+  exclude?: Record<string, unknown>[];
+  require?: Record<string, unknown>[];
+  app_count?: number;
+  reusable?: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+/**
+ * Creates a reusable Cloudflare Zero Trust [Access policy](https://developers.cloudflare.com/cloudflare-one/policies/access/)
+ * that can be attached to one or more {@link AccessApplication} resources.
+ *
+ * @example
+ * // Allow employees from a specific email domain.
+ * const employees = await AccessPolicy("employees", {
+ *   name: "Employees",
+ *   decision: "allow",
+ *   include: [{ email_domain: { domain: "acme.com" } }],
+ * });
+ *
+ * @example
+ * // Bypass Access for an office IP range.
+ * const officeBypass = await AccessPolicy("office-bypass", {
+ *   name: "Office Bypass",
+ *   decision: "bypass",
+ *   include: [{ ip: { ip: "203.0.113.0/24" } }],
+ * });
+ *
+ * @example
+ * // Reference an AccessGroup and require approval.
+ * const sensitive = await AccessPolicy("sensitive", {
+ *   name: "Sensitive admin access",
+ *   decision: "allow",
+ *   include: [{ group: { id: adminGroup } }],
+ *   approvalRequired: true,
+ *   approvalGroups: [
+ *     { approvalsNeeded: 2, emailAddresses: ["security@acme.com"] },
+ *   ],
+ *   isolationRequired: true,
+ * });
+ */
+export const AccessPolicy = Resource(
+  "cloudflare::AccessPolicy",
+  async function (
+    this: Context<AccessPolicy>,
+    id: string,
+    props: AccessPolicyProps,
+  ): Promise<AccessPolicy> {
+    const api = await createCloudflareApi(props);
+    const name = props.name ?? this.scope.createPhysicalName(id);
+    const basePath = `/accounts/${api.accountId}/access/policies`;
+
+    if (this.phase === "delete") {
+      if (this.output?.id && props.delete !== false) {
+        await deleteAccessPolicy(api, this.output.id);
+      }
+      return this.destroy();
+    }
+
+    if (!props.include || props.include.length === 0) {
+      throw new Error(
+        `AccessPolicy "${name}" requires at least one rule in 'include'.`,
+      );
+    }
+
+    // decision is immutable — recreate if it changed.
+    if (
+      this.phase === "update" &&
+      this.output &&
+      this.output.decision !== props.decision
+    ) {
+      this.replace(true);
+    }
+
+    const body: Record<string, unknown> = {
+      name,
+      decision: props.decision,
+      reusable: true,
+      include: props.include.map(serializeAccessRule),
+      exclude: (props.exclude ?? []).map(serializeAccessRule),
+      require: (props.require ?? []).map(serializeAccessRule),
+    };
+    if (props.approvalRequired !== undefined)
+      body.approval_required = props.approvalRequired;
+    if (props.approvalGroups)
+      body.approval_groups = props.approvalGroups.map((g) => ({
+        approvals_needed: g.approvalsNeeded,
+        email_addresses: g.emailAddresses,
+        email_list_uuid: g.emailListUuid,
+      }));
+    if (props.purposeJustificationRequired !== undefined)
+      body.purpose_justification_required = props.purposeJustificationRequired;
+    if (props.purposeJustificationPrompt !== undefined)
+      body.purpose_justification_prompt = props.purposeJustificationPrompt;
+    if (props.isolationRequired !== undefined)
+      body.isolation_required = props.isolationRequired;
+    if (props.sessionDuration !== undefined)
+      body.session_duration = props.sessionDuration;
+    if (props.mfaConfig)
+      body.mfa_config = {
+        allowed_authenticators: props.mfaConfig.allowedAuthenticators,
+        mfa_disabled: props.mfaConfig.mfaDisabled,
+        session_duration: props.mfaConfig.sessionDuration,
+      };
+    if (props.connectionRules?.rdp)
+      body.connection_rules = {
+        rdp: {
+          allowed_clipboard_formats:
+            props.connectionRules.rdp.allowedClipboardFormats,
+        },
+      };
+
+    let policy: CloudflareAccessPolicy;
+    if (this.phase === "update" && this.output?.id) {
+      policy = await extractCloudflareResult<CloudflareAccessPolicy>(
+        `update access policy "${name}"`,
+        api.put(`${basePath}/${this.output.id}`, body),
+      );
+    } else {
+      const adopt = props.adopt ?? this.scope.adopt;
+      try {
+        policy = await extractCloudflareResult<CloudflareAccessPolicy>(
+          `create access policy "${name}"`,
+          api.post(basePath, body),
+        );
+      } catch (err) {
+        if (adopt && isAccessDuplicateNameError(err)) {
+          const existing = await findAccessPolicyByName(api, name);
+          if (!existing) {
+            throw new Error(
+              `Access policy "${name}" already exists but could not be found for adoption.`,
+              { cause: err },
+            );
+          }
+          logger.log(
+            `Adopting existing access policy "${name}" (${existing.id})`,
+          );
+          policy = await extractCloudflareResult<CloudflareAccessPolicy>(
+            `adopt access policy "${name}"`,
+            api.put(`${basePath}/${existing.id}`, body),
+          );
+        } else {
+          throw err;
+        }
+      }
+    }
+
+    return {
+      id: policy.id,
+      name: policy.name,
+      decision: policy.decision,
+      include: props.include,
+      exclude: props.exclude,
+      require: props.require,
+      approvalRequired: props.approvalRequired,
+      approvalGroups: props.approvalGroups,
+      purposeJustificationRequired: props.purposeJustificationRequired,
+      purposeJustificationPrompt: props.purposeJustificationPrompt,
+      isolationRequired: props.isolationRequired,
+      mfaConfig: props.mfaConfig,
+      sessionDuration: props.sessionDuration,
+      connectionRules: props.connectionRules,
+      appCount: policy.app_count ?? 0,
+      createdAt: policy.created_at,
+      updatedAt: policy.updated_at,
+    };
+  },
+);
+
+/** @internal */
+function isAccessDuplicateNameError(err: unknown): boolean {
+  if (
+    isCloudflareApiError(err, { status: 409 }) ||
+    isCloudflareApiError(err, { status: 400 })
+  ) {
+    const data = err.errorData;
+    return (
+      Array.isArray(data) &&
+      data.some(
+        (e) => "message" in e && /already exists/i.test(String(e.message)),
+      )
+    );
+  }
+  return false;
+}
+
+/** @internal */
+async function findAccessPolicyByName(
+  api: CloudflareApi,
+  name: string,
+): Promise<CloudflareAccessPolicy | null> {
+  let page = 1;
+  const perPage = 50;
+  while (true) {
+    const response = await api.get(
+      `/accounts/${api.accountId}/access/policies?page=${page}&per_page=${perPage}`,
+    );
+    if (!response.ok) return null;
+    const data =
+      (await response.json()) as CloudflareApiListResponse<CloudflareAccessPolicy>;
+    const match = data.result.find((p) => p.name === name);
+    if (match) return match;
+    const info = data.result_info;
+    if (!info || info.page * info.per_page >= info.total_count) return null;
+    page++;
+  }
+}
+
+/** @internal */
+async function deleteAccessPolicy(
+  api: CloudflareApi,
+  policyId: string,
+): Promise<void> {
+  const response = await api.delete(
+    `/accounts/${api.accountId}/access/policies/${policyId}`,
+  );
+  if (!response.ok && response.status !== 404) {
+    logger.error(
+      `Error deleting access policy ${policyId}: ${response.status} ${response.statusText}`,
+    );
+  }
+}

--- a/alchemy/src/cloudflare/access-policy.ts
+++ b/alchemy/src/cloudflare/access-policy.ts
@@ -166,10 +166,6 @@ export function isAccessPolicy(resource: any): resource is AccessPolicy {
   return resource?.[ResourceKind] === "cloudflare::AccessPolicy";
 }
 
-/**
- * Cloudflare wire shape.
- * @internal
- */
 interface CloudflareAccessPolicy {
   id: string;
   name: string;
@@ -344,7 +340,6 @@ export const AccessPolicy = Resource(
   },
 );
 
-/** @internal */
 function isAccessDuplicateNameError(err: unknown): boolean {
   if (
     isCloudflareApiError(err, { status: 409 }) ||
@@ -361,7 +356,6 @@ function isAccessDuplicateNameError(err: unknown): boolean {
   return false;
 }
 
-/** @internal */
 async function findAccessPolicyByName(
   api: CloudflareApi,
   name: string,
@@ -383,7 +377,6 @@ async function findAccessPolicyByName(
   }
 }
 
-/** @internal */
 async function deleteAccessPolicy(
   api: CloudflareApi,
   policyId: string,

--- a/alchemy/src/cloudflare/access-rule.ts
+++ b/alchemy/src/cloudflare/access-rule.ts
@@ -1,0 +1,293 @@
+import type { AccessGroup } from "./access-group.ts";
+import type { AccessIdentityProvider } from "./access-identity-provider.ts";
+import type { AccessServiceToken } from "./access-service-token.ts";
+
+/**
+ * Match anyone with this email address.
+ */
+export interface EmailAccessRule {
+  email: { email: string };
+}
+
+/**
+ * Match anyone with an email address ending in this domain.
+ */
+export interface EmailDomainAccessRule {
+  email_domain: { domain: string };
+}
+
+/**
+ * Match a single IP address (IPv4 or IPv6) or CIDR.
+ */
+export interface IpAccessRule {
+  ip: { ip: string };
+}
+
+/**
+ * Match an IP from a managed Cloudflare IP list.
+ */
+export interface IpListAccessRule {
+  ip_list: { id: string };
+}
+
+/**
+ * Match every user. Rarely useful in `include` — typical in `exclude` or as a fallback.
+ */
+export interface EveryoneAccessRule {
+  everyone: Record<string, never>;
+}
+
+/**
+ * Match a member of the referenced Access group.
+ */
+export interface GroupAccessRule {
+  group: { id: string | AccessGroup };
+}
+
+/**
+ * Match requests authenticating with a specific service token.
+ */
+export interface ServiceTokenAccessRule {
+  service_token: { token_id: string | AccessServiceToken };
+}
+
+/**
+ * Match any valid service token in the account.
+ */
+export interface AnyValidServiceTokenAccessRule {
+  any_valid_service_token: Record<string, never>;
+}
+
+/**
+ * Match an Azure AD group by object ID.
+ */
+export interface AzureGroupAccessRule {
+  azure: {
+    id: string;
+    identity_provider_id: string | AccessIdentityProvider;
+  };
+}
+
+/**
+ * Match an Okta group by name.
+ */
+export interface OktaGroupAccessRule {
+  okta: {
+    name: string;
+    identity_provider_id: string | AccessIdentityProvider;
+  };
+}
+
+/**
+ * Match a SAML attribute returned by the IdP.
+ */
+export interface SamlAttributeAccessRule {
+  saml: {
+    attribute_name: string;
+    attribute_value: string;
+    identity_provider_id: string | AccessIdentityProvider;
+  };
+}
+
+/**
+ * Match a Google Workspace group by email.
+ */
+export interface GsuiteGroupAccessRule {
+  gsuite: {
+    email: string;
+    identity_provider_id: string | AccessIdentityProvider;
+  };
+}
+
+/**
+ * Match a member of a GitHub organization or team.
+ */
+export interface GithubOrganizationAccessRule {
+  github_organization: {
+    name: string;
+    team?: string;
+    identity_provider_id: string | AccessIdentityProvider;
+  };
+}
+
+/**
+ * Match any client presenting a valid mTLS certificate.
+ */
+export interface CertificateAccessRule {
+  certificate: Record<string, never>;
+}
+
+/**
+ * Match an mTLS certificate with the given Common Name.
+ */
+export interface CommonNameAccessRule {
+  common_name: { common_name: string };
+}
+
+/**
+ * Match a device that satisfies a configured posture check.
+ */
+export interface DevicePostureAccessRule {
+  device_posture: { integration_uid: string };
+}
+
+/**
+ * Match by authentication method (e.g., `mfa`, `pwd`).
+ */
+export interface AuthMethodAccessRule {
+  auth_method: { auth_method: string };
+}
+
+/**
+ * Match users who logged in via a specific identity provider.
+ */
+export interface LoginMethodAccessRule {
+  login_method: { id: string | AccessIdentityProvider };
+}
+
+/**
+ * Match an authentication context (e.g., Azure AD CA).
+ */
+export interface AuthenticationContextAccessRule {
+  authentication_context: {
+    id: string;
+    ac_id: string;
+    identity_provider_id: string | AccessIdentityProvider;
+  };
+}
+
+/**
+ * Match an OIDC claim returned by the IdP.
+ */
+export interface OidcClaimAccessRule {
+  oidc_claim: {
+    name: string;
+    value: string;
+    identity_provider_id: string | AccessIdentityProvider;
+  };
+}
+
+/**
+ * Match users at or above the given Cloudflare user-risk score.
+ */
+export interface UserRiskScoreAccessRule {
+  user_risk_score: {
+    provider: string;
+    risk_level: "low" | "medium" | "high";
+  };
+}
+
+/**
+ * Delegate evaluation to an external endpoint.
+ */
+export interface ExternalEvaluationAccessRule {
+  external_evaluation: { evaluate_url: string; keys_url: string };
+}
+
+/**
+ * Match by ISO 3166 country code (legacy alias of `geo`).
+ */
+export interface CountryAccessRule {
+  country: { country_code: string };
+}
+
+/**
+ * Match by ISO 3166 country code.
+ */
+export interface GeoAccessRule {
+  geo: { country_code: string };
+}
+
+/**
+ * Match a hostname/domain.
+ */
+export interface DomainAccessRule {
+  domain: { domain: string };
+}
+
+/**
+ * Match a token issued by a linked Access application.
+ */
+export interface LinkedAppTokenAccessRule {
+  linked_app_token: { app_uid: string };
+}
+
+/**
+ * Match an SSO authentication context (Azure AD CA equivalent).
+ */
+export interface AccessAuthContextAccessRule {
+  access_auth_context: {
+    id: string;
+    ac_id: string;
+    identity_provider_id: string | AccessIdentityProvider;
+  };
+}
+
+/**
+ * A single Access rule expression, used in `include`, `exclude`, and `require`
+ * arrays of {@link AccessPolicy} and {@link AccessGroup}.
+ *
+ * Each rule is a single-key object whose key is the rule type and whose value
+ * is the rule-specific configuration. Mirrors Cloudflare's wire format so
+ * expressions can be copy-pasted directly from the Cloudflare docs.
+ *
+ * @see https://developers.cloudflare.com/cloudflare-one/policies/access/
+ */
+export type AccessRule =
+  | EmailAccessRule
+  | EmailDomainAccessRule
+  | IpAccessRule
+  | IpListAccessRule
+  | EveryoneAccessRule
+  | GroupAccessRule
+  | ServiceTokenAccessRule
+  | AnyValidServiceTokenAccessRule
+  | AzureGroupAccessRule
+  | OktaGroupAccessRule
+  | SamlAttributeAccessRule
+  | GsuiteGroupAccessRule
+  | GithubOrganizationAccessRule
+  | CertificateAccessRule
+  | CommonNameAccessRule
+  | DevicePostureAccessRule
+  | AuthMethodAccessRule
+  | LoginMethodAccessRule
+  | AuthenticationContextAccessRule
+  | OidcClaimAccessRule
+  | UserRiskScoreAccessRule
+  | ExternalEvaluationAccessRule
+  | CountryAccessRule
+  | GeoAccessRule
+  | DomainAccessRule
+  | LinkedAppTokenAccessRule
+  | AccessAuthContextAccessRule;
+
+/**
+ * Serialize an {@link AccessRule} to its wire JSON shape, replacing any lifted
+ * Resource references (`group.id`, `service_token.token_id`,
+ * `*.identity_provider_id`, `login_method.id`) with the resource's `id`.
+ *
+ * @internal
+ */
+export function serializeAccessRule(rule: AccessRule): Record<string, unknown> {
+  const entries = Object.entries(rule);
+  if (entries.length !== 1) {
+    throw new Error(
+      `Invalid AccessRule: expected exactly one key, got ${entries.length}`,
+    );
+  }
+  const [key, value] = entries[0];
+  if (typeof value !== "object" || value === null) {
+    return { [key]: value };
+  }
+  const serialized: Record<string, unknown> = {};
+  for (const [field, fieldValue] of Object.entries(
+    value as Record<string, unknown>,
+  )) {
+    serialized[field] =
+      fieldValue && typeof fieldValue === "object" && !Array.isArray(fieldValue)
+        ? (fieldValue as { id: string }).id
+        : fieldValue;
+  }
+  return { [key]: serialized };
+}

--- a/alchemy/src/cloudflare/access-rule.ts
+++ b/alchemy/src/cloudflare/access-rule.ts
@@ -296,8 +296,6 @@ export function serializeAccessRule(rule: AccessRule): Record<string, unknown> {
  * True for Alchemy Resource objects (carry the {@link ResourceKind} symbol),
  * false for plain literal values — including future rule shapes that may nest
  * literal config objects.
- *
- * @internal
  */
 function isResourceRef(value: unknown): value is { id: string } {
   return (

--- a/alchemy/src/cloudflare/access-rule.ts
+++ b/alchemy/src/cloudflare/access-rule.ts
@@ -1,3 +1,4 @@
+import { ResourceKind } from "../resource.ts";
 import type { AccessGroup } from "./access-group.ts";
 import type { AccessIdentityProvider } from "./access-identity-provider.ts";
 import type { AccessServiceToken } from "./access-service-token.ts";
@@ -284,10 +285,25 @@ export function serializeAccessRule(rule: AccessRule): Record<string, unknown> {
   for (const [field, fieldValue] of Object.entries(
     value as Record<string, unknown>,
   )) {
-    serialized[field] =
-      fieldValue && typeof fieldValue === "object" && !Array.isArray(fieldValue)
-        ? (fieldValue as { id: string }).id
-        : fieldValue;
+    serialized[field] = isResourceRef(fieldValue)
+      ? (fieldValue as { id: string }).id
+      : fieldValue;
   }
   return { [key]: serialized };
+}
+
+/**
+ * True for Alchemy Resource objects (carry the {@link ResourceKind} symbol),
+ * false for plain literal values — including future rule shapes that may nest
+ * literal config objects.
+ *
+ * @internal
+ */
+function isResourceRef(value: unknown): value is { id: string } {
+  return (
+    !!value &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    (value as Record<symbol, unknown>)[ResourceKind] !== undefined
+  );
 }

--- a/alchemy/src/cloudflare/access-service-token.ts
+++ b/alchemy/src/cloudflare/access-service-token.ts
@@ -1,0 +1,262 @@
+import { alchemy } from "../alchemy.ts";
+import type { Context } from "../context.ts";
+import { Resource, ResourceKind } from "../resource.ts";
+import type { Secret } from "../secret.ts";
+import { logger } from "../util/logger.ts";
+import { isCloudflareApiError } from "./api-error.ts";
+import {
+  extractCloudflareResult,
+  type CloudflareApiListResponse,
+} from "./api-response.ts";
+import {
+  createCloudflareApi,
+  type CloudflareApi,
+  type CloudflareApiOptions,
+} from "./api.ts";
+
+/**
+ * Properties for creating or updating an {@link AccessServiceToken}.
+ */
+export interface AccessServiceTokenProps extends CloudflareApiOptions {
+  /**
+   * Display name of the service token.
+   *
+   * @default ${app}-${stage}-${id}
+   */
+  name?: string;
+
+  /**
+   * How long the token is valid for. Format: a Cloudflare duration string
+   * such as `"24h"`, `"30d"`, or `"8760h"` (one year).
+   *
+   * @default "8760h"
+   */
+  duration?: string;
+
+  /**
+   * Adopt an existing service token with the same name instead of failing
+   * with a duplicate-name error.
+   *
+   * Note: when adopting, the `clientSecret` cannot be recovered — the output
+   * `clientSecret` will be `undefined`. Recreate the resource (or rotate via
+   * the Cloudflare dashboard) if you need a new secret.
+   *
+   * @default false
+   */
+  adopt?: boolean;
+
+  /**
+   * Whether to delete the token when removed from Alchemy.
+   *
+   * @default true
+   */
+  delete?: boolean;
+}
+
+/**
+ * Output for an {@link AccessServiceToken}.
+ */
+export type AccessServiceToken = Omit<
+  AccessServiceTokenProps,
+  "delete" | "adopt"
+> & {
+  /** Cloudflare-assigned token UUID. */
+  id: string;
+  /** Display name of the token. */
+  name: string;
+  /**
+   * Value sent in the `CF-Access-Client-Id` header when authenticating.
+   */
+  clientId: string;
+  /**
+   * Value sent in the `CF-Access-Client-Secret` header when authenticating.
+   * **Returned only on creation** — `undefined` for adopted tokens.
+   */
+  clientSecret?: Secret;
+  /** ISO 8601 creation timestamp. */
+  createdAt: string;
+  /** ISO 8601 last-update timestamp. */
+  updatedAt: string;
+};
+
+/**
+ * Type guard for {@link AccessServiceToken}.
+ */
+export function isAccessServiceToken(
+  resource: any,
+): resource is AccessServiceToken {
+  return resource?.[ResourceKind] === "cloudflare::AccessServiceToken";
+}
+
+/**
+ * Cloudflare wire shape for an Access service token.
+ * @internal
+ */
+interface CloudflareAccessServiceToken {
+  id: string;
+  name: string;
+  client_id: string;
+  client_secret?: string;
+  duration?: string;
+  created_at: string;
+  updated_at: string;
+}
+
+/**
+ * Creates a Cloudflare Zero Trust [Access service token](https://developers.cloudflare.com/cloudflare-one/identity/service-tokens/)
+ * for machine-to-machine authentication against Access-protected applications.
+ *
+ * The returned `clientSecret` is only available on creation — store it
+ * immediately. Adopted tokens have `clientSecret: undefined`.
+ *
+ * @example
+ * // Basic service token (defaults to 1 year duration)
+ * const token = await AccessServiceToken("ci-token", {
+ *   name: "ci-runner",
+ * });
+ *
+ * @example
+ * // Custom duration
+ * const shortLived = await AccessServiceToken("preview", {
+ *   name: "preview-deploy-token",
+ *   duration: "720h", // 30 days
+ * });
+ */
+export const AccessServiceToken = Resource(
+  "cloudflare::AccessServiceToken",
+  async function (
+    this: Context<AccessServiceToken>,
+    id: string,
+    props: AccessServiceTokenProps,
+  ): Promise<AccessServiceToken> {
+    const api = await createCloudflareApi(props);
+    const name = props.name ?? this.scope.createPhysicalName(id);
+    const basePath = `/accounts/${api.accountId}/access/service_tokens`;
+
+    if (this.phase === "delete") {
+      if (this.output?.id && props.delete !== false) {
+        await deleteAccessServiceToken(api, this.output.id);
+      }
+      return this.destroy();
+    }
+
+    const body: Record<string, unknown> = { name };
+    if (props.duration) body.duration = props.duration;
+
+    let token: CloudflareAccessServiceToken;
+    if (this.phase === "update" && this.output?.id) {
+      token = await extractCloudflareResult<CloudflareAccessServiceToken>(
+        `update access service token "${name}"`,
+        api.put(`${basePath}/${this.output.id}`, body),
+      );
+    } else {
+      const adopt = props.adopt ?? this.scope.adopt;
+      try {
+        token = await extractCloudflareResult<CloudflareAccessServiceToken>(
+          `create access service token "${name}"`,
+          api.post(basePath, body),
+        );
+      } catch (err) {
+        if (adopt && isAccessDuplicateNameError(err)) {
+          const existing = await findAccessServiceTokenByName(api, name);
+          if (!existing) {
+            throw new Error(
+              `Service token "${name}" already exists but could not be found for adoption.`,
+              { cause: err },
+            );
+          }
+          logger.log(
+            `Adopting existing access service token "${name}" (${existing.id})`,
+          );
+          token = await extractCloudflareResult<CloudflareAccessServiceToken>(
+            `adopt access service token "${name}"`,
+            api.put(`${basePath}/${existing.id}`, body),
+          );
+        } else {
+          throw err;
+        }
+      }
+    }
+
+    // clientSecret is only returned on creation; retain on subsequent updates.
+    const clientSecret = token.client_secret
+      ? alchemy.secret(token.client_secret)
+      : this.output?.clientSecret;
+
+    return {
+      id: token.id,
+      name: token.name,
+      clientId: token.client_id,
+      clientSecret,
+      duration: token.duration,
+      createdAt: token.created_at,
+      updatedAt: token.updated_at,
+    };
+  },
+);
+
+/**
+ * Cloudflare returns error code 12132 ("Access service token already exists")
+ * for duplicate names.
+ * @internal
+ */
+function isAccessDuplicateNameError(err: unknown): boolean {
+  if (
+    isCloudflareApiError(err, { status: 409 }) ||
+    isCloudflareApiError(err, { status: 400 })
+  ) {
+    const data = err.errorData;
+    if (
+      Array.isArray(data) &&
+      data.some(
+        (e) => "message" in e && /already exists/i.test(String(e.message)),
+      )
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Look up an existing service token by name across paginated results.
+ * @internal
+ */
+async function findAccessServiceTokenByName(
+  api: CloudflareApi,
+  name: string,
+): Promise<CloudflareAccessServiceToken | null> {
+  let page = 1;
+  const perPage = 50;
+  while (true) {
+    const response = await api.get(
+      `/accounts/${api.accountId}/access/service_tokens?page=${page}&per_page=${perPage}`,
+    );
+    if (!response.ok) return null;
+    const data =
+      (await response.json()) as CloudflareApiListResponse<CloudflareAccessServiceToken>;
+    const match = data.result.find((t) => t.name === name);
+    if (match) return match;
+    const info = data.result_info;
+    if (!info || info.page * info.per_page >= info.total_count) return null;
+    page++;
+  }
+}
+
+/**
+ * Delete a service token. No-op on 404.
+ * @internal
+ */
+async function deleteAccessServiceToken(
+  api: CloudflareApi,
+  tokenId: string,
+): Promise<void> {
+  const response = await api.delete(
+    `/accounts/${api.accountId}/access/service_tokens/${tokenId}`,
+  );
+  if (!response.ok && response.status !== 404) {
+    logger.error(
+      `Error deleting access service token ${tokenId}: ${response.status} ${response.statusText}`,
+    );
+  }
+}

--- a/alchemy/src/cloudflare/access-service-token.ts
+++ b/alchemy/src/cloudflare/access-service-token.ts
@@ -88,10 +88,6 @@ export function isAccessServiceToken(
   return resource?.[ResourceKind] === "cloudflare::AccessServiceToken";
 }
 
-/**
- * Cloudflare wire shape for an Access service token.
- * @internal
- */
 interface CloudflareAccessServiceToken {
   id: string;
   name: string;
@@ -198,7 +194,6 @@ export const AccessServiceToken = Resource(
 /**
  * Cloudflare returns error code 12132 ("Access service token already exists")
  * for duplicate names.
- * @internal
  */
 function isAccessDuplicateNameError(err: unknown): boolean {
   if (
@@ -220,7 +215,6 @@ function isAccessDuplicateNameError(err: unknown): boolean {
 
 /**
  * Look up an existing service token by name across paginated results.
- * @internal
  */
 async function findAccessServiceTokenByName(
   api: CloudflareApi,
@@ -245,7 +239,6 @@ async function findAccessServiceTokenByName(
 
 /**
  * Delete a service token. No-op on 404.
- * @internal
  */
 async function deleteAccessServiceToken(
   api: CloudflareApi,

--- a/alchemy/src/cloudflare/index.ts
+++ b/alchemy/src/cloudflare/index.ts
@@ -1,5 +1,11 @@
 /// <reference types="@cloudflare/workers-types" />
 
+export * from "./access-application.ts";
+export * from "./access-group.ts";
+export * from "./access-identity-provider.ts";
+export * from "./access-policy.ts";
+export * from "./access-rule.ts";
+export * from "./access-service-token.ts";
 export * from "./account-api-token.ts";
 export * from "./account-id.ts";
 export * from "./ai-crawler.ts";

--- a/alchemy/test/cloudflare/access-application.test.ts
+++ b/alchemy/test/cloudflare/access-application.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect } from "vitest";
+import { alchemy } from "../../src/alchemy.ts";
+import { AccessApplication } from "../../src/cloudflare/access-application.ts";
+import { createCloudflareApi } from "../../src/cloudflare/api.ts";
+import { destroy } from "../../src/destroy.ts";
+import { BRANCH_PREFIX } from "../util.ts";
+
+import "../../src/test/vitest.ts";
+
+const api = await createCloudflareApi();
+
+const test = alchemy.test(import.meta, {
+  prefix: BRANCH_PREFIX,
+});
+
+describe.skipIf(!process.env.ALL_TESTS)("AccessApplication Resource", () => {
+  const testId = `${BRANCH_PREFIX}-access-app`;
+
+  test("create, update, and delete bookmark application", async (scope) => {
+    let app: AccessApplication | undefined;
+    try {
+      // Bookmark apps are account-scoped (no zone fixture needed).
+      app = await AccessApplication(testId, {
+        type: "bookmark",
+        name: `Test Bookmark ${testId}`,
+        domain: "https://example.com",
+        appLauncherVisible: true,
+      });
+      expect(app.id).toBeTruthy();
+      expect(app.type).toEqual("bookmark");
+      expect(app.aud).toBeTruthy();
+      const initialId = app.id;
+
+      // Update name.
+      app = await AccessApplication(testId, {
+        type: "bookmark",
+        name: `Updated Bookmark ${testId}`,
+        domain: "https://example.com",
+        appLauncherVisible: true,
+      });
+      expect(app.id).toEqual(initialId);
+      expect(app.name).toEqual(`Updated Bookmark ${testId}`);
+    } finally {
+      await destroy(scope);
+      if (app?.id) {
+        const response = await api.get(
+          `/accounts/${api.accountId}/access/apps/${app.id}`,
+        );
+        expect(response.status).toEqual(404);
+      }
+    }
+  });
+});

--- a/alchemy/test/cloudflare/access-group.test.ts
+++ b/alchemy/test/cloudflare/access-group.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect } from "vitest";
+import { alchemy } from "../../src/alchemy.ts";
+import { AccessGroup } from "../../src/cloudflare/access-group.ts";
+import { createCloudflareApi } from "../../src/cloudflare/api.ts";
+import { destroy } from "../../src/destroy.ts";
+import { BRANCH_PREFIX } from "../util.ts";
+
+import "../../src/test/vitest.ts";
+
+const api = await createCloudflareApi();
+
+const test = alchemy.test(import.meta, {
+  prefix: BRANCH_PREFIX,
+});
+
+describe.skipIf(!process.env.ALL_TESTS)("AccessGroup Resource", () => {
+  const testId = `${BRANCH_PREFIX}-access-group`;
+
+  test("create, update, and delete access group", async (scope) => {
+    let group: AccessGroup | undefined;
+    try {
+      // Create with a single email rule.
+      group = await AccessGroup(testId, {
+        name: `Test Group ${testId}`,
+        include: [{ email_domain: { domain: "example.com" } }],
+      });
+      expect(group.id).toBeTruthy();
+      const initialId = group.id;
+
+      // Update — add an exclude rule.
+      group = await AccessGroup(testId, {
+        name: `Test Group ${testId}`,
+        include: [{ email_domain: { domain: "example.com" } }],
+        exclude: [{ email: { email: "blocked@example.com" } }],
+      });
+      expect(group.id).toEqual(initialId);
+      expect(group.exclude).toHaveLength(1);
+    } finally {
+      await destroy(scope);
+      if (group?.id) {
+        const response = await api.get(
+          `/accounts/${api.accountId}/access/groups/${group.id}`,
+        );
+        expect(response.status).toEqual(404);
+      }
+    }
+  });
+});

--- a/alchemy/test/cloudflare/access-identity-provider.test.ts
+++ b/alchemy/test/cloudflare/access-identity-provider.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect } from "vitest";
+import { alchemy } from "../../src/alchemy.ts";
+import { AccessIdentityProvider } from "../../src/cloudflare/access-identity-provider.ts";
+import { createCloudflareApi } from "../../src/cloudflare/api.ts";
+import { destroy } from "../../src/destroy.ts";
+import { BRANCH_PREFIX } from "../util.ts";
+
+import "../../src/test/vitest.ts";
+
+const api = await createCloudflareApi();
+
+const test = alchemy.test(import.meta, {
+  prefix: BRANCH_PREFIX,
+});
+
+describe.skipIf(!process.env.ALL_TESTS)(
+  "AccessIdentityProvider Resource",
+  () => {
+    const testId = `${BRANCH_PREFIX}-access-otp-idp`;
+
+    test("create, update, and delete OneTimePin identity provider", async (scope) => {
+      let idp: AccessIdentityProvider | undefined;
+      try {
+        // Create — OneTimePin requires no external config.
+        idp = await AccessIdentityProvider(testId, {
+          type: "onetimepin",
+          name: `Test OTP ${testId}`,
+        });
+        expect(idp.id).toBeTruthy();
+        expect(idp.type).toEqual("onetimepin");
+        const initialId = idp.id;
+
+        // Update name.
+        idp = await AccessIdentityProvider(testId, {
+          type: "onetimepin",
+          name: `Updated OTP ${testId}`,
+        });
+        expect(idp.id).toEqual(initialId);
+        expect(idp.name).toEqual(`Updated OTP ${testId}`);
+      } finally {
+        await destroy(scope);
+        if (idp?.id) {
+          const response = await api.get(
+            `/accounts/${api.accountId}/access/identity_providers/${idp.id}`,
+          );
+          expect(response.status).toEqual(404);
+        }
+      }
+    });
+  },
+);

--- a/alchemy/test/cloudflare/access-identity-provider.test.ts
+++ b/alchemy/test/cloudflare/access-identity-provider.test.ts
@@ -3,6 +3,7 @@ import { alchemy } from "../../src/alchemy.ts";
 import { AccessIdentityProvider } from "../../src/cloudflare/access-identity-provider.ts";
 import { createCloudflareApi } from "../../src/cloudflare/api.ts";
 import { destroy } from "../../src/destroy.ts";
+import { Secret } from "../../src/secret.ts";
 import { BRANCH_PREFIX } from "../util.ts";
 
 import "../../src/test/vitest.ts";
@@ -16,27 +17,51 @@ const test = alchemy.test(import.meta, {
 describe.skipIf(!process.env.ALL_TESTS)(
   "AccessIdentityProvider Resource",
   () => {
-    const testId = `${BRANCH_PREFIX}-access-otp-idp`;
+    const testId = `${BRANCH_PREFIX}-access-oidc-idp`;
 
-    test("create, update, and delete OneTimePin identity provider", async (scope) => {
+    // Cloudflare allows only one OneTimePin IdP per account, which makes it a
+    // poor choice for an integration test on accounts that already have one.
+    // OIDC has no such constraint and accepts stub URLs at creation time, so
+    // it exercises the create/update/delete path plus secret normalisation
+    // (camelToSnakeWithSecrets + clientSecret -> Secret on output).
+    test("create, update, and delete OIDC identity provider", async (scope) => {
       let idp: AccessIdentityProvider | undefined;
       try {
-        // Create — OneTimePin requires no external config.
         idp = await AccessIdentityProvider(testId, {
-          type: "onetimepin",
-          name: `Test OTP ${testId}`,
+          type: "oidc",
+          name: `Test OIDC ${testId}`,
+          config: {
+            authUrl: "https://idp.example.com/oauth2/authorize",
+            tokenUrl: "https://idp.example.com/oauth2/token",
+            certsUrl: "https://idp.example.com/oauth2/certs",
+            clientId: "test-client-id",
+            clientSecret: "test-client-secret",
+          },
         });
         expect(idp.id).toBeTruthy();
-        expect(idp.type).toEqual("onetimepin");
+        expect(idp.type).toEqual("oidc");
+        // Output convention: secrets are always wrapped, even when the user
+        // passed a raw string in props.
+        const config = (idp as unknown as { config: { clientSecret: Secret } })
+          .config;
+        expect(config.clientSecret).toBeInstanceOf(Secret);
         const initialId = idp.id;
 
-        // Update name.
+        // Update name (and re-send the secret — Cloudflare requires it on PUT
+        // or it overwrites with empty).
         idp = await AccessIdentityProvider(testId, {
-          type: "onetimepin",
-          name: `Updated OTP ${testId}`,
+          type: "oidc",
+          name: `Updated OIDC ${testId}`,
+          config: {
+            authUrl: "https://idp.example.com/oauth2/authorize",
+            tokenUrl: "https://idp.example.com/oauth2/token",
+            certsUrl: "https://idp.example.com/oauth2/certs",
+            clientId: "test-client-id",
+            clientSecret: "test-client-secret",
+          },
         });
         expect(idp.id).toEqual(initialId);
-        expect(idp.name).toEqual(`Updated OTP ${testId}`);
+        expect(idp.name).toEqual(`Updated OIDC ${testId}`);
       } finally {
         await destroy(scope);
         if (idp?.id) {

--- a/alchemy/test/cloudflare/access-identity-provider.test.ts
+++ b/alchemy/test/cloudflare/access-identity-provider.test.ts
@@ -30,21 +30,19 @@ describe.skipIf(!process.env.ALL_TESTS)(
         idp = await AccessIdentityProvider(testId, {
           type: "oidc",
           name: `Test OIDC ${testId}`,
-          config: {
-            authUrl: "https://idp.example.com/oauth2/authorize",
-            tokenUrl: "https://idp.example.com/oauth2/token",
-            certsUrl: "https://idp.example.com/oauth2/certs",
-            clientId: "test-client-id",
-            clientSecret: "test-client-secret",
-          },
+          authUrl: "https://idp.example.com/oauth2/authorize",
+          tokenUrl: "https://idp.example.com/oauth2/token",
+          certsUrl: "https://idp.example.com/oauth2/certs",
+          clientId: "test-client-id",
+          clientSecret: "test-client-secret",
         });
         expect(idp.id).toBeTruthy();
         expect(idp.type).toEqual("oidc");
         // Output convention: secrets are always wrapped, even when the user
         // passed a raw string in props.
-        const config = (idp as unknown as { config: { clientSecret: Secret } })
-          .config;
-        expect(config.clientSecret).toBeInstanceOf(Secret);
+        expect(
+          (idp as unknown as { clientSecret: Secret }).clientSecret,
+        ).toBeInstanceOf(Secret);
         const initialId = idp.id;
 
         // Update name (and re-send the secret — Cloudflare requires it on PUT
@@ -52,13 +50,11 @@ describe.skipIf(!process.env.ALL_TESTS)(
         idp = await AccessIdentityProvider(testId, {
           type: "oidc",
           name: `Updated OIDC ${testId}`,
-          config: {
-            authUrl: "https://idp.example.com/oauth2/authorize",
-            tokenUrl: "https://idp.example.com/oauth2/token",
-            certsUrl: "https://idp.example.com/oauth2/certs",
-            clientId: "test-client-id",
-            clientSecret: "test-client-secret",
-          },
+          authUrl: "https://idp.example.com/oauth2/authorize",
+          tokenUrl: "https://idp.example.com/oauth2/token",
+          certsUrl: "https://idp.example.com/oauth2/certs",
+          clientId: "test-client-id",
+          clientSecret: "test-client-secret",
         });
         expect(idp.id).toEqual(initialId);
         expect(idp.name).toEqual(`Updated OIDC ${testId}`);

--- a/alchemy/test/cloudflare/access-policy.test.ts
+++ b/alchemy/test/cloudflare/access-policy.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect } from "vitest";
+import { alchemy } from "../../src/alchemy.ts";
+import { AccessPolicy } from "../../src/cloudflare/access-policy.ts";
+import { createCloudflareApi } from "../../src/cloudflare/api.ts";
+import { destroy } from "../../src/destroy.ts";
+import { BRANCH_PREFIX } from "../util.ts";
+
+import "../../src/test/vitest.ts";
+
+const api = await createCloudflareApi();
+
+const test = alchemy.test(import.meta, {
+  prefix: BRANCH_PREFIX,
+});
+
+describe.skipIf(!process.env.ALL_TESTS)("AccessPolicy Resource", () => {
+  const testId = `${BRANCH_PREFIX}-access-policy`;
+
+  test("create, update, and delete access policy", async (scope) => {
+    let policy: AccessPolicy | undefined;
+    try {
+      // Create — allow policy with email rule.
+      policy = await AccessPolicy(testId, {
+        name: `Test Policy ${testId}`,
+        decision: "allow",
+        include: [{ email_domain: { domain: "example.com" } }],
+      });
+      expect(policy.id).toBeTruthy();
+      expect(policy.decision).toEqual("allow");
+      const initialId = policy.id;
+
+      // Update name (decision unchanged so no replacement).
+      policy = await AccessPolicy(testId, {
+        name: `Updated Policy ${testId}`,
+        decision: "allow",
+        include: [{ email_domain: { domain: "example.com" } }],
+      });
+      expect(policy.id).toEqual(initialId);
+      expect(policy.name).toEqual(`Updated Policy ${testId}`);
+    } finally {
+      await destroy(scope);
+      if (policy?.id) {
+        const response = await api.get(
+          `/accounts/${api.accountId}/access/policies/${policy.id}`,
+        );
+        expect(response.status).toEqual(404);
+      }
+    }
+  });
+});

--- a/alchemy/test/cloudflare/access-rule.test.ts
+++ b/alchemy/test/cloudflare/access-rule.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "vitest";
+import { serializeAccessRule } from "../../src/cloudflare/access-rule.ts";
+import { ResourceKind } from "../../src/resource.ts";
+
+describe("serializeAccessRule", () => {
+  test("passes through literal scalar values unchanged", () => {
+    expect(
+      serializeAccessRule({ email: { email: "user@example.com" } }),
+    ).toEqual({
+      email: { email: "user@example.com" },
+    });
+  });
+
+  test("preserves the empty-object shape for parameterless rules", () => {
+    expect(serializeAccessRule({ everyone: {} })).toEqual({
+      everyone: {},
+    });
+    expect(serializeAccessRule({ certificate: {} })).toEqual({
+      certificate: {},
+    });
+  });
+
+  test("preserves a string id reference (no resource lifting)", () => {
+    expect(serializeAccessRule({ group: { id: "abc-123" } })).toEqual({
+      group: { id: "abc-123" },
+    });
+  });
+
+  test("extracts .id from an Alchemy Resource reference", () => {
+    const fakeGroup = {
+      id: "real-group-uuid",
+      [ResourceKind]: "cloudflare::AccessGroup",
+    };
+    expect(serializeAccessRule({ group: { id: fakeGroup as any } })).toEqual({
+      group: { id: "real-group-uuid" },
+    });
+  });
+
+  test("preserves multi-string fields without mangling them (regression for non-Resource nested objects)", () => {
+    // external_evaluation has two literal string fields — neither is a
+    // Resource. The serializer must leave both alone.
+    expect(
+      serializeAccessRule({
+        external_evaluation: {
+          evaluate_url: "https://eval.example.com/check",
+          keys_url: "https://eval.example.com/keys",
+        },
+      }),
+    ).toEqual({
+      external_evaluation: {
+        evaluate_url: "https://eval.example.com/check",
+        keys_url: "https://eval.example.com/keys",
+      },
+    });
+  });
+
+  test("mixes literal fields with a Resource ref in the same rule", () => {
+    const fakeIdp = {
+      id: "idp-uuid",
+      [ResourceKind]: "cloudflare::AccessIdentityProvider",
+    };
+    expect(
+      serializeAccessRule({
+        saml: {
+          attribute_name: "department",
+          attribute_value: "engineering",
+          identity_provider_id: fakeIdp as any,
+        },
+      }),
+    ).toEqual({
+      saml: {
+        attribute_name: "department",
+        attribute_value: "engineering",
+        identity_provider_id: "idp-uuid",
+      },
+    });
+  });
+
+  test("rejects a rule with multiple top-level keys", () => {
+    expect(() =>
+      serializeAccessRule({
+        email: { email: "a@b.com" },
+        ip: { ip: "1.2.3.4" },
+      } as any),
+    ).toThrow(/exactly one key/);
+  });
+});

--- a/alchemy/test/cloudflare/access-service-token.test.ts
+++ b/alchemy/test/cloudflare/access-service-token.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect } from "vitest";
+import { alchemy } from "../../src/alchemy.ts";
+import { AccessServiceToken } from "../../src/cloudflare/access-service-token.ts";
+import { createCloudflareApi } from "../../src/cloudflare/api.ts";
+import { destroy } from "../../src/destroy.ts";
+import { BRANCH_PREFIX } from "../util.ts";
+
+import "../../src/test/vitest.ts";
+
+const api = await createCloudflareApi();
+
+const test = alchemy.test(import.meta, {
+  prefix: BRANCH_PREFIX,
+});
+
+describe.skipIf(!process.env.ALL_TESTS)("AccessServiceToken Resource", () => {
+  const testId = `${BRANCH_PREFIX}-access-svc-token`;
+
+  test("create, update, and delete service token", async (scope) => {
+    let token: AccessServiceToken | undefined;
+    try {
+      // Create
+      token = await AccessServiceToken(testId, {
+        name: `Test Service Token ${testId}`,
+        duration: "24h",
+      });
+      expect(token.id).toBeTruthy();
+      expect(token.clientId).toBeTruthy();
+      expect(token.clientSecret?.unencrypted).toBeTruthy();
+      const initialSecret = token.clientSecret?.unencrypted;
+      const initialId = token.id;
+
+      // Update name — clientSecret must be retained.
+      token = await AccessServiceToken(testId, {
+        name: `Updated Service Token ${testId}`,
+        duration: "24h",
+      });
+      expect(token.id).toEqual(initialId);
+      expect(token.name).toEqual(`Updated Service Token ${testId}`);
+      expect(token.clientSecret?.unencrypted).toEqual(initialSecret);
+    } finally {
+      await destroy(scope);
+      if (token?.id) {
+        const response = await api.get(
+          `/accounts/${api.accountId}/access/service_tokens/${token.id}`,
+        );
+        expect(response.status).toEqual(404);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds five foundational Cloudflare Zero Trust Access resources plus a shared rule-expression types module — closing the largest remaining gap in the Cloudflare provider for "managing my Cloudflare account like Terraform". After this lands, a user can fully configure ZTNA (IdP + Group + Policy + Application + ServiceToken) from a single `alchemy.run.ts`.

- **`AccessIdentityProvider`** — strict types for OneTimePin / Google / Okta / OIDC / SAML; permissive `OtherIdentityProviderProps` for Azure AD, GitHub, Centrify, Facebook, LinkedIn, OneLogin, PingOne, Yandex. `type` is immutable.
- **`AccessApplication`** — strict for `self_hosted` / `saas` / `bookmark`; permissive catch-all for `ssh` / `vnc` / `rdp` / `infrastructure` / `app_launcher` / etc. Account- or zone-scoped; `type` and `zone` are immutable.
- **`AccessPolicy`** — reusable form (always `reusable: true`). `decision` is immutable.
- **`AccessGroup`** — reusable rule bundles, fully mutable.
- **`AccessServiceToken`** — m2m credentials. `clientSecret` returned only on POST; retained on subsequent updates.
- **`access-rule.ts`** — 27-variant `AccessRule` discriminated union (`email`, `email_domain`, `ip`, `ip_list`, `group`, `service_token`, `azure`, `okta`, `saml`, `gsuite`, `github_organization`, `device_posture`, `oidc_claim`, `user_risk_score`, `external_evaluation`, … plus `auth_method`, `login_method`, `certificate`, `common_name`, `everyone`, `country`, `geo`, `domain`, etc.) — wire-format keys preserved, lifted `string | Resource` references for IDs, normalised by `serializeAccessRule`.

### Example usage

```ts
import {
  AccessApplication,
  AccessGroup,
  AccessIdentityProvider,
  AccessPolicy,
  AccessServiceToken,
} from "alchemy/cloudflare";

const idp = await AccessIdentityProvider("google", {
  type: "google",
  name: "Google",
  config: {
    clientId: process.env.GOOGLE_CLIENT_ID!,
    clientSecret: alchemy.secret.env.GOOGLE_CLIENT_SECRET,
  },
});

const employees = await AccessGroup("employees", {
  name: "Employees",
  include: [{ email_domain: { domain: "acme.com" } }],
});

const policy = await AccessPolicy("employees-allow", {
  name: "Employees allow",
  decision: "allow",
  include: [{ group: { id: employees } }],
  sessionDuration: "8h",
});

const app = await AccessApplication("admin", {
  type: "self_hosted",
  name: "Internal Admin",
  domain: "admin.acme.com",
  allowedIdps: [idp],
  policies: [policy],
});

const ciToken = await AccessServiceToken("ci", { name: "ci-runner" });
// ciToken.clientId / ciToken.clientSecret -> CF-Access-Client-Id / -Secret headers
```

## Scope

Intentionally minimal so the diff stays reviewable in one sitting. Out of scope here (can be added later if needed):

- ServiceToken rotation (`clientSecretVersion`)
- IdP `scim_config` (likely a separate `AccessScimConfig` resource)
- Strict typing for the long-tail IdP / Application variants
- Replacement-on-immutable-change tests, adoption-only tests, multi-resource e2e tests
- Zone-scoped Application test (needs `TEST_DOMAIN` fixture)
- `examples/cloudflare-access/` example project

## Test plan

All five integration suites are gated on `ALL_TESTS=1` (matches `zone.test.ts:16`). Each does a single comprehensive create → update → delete → 404 assertion. Plus 7 unit tests for `serializeAccessRule` (pure logic, no API). Run against a real ZT-enabled Cloudflare account — **all 12/12 green**:

- [x] `bun tsc -b alchemy` — clean
- [x] `bun run format:check` — clean
- [x] `bun vitest ./alchemy/test/cloudflare/access-rule.test.ts` (7 unit tests, no API)
- [x] `ALL_TESTS=1 bun vitest ./alchemy/test/cloudflare/access-service-token.test.ts`
- [x] `ALL_TESTS=1 bun vitest ./alchemy/test/cloudflare/access-identity-provider.test.ts`
- [x] `ALL_TESTS=1 bun vitest ./alchemy/test/cloudflare/access-group.test.ts`
- [x] `ALL_TESTS=1 bun vitest ./alchemy/test/cloudflare/access-policy.test.ts`
- [x] `ALL_TESTS=1 bun vitest ./alchemy/test/cloudflare/access-application.test.ts`
- [x] Manual smoke: provisioned `AccessGroup` + `AccessPolicy` + `AccessApplication` against a real `*.workers.dev` URL → confirmed `HTTP 200 "Hello World!"` → `HTTP 302 -> *.cloudflareaccess.com/cdn-cgi/access/login/...` after apply, then back to `HTTP 200` after `--destroy`. No leftover resources in the dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)