### PR TITLE
Add Cloudflare Artifacts binding

### DIFF
--- a/alchemy/src/cloudflare/artifacts.ts
+++ b/alchemy/src/cloudflare/artifacts.ts
@@ -1,0 +1,69 @@
+/**
+ * Properties for creating an Artifacts binding.
+ *
+ * Artifacts namespaces are created implicitly by Cloudflare when the first
+ * repository is created in the namespace, so this binding does not provision
+ * or delete a namespace resource.
+ */
+export interface ArtifactsProps {
+  /**
+   * Artifacts namespace name.
+   */
+  namespace: string;
+
+  dev?: {
+    /**
+     * Whether to run the Artifacts binding remotely in local development.
+     *
+     * Artifacts do not have a local emulator, so generated Wrangler config
+     * defaults this binding to remote mode.
+     *
+     * @default true
+     */
+    remote?: boolean;
+  };
+}
+
+/**
+ * Cloudflare Artifacts binding.
+ *
+ * Artifacts namespaces are implicit containers for repositories. Use this
+ * helper to bind a Worker to a namespace; repository lifecycle should be
+ * managed through the Artifacts runtime API, REST API, or Git endpoint.
+ *
+ * @example
+ * ```ts
+ * import { Artifacts, Worker } from "alchemy/cloudflare";
+ *
+ * await Worker("site-editor", {
+ *   entrypoint: "./src/worker.ts",
+ *   bindings: {
+ *     SITE_ARTIFACTS: Artifacts({ namespace: "my-sites" }),
+ *   },
+ * });
+ * ```
+ *
+ * @see https://developers.cloudflare.com/artifacts/
+ */
+export interface Artifacts {
+  type: "artifacts";
+  namespace: string;
+  dev?: {
+    remote?: boolean;
+  };
+}
+
+export function Artifacts(props: string | ArtifactsProps): Artifacts {
+  if (typeof props === "string") {
+    return {
+      type: "artifacts",
+      namespace: props,
+    };
+  }
+
+  return {
+    type: "artifacts",
+    namespace: props.namespace,
+    dev: props.dev,
+  };
+}

--- a/alchemy/src/cloudflare/bindings.ts
+++ b/alchemy/src/cloudflare/bindings.ts
@@ -8,6 +8,7 @@ import type { Ai } from "./ai.ts";
 import type { AiSearchNamespace } from "./ai-search-namespace.ts";
 import type { AiSearch } from "./ai-search.ts";
 import type { AnalyticsEngineDataset } from "./analytics-engine.ts";
+import type { Artifacts } from "./artifacts.ts";
 import type { Assets } from "./assets.ts";
 import type { Bound } from "./bound.ts";
 import type { BrowserRendering } from "./browser-rendering.ts";
@@ -54,6 +55,7 @@ export type Binding =
   | AiSearch
   | AiSearchNamespace
   | Assets
+  | Artifacts
   | Container
   | CloudflareSecret
   | CloudflareSecretRef
@@ -127,6 +129,7 @@ export type WorkerBindingSpec =
   | WorkerBindingAiSearch
   | WorkerBindingAiSearchNamespace
   | WorkerBindingAnalyticsEngine
+  | WorkerBindingArtifacts
   | WorkerBindingAssets
   | WorkerBindingBrowserRendering
   | WorkerBindingD1
@@ -204,6 +207,18 @@ export interface WorkerBindingAnalyticsEngine {
   type: "analytics_engine";
   /** Dataset name */
   dataset: string;
+}
+
+/**
+ * Artifacts binding type
+ */
+export interface WorkerBindingArtifacts {
+  /** The name of the binding */
+  name: string;
+  /** Type identifier for Artifacts binding */
+  type: "artifacts";
+  /** Artifacts namespace name */
+  namespace: string;
 }
 
 /**

--- a/alchemy/src/cloudflare/bound.ts
+++ b/alchemy/src/cloudflare/bound.ts
@@ -5,6 +5,7 @@ import type { Ai as _Ai } from "./ai.ts";
 import type { AiSearchNamespace as _AiSearchNamespace } from "./ai-search-namespace.ts";
 import type { AiSearch as _AiSearch } from "./ai-search.ts";
 import type { AnalyticsEngineDataset as _AnalyticsEngineDataset } from "./analytics-engine.ts";
+import type { Artifacts as _Artifacts } from "./artifacts.ts";
 import type { Assets } from "./assets.ts";
 import type { Binding, Json, Self } from "./bindings.ts";
 import type { BrowserRendering } from "./browser-rendering.ts";
@@ -61,6 +62,8 @@ export type Bound<T extends Binding> = T extends _AiSearch
           ? BoundWorker<RPC>
           : T extends _Worker<any, infer RPC> | WorkerRef<infer RPC>
             ? BoundWorker<RPC>
+            : T extends _Artifacts
+              ? Artifacts
             : T extends { type: "service" }
               ? Service
               : T extends _R2Bucket

--- a/alchemy/src/cloudflare/index.ts
+++ b/alchemy/src/cloudflare/index.ts
@@ -20,6 +20,7 @@ export * from "./api-gateway-operation.ts";
 export * from "./api-schema.ts";
 export * from "./api-shield.ts";
 export * from "./api.ts";
+export * from "./artifacts.ts";
 export * from "./assets.ts";
 export * from "./astro/astro.ts";
 export * from "./bindings.ts";

--- a/alchemy/src/cloudflare/miniflare/build-worker-options.ts
+++ b/alchemy/src/cloudflare/miniflare/build-worker-options.ts
@@ -167,6 +167,11 @@ export const buildWorkerOptions = async (
         };
         break;
       }
+      case "artifacts": {
+        throw new Error(
+          "Artifacts bindings are not supported in Alchemy local dev yet. Deploy the Worker or use generated Wrangler config with remote Artifacts bindings.",
+        );
+      }
       case "assets": {
         options.assets = {
           binding: key,

--- a/alchemy/src/cloudflare/worker-metadata.ts
+++ b/alchemy/src/cloudflare/worker-metadata.ts
@@ -516,6 +516,12 @@ export async function prepareWorkerMetadata(
         jurisdiction:
           binding.jurisdiction === "default" ? undefined : binding.jurisdiction,
       });
+    } else if (binding.type === "artifacts") {
+      meta.bindings.push({
+        type: "artifacts",
+        name: bindingName,
+        namespace: binding.namespace,
+      });
     } else if (binding.type === "send_email") {
       meta.bindings.push({
         type: "send_email",

--- a/alchemy/src/cloudflare/wrangler.json.ts
+++ b/alchemy/src/cloudflare/wrangler.json.ts
@@ -264,6 +264,11 @@ async function processBindings(
   const kvNamespaces: WranglerJsonConfig["kv_namespaces"] = [];
   const durableObjects: WranglerJsonConfig["durable_objects"]["bindings"] = [];
   const r2Buckets: WranglerJsonConfig["r2_buckets"] = [];
+  const artifacts: {
+    binding: string;
+    namespace: string;
+    remote?: boolean;
+  }[] = [];
   const services: WranglerJsonConfig["services"] = [];
   const sendEmailBindings: WranglerJsonConfig["send_email"] = [];
   const secrets: string[] = [];
@@ -421,6 +426,12 @@ async function processBindings(
         allowed_destination_addresses: binding.allowedDestinationAddresses,
         allowed_sender_addresses: binding.allowedSenderAddresses,
         ...(binding.dev?.remote ? { remote: true } : {}),
+      });
+    } else if (binding.type === "artifacts") {
+      artifacts.push({
+        binding: bindingName,
+        namespace: binding.namespace,
+        remote: binding.dev?.remote ?? true,
       });
     } else if (binding.type === "secret") {
       // Secret binding
@@ -596,6 +607,14 @@ async function processBindings(
 
   if (r2Buckets.length > 0) {
     spec.r2_buckets = r2Buckets;
+  }
+
+  if (artifacts.length > 0) {
+    (
+      spec as WranglerJsonSpec & {
+        artifacts?: typeof artifacts;
+      }
+    ).artifacts = artifacts;
   }
 
   if (services.length > 0) {

--- a/alchemy/test/cloudflare/worker.test.ts
+++ b/alchemy/test/cloudflare/worker.test.ts
@@ -4,6 +4,7 @@ import { describe, expect } from "vitest";
 import { alchemy } from "../../src/alchemy.ts";
 import { AnalyticsEngineDataset } from "../../src/cloudflare/analytics-engine.ts";
 import { createCloudflareApi } from "../../src/cloudflare/api.ts";
+import { Artifacts } from "../../src/cloudflare/artifacts.ts";
 import { Assets } from "../../src/cloudflare/assets.ts";
 import { Self } from "../../src/cloudflare/bindings.ts";
 import { DurableObjectNamespace } from "../../src/cloudflare/durable-object-namespace.ts";
@@ -37,6 +38,8 @@ import "../../src/test/vitest.ts";
 const ENABLE_WFP_TESTS = process.env.CLOUDFLARE_ACCOUNT_ENABLE_WFP !== "false";
 const ENABLE_PAID_TESTS =
   process.env.CLOUDFLARE_ACCOUNT_ENABLE_PAID !== "false";
+const ENABLE_ARTIFACTS_TESTS =
+  process.env.CLOUDFLARE_ACCOUNT_ENABLE_ARTIFACTS !== "false";
 
 const test = alchemy.test(import.meta, {
   prefix: BRANCH_PREFIX,
@@ -1402,6 +1405,159 @@ describe("Worker Resource", () => {
       await assertWorkerDoesNotExist(api, workerName);
     }
   }, 60000); // Increase timeout for Worker operations
+
+  test.skipIf(!ENABLE_ARTIFACTS_TESTS)(
+    "create and test worker with Artifacts binding",
+    async (scope) => {
+      const workerName = `${BRANCH_PREFIX}-test-worker-artifacts-binding`;
+      const namespace = `${BRANCH_PREFIX}-test-artifacts`;
+      const repoName = `${BRANCH_PREFIX}-test-worker-artifacts-repo`;
+
+      let worker: Worker | undefined;
+
+      try {
+        worker = await Worker(workerName, {
+          name: workerName,
+          script: `
+            export default {
+              async fetch(request, env, ctx) {
+                const url = new URL(request.url);
+
+                if (url.pathname !== "/check-binding") {
+                  return new Response("Artifacts Worker is running!", {
+                    status: 200,
+                    headers: { "Content-Type": "text/plain" }
+                  });
+                }
+
+                if (!env.ARTIFACTS) {
+                  return Response.json({
+                    success: false,
+                    hasBinding: false
+                  }, { status: 500 });
+                }
+
+                const repoName = ${JSON.stringify(repoName)};
+
+                try {
+                  await env.ARTIFACTS.delete(repoName);
+
+                  const created = await env.ARTIFACTS.create(repoName, {
+                    description: "Alchemy Artifacts binding test"
+                  });
+                  const repo = await env.ARTIFACTS.get(repoName);
+                  const deleted = await env.ARTIFACTS.delete(repoName);
+
+                  return Response.json({
+                    success: true,
+                    hasBinding: true,
+                    bindingType: typeof env.ARTIFACTS,
+                    created: {
+                      name: created.name,
+                      remote: created.remote,
+                      hasToken: typeof created.token === "string" && created.token.length > 0
+                    },
+                    info: {
+                      name: repo.name,
+                      remote: repo.remote,
+                      defaultBranch: repo.defaultBranch,
+                      readOnly: repo.readOnly
+                    },
+                    deleted
+                  });
+                } catch (error) {
+                  try {
+                    await env.ARTIFACTS.delete(repoName);
+                  } catch {}
+
+                  return Response.json({
+                    success: false,
+                    hasBinding: true,
+                    error: error?.message ?? String(error),
+                    code: error?.code,
+                    name: error?.name
+                  }, { status: 500 });
+                }
+              }
+            };
+          `,
+          format: "esm",
+          url: true,
+          bindings: {
+            ARTIFACTS: Artifacts({ namespace }),
+          },
+          adopt: true,
+        });
+
+        expect(worker.id).toBeTruthy();
+        expect(worker.name).toEqual(workerName);
+        expect(worker.bindings?.ARTIFACTS).toBeDefined();
+        expect(worker.url).toBeTruthy();
+
+        const data = await waitFor(
+          async () => {
+            const response = await fetch(`${worker!.url}/check-binding`);
+            if (!response.ok) {
+              return {
+                success: false,
+                status: response.status,
+                body: await response.text(),
+              };
+            }
+            return (await response.json()) as {
+              success: boolean;
+              hasBinding: boolean;
+              bindingType: string;
+              created: {
+                name: string;
+                remote: string;
+                hasToken: boolean;
+              };
+              info: {
+                name: string;
+                remote: string;
+                defaultBranch: string;
+                readOnly: boolean;
+              };
+              deleted: boolean;
+            };
+          },
+          (data) =>
+            data.success === true &&
+            "created" in data &&
+            data.created.name === repoName,
+          { timeoutMs: 30_000, intervalMs: 1_000 },
+        );
+
+        if (!data.success || !("created" in data)) {
+          throw new Error(
+            `Artifacts binding check failed: ${JSON.stringify(data)}`,
+          );
+        }
+
+        expect(data.success).toEqual(true);
+        expect(data.hasBinding).toEqual(true);
+        expect(data.bindingType).toEqual("object");
+        expect(data.created.name).toEqual(repoName);
+        expect(data.created.remote).toContain(
+          `artifacts.cloudflare.net/${namespace}/${repoName}.git`,
+        );
+        expect(data.created.hasToken).toEqual(true);
+        expect(data.info).toMatchObject({
+          name: repoName,
+          readOnly: false,
+        });
+        expect(data.info.remote).toContain(
+          `artifacts.cloudflare.net/${namespace}/${repoName}.git`,
+        );
+        expect(data.deleted).toEqual(true);
+      } finally {
+        await destroy(scope);
+        await assertWorkerDoesNotExist(api, workerName);
+      }
+    },
+    60000,
+  );
 
   test("can bind to a worker referenced by name", async (scope) => {
     const workerName = `${BRANCH_PREFIX}-test-worker-bind-by-name`;

--- a/alchemy/test/cloudflare/wrangler-json.test.ts
+++ b/alchemy/test/cloudflare/wrangler-json.test.ts
@@ -3,6 +3,7 @@ import path from "pathe";
 import { describe, expect } from "vitest";
 import { alchemy } from "../../src/alchemy.ts";
 import { Ai } from "../../src/cloudflare/ai.ts";
+import { Artifacts } from "../../src/cloudflare/artifacts.ts";
 import { R2Bucket } from "../../src/cloudflare/bucket.ts";
 import { D1Database } from "../../src/cloudflare/d1-database.ts";
 import { DurableObjectNamespace } from "../../src/cloudflare/durable-object-namespace.ts";
@@ -744,6 +745,49 @@ describe("WranglerJson Resource", () => {
       } finally {
         await fs.rm(tempDir, { recursive: true, force: true });
         await destroy(scope);
+      }
+    });
+
+    test("with Artifacts binding", async () => {
+      const name = `${BRANCH_PREFIX}-test-worker-artifacts`;
+      const tempDir = path.join(".out", "alchemy-artifacts-test");
+      const entrypoint = path.join(tempDir, "worker.ts");
+
+      try {
+        await fs.rm(tempDir, { recursive: true, force: true });
+        await fs.mkdir(tempDir, { recursive: true });
+        await fs.writeFile(entrypoint, esmWorkerScript);
+
+        const worker = {
+          name,
+          format: "esm" as const,
+          entrypoint,
+          compatibilityDate: "2025-06-16",
+          compatibilityFlags: [] as string[],
+          bindings: {
+            ARTIFACTS: Artifacts({ namespace: "test-artifacts" }),
+          },
+        };
+
+        const { spec } = await WranglerJson({ worker });
+        const artifacts = (
+          spec as typeof spec & {
+            artifacts?: Array<{
+              binding: string;
+              namespace: string;
+              remote?: boolean;
+            }>;
+          }
+        ).artifacts;
+
+        expect(artifacts).toHaveLength(1);
+        expect(artifacts?.[0]).toMatchObject({
+          binding: "ARTIFACTS",
+          namespace: "test-artifacts",
+          remote: true,
+        });
+      } finally {
+        await fs.rm(tempDir, { recursive: true, force: true });
       }
     });
 


### PR DESCRIPTION
## Summary

Adds first-class Cloudflare Artifacts binding support to Alchemy.

This introduces an `Artifacts(...)` helper that can be used in Worker bindings, emits the binding into Worker upload metadata, includes it in generated Wrangler config, and maps the bound Worker env type to Cloudflare Workers' `Artifacts` runtime type.

## Why

Cloudflare Artifacts can be bound to Workers, but Alchemy did not know how to serialize that binding during Worker deployment. As a result, projects could add Artifacts to generated Wrangler config manually, but the binding could disappear or fail to deploy correctly when Alchemy uploaded the Worker metadata.

## Changes

- Add `Artifacts(...)` binding helper under `alchemy/cloudflare`
- Add Artifacts to the Cloudflare binding union and Worker binding spec
- Serialize Artifacts bindings into Worker metadata as:

  ```ts
  {
    type: "artifacts",
    name,
    namespace
  }
  ```

- Emit `artifacts` in generated Wrangler config with remote local-dev behavior by default
- Map `Bound<Artifacts>` to the Workers runtime `Artifacts` type
- Add a focused Wrangler config test for Artifacts bindings
- Fail fast in Alchemy local dev for Artifacts bindings until local/remote dev support is implemented

## Notes

This is binding support only. Artifacts namespaces are implicit on Cloudflare and are created when the first repository is created in the namespace, so this PR does not add a separate namespace lifecycle resource with `adopt` / `delete`.

## Validation

```sh
bun vitest run ./alchemy/test/cloudflare/wrangler-json.test.ts -t "with Artifacts binding"
```

Passes.
