### PR TITLE
fix(cloudflare): kill cloudflared properly on dev exit

### DIFF
--- a/alchemy/src/cloudflare/miniflare/tunnel.ts
+++ b/alchemy/src/cloudflare/miniflare/tunnel.ts
@@ -70,6 +70,7 @@ export async function createTunnel(
   const remoteUrlString = await Scope.current.spawn("tunnel", {
     processName: `cloudflared-${proxy.url.port}`,
     cmd: `cloudflared tunnel --url ${proxy.url.toString()}`,
+    shell: false,
     quiet: !process.env.DEBUG,
     extract: (line) => {
       const match = line.match(/https:\/\/([^\s]+)\.trycloudflare\.com/);

--- a/alchemy/src/cloudflare/quick-tunnel.ts
+++ b/alchemy/src/cloudflare/quick-tunnel.ts
@@ -18,6 +18,7 @@ export const quickTunnel = async (
    */
   tunnelUrl: await scope.spawn("tunnel", {
     cmd: `cloudflared tunnel --url ${localUrl}`,
+    shell: false,
     // used to check if a PID is a cloudflared process when the parent exits, for resumability
     processName: "cloudflared",
     extract: (line) => {

--- a/alchemy/src/util/idempotent-spawn.ts
+++ b/alchemy/src/util/idempotent-spawn.ts
@@ -19,6 +19,19 @@ export interface IdempotentSpawnOptions {
    * If true, the child's stdout and stderr will not be mirrored to this process's console.
    */
   quiet?: boolean;
+  /**
+   * Whether to spawn the command through a shell.
+   *
+   * - `true` (default): the command is run via `cmd.exe /c` on Windows or `/bin/sh -c` on POSIX.
+   *   This lets the cmd resolve `.cmd`/`.bat` files and use shell features (env expansion, `&&`, pipes).
+   *   The stored PID is the SHELL's, not the underlying program's, so on cleanup the shell is killed
+   *   but its children may be orphaned. We compensate on Windows by tree-killing via `taskkill /T /F`.
+   *
+   * - `false`: the cmd is parsed as a whitespace-separated argv and the program is spawned directly.
+   *   The stored PID is the program's actual PID, so kill is reliable across platforms.
+   *   Use this for direct executables (e.g. `cloudflared ...`) where shell features aren't needed.
+   */
+  shell?: boolean;
 }
 
 /**
@@ -39,6 +52,7 @@ export async function idempotentSpawn({
   extract,
   isSameProcess,
   quiet = false,
+  shell = true,
 }: IdempotentSpawnOptions): Promise<{
   extracted: Promise<string | undefined>;
   stop: () => Promise<void>;
@@ -108,14 +122,29 @@ export async function idempotentSpawn({
   async function spawnLoggedChild() {
     const out = await fsp.open(outPath, "a");
 
-    // shell:true, NO args — pass a single command string
-    const child = spawn(cmd, {
-      shell: true,
-      cwd,
-      stdio: ["inherit", out.fd, out.fd], // stdout/stderr -> files (OS-level)
-      env,
-      detached: false,
-    });
+    const child = shell
+      ? // shell:true, NO args — pass a single command string
+        spawn(cmd, {
+          shell: true,
+          cwd,
+          stdio: ["inherit", out.fd, out.fd], // stdout/stderr -> files (OS-level)
+          env,
+          detached: false,
+        })
+      : (() => {
+          // shell:false — parse cmd into argv so the stored PID is the program's, not a shell wrapper.
+          // We split on whitespace; callers using shell:false must not rely on shell features.
+          const [bin, ...args] = cmd.split(/\s+/).filter(Boolean);
+          if (!bin) {
+            throw new Error(`Empty command passed to idempotentSpawn: ${cmd}`);
+          }
+          return spawn(bin, args, {
+            cwd,
+            stdio: ["inherit", out.fd, out.fd],
+            env,
+            detached: false,
+          });
+        })();
 
     // Child now owns dup'd fds; close our handles.
     await out.close();
@@ -306,6 +335,25 @@ export async function idempotentSpawn({
   }
 
   async function kill(pid: number) {
+    // On Windows, killing a shell wrapper (cmd.exe) does NOT kill its children — they orphan.
+    // Use taskkill /T to terminate the full process tree. This is a no-op for shell:false callers
+    // (where pid IS the program), but matters for shell:true callers like website dev commands.
+    if (process.platform === "win32") {
+      try {
+        const { spawn: cpSpawn } = await import("node:child_process");
+        await new Promise<void>((resolve) => {
+          const tk = cpSpawn("taskkill", ["/T", "/F", "/PID", String(pid)], {
+            stdio: "ignore",
+            windowsHide: true,
+          });
+          tk.on("exit", () => resolve());
+          tk.on("error", () => resolve());
+        });
+        return;
+      } catch {
+        // fall through to signal-based kill
+      }
+    }
     // 1. Kill with SIGTERM
     try {
       process.kill(pid, "SIGTERM");


### PR DESCRIPTION
## Summary

Fixes a `530` error when restarting `alchemy dev` with `dev: { tunnel: true }` after switching Cloudflare profiles (or just restarting the dev server) on Windows.

### Root cause

`idempotentSpawn` runs the child with `shell: true`, so the PID it records in `.alchemy/pids/tunnel.pid.json` is the `cmd.exe` wrapper, not `cloudflared.exe`. On cleanup we `process.kill` the wrapper, but Windows doesn't auto-kill its children — so `cloudflared.exe` orphans.

On the next `alchemy dev` run, one of two things happens:

1. The orphan is still alive and races against a freshly-spawned `cloudflared`. Whichever loses the race produces a stale `trycloudflare.com` host that gets baked into the deployed `tunnel-proxy` worker's `TUNNEL_HOST` binding. Requests forward to a dead tunnel → 530.
2. The state-file PID happens to still resolve (`process.kill(pid, 0)` is lenient) and `idempotentSpawn` reuses it, skipping the new spawn entirely — so the deployed `TUNNEL_HOST` points at a long-dead trycloudflare URL.

It worked on the first profile and broke on the second because no orphan exists before the very first dev run. It worked with `tunnel: false` because the `cloudflared` codepath is bypassed entirely.

Reproduced with two profiles + the playground worker; `Get-Process cloudflared` showed PID `54172` while `tunnel.pid.json` stored PID `33132` (the dead `cmd.exe`), confirming the orphan.

### Fix

1. Add a `shell?: boolean` option to `idempotentSpawn`, default `true` (preserves current behavior for user-provided dev commands that rely on `.cmd` resolution / shell features). When `false`, parse `cmd` into argv and spawn directly — the stored PID is then the program's own PID.
2. Pass `shell: false` from the two cloudflared spawn sites (`cloudflare/miniflare/tunnel.ts` and `cloudflare/quick-tunnel.ts`); both run `cloudflared tunnel --url <url>`, which needs no shell features.
3. As defense-in-depth for the remaining `shell: true` callers (website / bun-spa dev commands), use `taskkill /T /F /PID` in `kill()` on Windows so the entire process tree is torn down instead of just the shell.

## Test plan
- [x] Repro: switch profile + restart dev → 530 (before fix)
- [x] With patch installed in playground: switch profile + restart dev → worker responds normally
- [x] `Get-Process cloudflared` after Ctrl+C now shows no orphan
- [ ] POSIX still works for the `shell: false` callers (cloudflared is on `PATH`, no shell features used)
- [ ] Website/bun-spa dev commands (`npm run dev`, etc.) still work — they remain `shell: true`